### PR TITLE
Spike: parser extension (GGSQL PING) to verify WASM compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXTENSION_SOURCES
     src/chisq_function.cpp
     src/read_stat_function.cpp
     src/read_stat_types.cpp
+    src/ggsql_parser_extension.cpp
     ${READSTAT_SOURCES})
 
 # ── Platform-specific iconv/zlib handling ────────────────────────────────────

--- a/src/ggsql_parser_extension.cpp
+++ b/src/ggsql_parser_extension.cpp
@@ -1,0 +1,135 @@
+#include "ggsql_parser_extension.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parser_extension.hpp"
+
+namespace duckdb {
+
+struct GgsqlParseData : public ParserExtensionParseData {
+	explicit GgsqlParseData(string command_p) : command(std::move(command_p)) {
+	}
+
+	string command;
+
+	unique_ptr<ParserExtensionParseData> Copy() const override {
+		return make_uniq<GgsqlParseData>(command);
+	}
+	string ToString() const override {
+		return "GGSQL " + command;
+	}
+};
+
+struct GgsqlSpikeBindData : public TableFunctionData {
+	explicit GgsqlSpikeBindData(string reply_p) : reply(std::move(reply_p)) {
+	}
+
+	string reply;
+};
+
+struct GgsqlSpikeGlobalState : public GlobalTableFunctionState {
+	GgsqlSpikeGlobalState() : emitted(false) {
+	}
+
+	bool emitted;
+};
+
+static unique_ptr<FunctionData> GgsqlSpikeBind(ClientContext &, TableFunctionBindInput &input,
+                                               vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("result");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	auto reply = input.inputs.empty() ? string("pong") : input.inputs[0].GetValue<string>();
+	return make_uniq<GgsqlSpikeBindData>(std::move(reply));
+}
+
+static unique_ptr<GlobalTableFunctionState> GgsqlSpikeInit(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<GgsqlSpikeGlobalState>();
+}
+
+static void GgsqlSpikeFunc(ClientContext &, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<GgsqlSpikeBindData>();
+	auto &state = data_p.global_state->Cast<GgsqlSpikeGlobalState>();
+	if (state.emitted) {
+		output.SetCardinality(0);
+		return;
+	}
+	output.SetValue(0, 0, Value(bind_data.reply));
+	output.SetCardinality(1);
+	state.emitted = true;
+}
+
+static bool StartsWithIdentifier(const string &lower, const string &keyword) {
+	if (lower.size() < keyword.size()) {
+		return false;
+	}
+	if (lower.compare(0, keyword.size(), keyword) != 0) {
+		return false;
+	}
+	if (lower.size() == keyword.size()) {
+		return true;
+	}
+	auto next = lower[keyword.size()];
+	return next == ' ' || next == '\t' || next == '\n' || next == '\r' || next == ';';
+}
+
+static ParserExtensionParseResult GgsqlParse(ParserExtensionInfo *, const string &query) {
+	string trimmed = query;
+	StringUtil::Trim(trimmed);
+	while (!trimmed.empty() && trimmed.back() == ';') {
+		trimmed.pop_back();
+		StringUtil::Trim(trimmed);
+	}
+	auto lower = StringUtil::Lower(trimmed);
+	if (!StartsWithIdentifier(lower, "ggsql")) {
+		return ParserExtensionParseResult();
+	}
+	auto rest = trimmed.substr(5);
+	StringUtil::Trim(rest);
+	if (rest.empty()) {
+		return ParserExtensionParseResult("GGSQL requires a command (e.g. GGSQL PING)");
+	}
+	auto rest_lower = StringUtil::Lower(rest);
+	if (rest_lower != "ping") {
+		return ParserExtensionParseResult("Unknown GGSQL command: " + rest);
+	}
+	return ParserExtensionParseResult(make_uniq<GgsqlParseData>("ping"));
+}
+
+static ParserExtensionPlanResult GgsqlPlan(ParserExtensionInfo *, ClientContext &,
+                                           unique_ptr<ParserExtensionParseData> parse_data) {
+	auto &data = (GgsqlParseData &)*parse_data;
+	string reply = data.command == "ping" ? "pong" : data.command;
+
+	TableFunction ggsql_spike;
+	ggsql_spike.name = "ggsql_spike";
+	ggsql_spike.arguments.push_back(LogicalType::VARCHAR);
+	ggsql_spike.bind = GgsqlSpikeBind;
+	ggsql_spike.init_global = GgsqlSpikeInit;
+	ggsql_spike.function = GgsqlSpikeFunc;
+
+	ParserExtensionPlanResult result;
+	result.function = std::move(ggsql_spike);
+	result.parameters.emplace_back(Value(reply));
+	result.requires_valid_transaction = false;
+	result.return_type = StatementReturnType::QUERY_RESULT;
+	return result;
+}
+
+class GgsqlParserExtension : public ParserExtension {
+public:
+	GgsqlParserExtension() {
+		parse_function = GgsqlParse;
+		plan_function = GgsqlPlan;
+	}
+};
+
+void RegisterGgsqlParserExtension(ExtensionLoader &loader) {
+	auto &db = loader.GetDatabaseInstance();
+	auto &config = DBConfig::GetConfig(db);
+	ParserExtension::Register(config, GgsqlParserExtension());
+}
+
+} // namespace duckdb

--- a/src/include/ggsql_parser_extension.hpp
+++ b/src/include/ggsql_parser_extension.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+class ExtensionLoader;
+
+void RegisterGgsqlParserExtension(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -11,31 +11,46 @@
 #include "anova_function.hpp"
 #include "chisq_function.hpp"
 #include "read_stat_function.hpp"
+#include "ggsql_parser_extension.hpp"
 
 #include "duckdb/main/extension/extension_loader.hpp"
 
+#include <cstdio>
+
 namespace duckdb {
+
+#define TRY_REGISTER(call)                                                                                              \
+	do {                                                                                                                \
+		std::fprintf(stderr, "[stats_duck] before " #call "\n");                                                        \
+		std::fflush(stderr);                                                                                            \
+		call;                                                                                                           \
+		std::fprintf(stderr, "[stats_duck] after  " #call "\n");                                                        \
+		std::fflush(stderr);                                                                                            \
+	} while (0)
 
 static void LoadInternal(ExtensionLoader &loader) {
 	// Hypothesis tests
-	RegisterTTest1SampAgg(loader);
-	RegisterTTest2SampAgg(loader);
-	RegisterTTestPairedAgg(loader);
-	RegisterMannWhitneyU(loader);
-	RegisterWilcoxonSignedRank(loader);
-	RegisterPearsonTest(loader);
-	RegisterJarqueBera(loader);
-	RegisterAnovaOneway(loader);
-	RegisterChiSquareTests(loader);
+	TRY_REGISTER(RegisterTTest1SampAgg(loader));
+	TRY_REGISTER(RegisterTTest2SampAgg(loader));
+	TRY_REGISTER(RegisterTTestPairedAgg(loader));
+	TRY_REGISTER(RegisterMannWhitneyU(loader));
+	TRY_REGISTER(RegisterWilcoxonSignedRank(loader));
+	TRY_REGISTER(RegisterPearsonTest(loader));
+	TRY_REGISTER(RegisterJarqueBera(loader));
+	TRY_REGISTER(RegisterAnovaOneway(loader));
+	TRY_REGISTER(RegisterChiSquareTests(loader));
 
 	// Descriptive statistics
-	RegisterSummaryStats(loader);
+	TRY_REGISTER(RegisterSummaryStats(loader));
 
 	// Scalar distribution functions (dnorm/pnorm/qnorm/dt/pt/qt/dchisq/...)
-	RegisterDistributionFunctions(loader);
+	TRY_REGISTER(RegisterDistributionFunctions(loader));
 
 	// Data import
-	RegisterReadStat(loader);
+	TRY_REGISTER(RegisterReadStat(loader));
+
+	// Parser extension spike (ggsql)
+	TRY_REGISTER(RegisterGgsqlParserExtension(loader));
 }
 
 void StatsDuckExtension::Load(ExtensionLoader &loader) {

--- a/test/sql/ggsql_spike.test
+++ b/test/sql/ggsql_spike.test
@@ -1,0 +1,30 @@
+# name: test/sql/ggsql_spike.test
+# description: Parser extension spike — GGSQL PING returns 'pong'
+# group: [stats_duck]
+
+require stats_duck
+
+query T
+GGSQL PING
+----
+pong
+
+query T
+ggsql ping
+----
+pong
+
+query T
+GGSQL PING;
+----
+pong
+
+statement error
+GGSQL
+----
+GGSQL requires a command
+
+statement error
+GGSQL UNKNOWN_CMD
+----
+Unknown GGSQL command


### PR DESCRIPTION
## Summary
- Minimal `ParserExtension` added to stats_duck: `GGSQL PING` → `'pong'`
- Purpose: verify DuckDB's `ParserExtension` API works end-to-end in WASM, as a prerequisite for building a full ggsql (Grammar of Graphics for SQL) extension
- Native: 5/5 assertions in `test/sql/ggsql_spike.test` pass

## Why open this PR
Not intended for merge. Exists so the CI pipeline produces `wasm_mvp` / `wasm_eh` / `wasm_threads` artifacts that Bedevere Wise can load to confirm parser extensions work at WASM runtime.

## Test plan
- [x] Native debug build passes (`make debug`)
- [x] `test/sql/ggsql_spike.test` passes (5 assertions)
- [ ] CI produces WASM artifacts
- [ ] `GGSQL PING` returns `'pong'` when stats_duck is loaded in Bedevere Wise via WASM

If the last item works, this confirms the architecture for ggsql and I'll close this PR without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)