### PR TITLE
ggsql: VISUALIZE syntax via parser extension + 11 marks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ set(EXTENSION_SOURCES
     src/chisq_function.cpp
     src/read_stat_function.cpp
     src/read_stat_types.cpp
+    src/ggsql.cpp
+    src/ggsql_grammar.cpp
     ${READSTAT_SOURCES})
 
 # ── Platform-specific iconv/zlib handling ────────────────────────────────────

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set(EXTENSION_SOURCES
     src/read_stat_types.cpp
     src/ggsql.cpp
     src/ggsql_grammar.cpp
+    src/ggsql_marks.cpp
     ${READSTAT_SOURCES})
 
 # ── Platform-specific iconv/zlib handling ────────────────────────────────────
@@ -110,6 +111,16 @@ if(Iconv_FOUND AND NOT WIN32)
 endif()
 
 set(PARAMETERS "-warnings")
+# Force i64 → (i32,i32) legalization at the WASM ABI boundary. Emscripten ≥ 4.0
+# defaults to -sWASM_BIGINT=1 (native i64), but @duckdb/duckdb-wasm 1.33.x and
+# the deployed phase-2 extension speak the legalized ABI. Mismatched modules
+# fail to link with a TemplatedValidityMask::Copy LinkError on instantiation.
+# Read by build_loadable_extension_directory at duckdb/extension/extension_build_tools.cmake:186
+# and spliced into the post-build emcc command.
+if(EMSCRIPTEN)
+    string(TOUPPER ${TARGET_NAME} _STATS_DUCK_UPPER)
+    set(DUCKDB_EXTENSION_${_STATS_DUCK_UPPER}_LINKED_LIBS "-sWASM_BIGINT=0")
+endif()
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
 if(ZLIB_FOUND)
     target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE HAVE_ZLIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,3 +135,17 @@ install(
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+
+# ── Phase 3 cross-extension WASM spike ──────────────────────────────────────
+# Builds a second loadable extension `marks_demo` that registers
+# `ggsql_mark_v1_demo`. Lets us verify cross-WASM-module mark dispatch (a
+# stats_duck.wasm session looking up + invoking a mark registered by
+# marks_demo.wasm). Throwaway — do not ship.
+if(BUILD_GGSQL_SPIKE OR EMSCRIPTEN)
+    set(MARKS_DEMO_NAME marks_demo)
+    set(MARKS_DEMO_SOURCES spike/marks_demo/marks_demo_extension.cpp)
+    if(EMSCRIPTEN)
+        set(DUCKDB_EXTENSION_MARKS_DEMO_LINKED_LIBS "-sWASM_BIGINT=0")
+    endif()
+    build_loadable_extension(${MARKS_DEMO_NAME} "-warnings" ${MARKS_DEMO_SOURCES})
+endif()

--- a/spike/marks_demo/marks_demo_extension.cpp
+++ b/spike/marks_demo/marks_demo_extension.cpp
@@ -1,0 +1,67 @@
+// marks_demo_extension.cpp — throwaway spike to verify cross-WASM-module mark
+// dispatch in DuckDB-WASM. Registers a single mark "demo" with a sentinel
+// renderer, so we can VISUALIZE ... DRAW demo from a stats_duck-loaded
+// session and confirm:
+//   1. Two of our own DuckDB extensions can co-load (catalog merge works).
+//   2. stats_duck's plan_function can find a mark registered by a DIFFERENT
+//      extension via Catalog::GetEntry + ScalarFunction::function_info.
+//   3. The function pointer cross-module dispatch (mark_render_t) hits the
+//      right code in marks_demo.wasm.
+//
+// In bio-stats this header would be vendored. Here we include from src/include
+// because the spike is in-tree.
+
+#define DUCKDB_EXTENSION_MAIN
+
+#include "ggsql_marks.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+namespace {
+
+ggsql::MarkResult RenderDemo(const ggsql::MarkContext &ctx) {
+	ggsql::MarkResult r;
+	// Sentinel string lets the Bedevere agent verify the dispatch went through
+	// THIS extension's code (and not, e.g., a stale stats_duck binding).
+	r.layer_body =
+	    R"("mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}},"description":"GGSQL_MARKS_DEMO_SENTINEL_v1")";
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
+void RegisterDemoMark(ExtensionLoader &loader) {
+	// Re-implement a minimal version of stats_duck's RegisterMark, so that
+	// marks_demo has zero link-time dependency on stats_duck's symbols.
+	ScalarFunction func("ggsql_mark_v1_demo", {}, LogicalType::VARCHAR,
+	                    [](DataChunk &args, ExpressionState &state, Vector &result) {
+		                    (void)args;
+		                    (void)state;
+		                    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		                    auto data = ConstantVector::GetData<string_t>(result);
+		                    data[0] = StringVector::AddString(
+		                        result, "{\"name\":\"demo\",\"required_aesthetics\":[\"x\",\"y\"]}");
+	                    });
+
+	auto info = make_shared_ptr<ggsql::MarkInfo>();
+	info->abi_version = GGSQL_MARK_ABI_VERSION;
+	info->name = "demo";
+	info->required_aesthetics = {"x", "y"};
+	info->render = RenderDemo;
+	func.SetExtraFunctionInfo(std::move(info));
+
+	loader.RegisterFunction(std::move(func));
+}
+
+} // namespace
+
+} // namespace duckdb
+
+extern "C" {
+
+DUCKDB_CPP_EXTENSION_ENTRY(marks_demo, loader) {
+	duckdb::RegisterDemoMark(loader);
+}
+}

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -124,7 +124,17 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	}
 	string projected_sql = BuildProjectedSql(stmt);
 	bool faceted = HasFacet(stmt);
-	const char *facet_block = "\"facet\":{\"field\":\"facet\",\"type\":\"nominal\"},\"spec\":";
+	string facet_block;
+	if (faceted) {
+		if (stmt.facet_layout == "rows") {
+			facet_block = "\"facet\":{\"row\":{\"field\":\"facet\",\"type\":\"nominal\"}},\"spec\":";
+		} else if (stmt.facet_layout == "cols") {
+			facet_block =
+			    "\"facet\":{\"column\":{\"field\":\"facet\",\"type\":\"nominal\"}},\"spec\":";
+		} else {
+			facet_block = "\"facet\":{\"field\":\"facet\",\"type\":\"nominal\"},\"spec\":";
+		}
+	}
 	CompiledResult out;
 
 	if (stmt.layers.size() == 1) {

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -1,0 +1,222 @@
+#include "ggsql.hpp"
+
+#include "ggsql_grammar.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/insertion_order_preserving_map.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parser_extension.hpp"
+
+namespace duckdb {
+namespace ggsql {
+
+namespace {
+
+string BuildProjectedSql(const VisualizeStatement &stmt) {
+	string sql = "SELECT ";
+	for (size_t i = 0; i < stmt.aesthetics.size(); i++) {
+		if (i > 0) {
+			sql += ", ";
+		}
+		sql += stmt.aesthetics[i].expression + " AS " + stmt.aesthetics[i].aesthetic;
+	}
+	sql += " FROM " + stmt.from_table;
+	return sql;
+}
+
+// Phase 1: hardcoded mark table. Phase 3 will replace this with a proper
+// registry so external extensions (e.g., bio-stats) can plug in their own marks.
+// Each entry returns the Vega-Lite layer fragment (without $schema or data keys)
+// plus the SQL that computes that layer's data.
+struct MarkResult {
+	string layer_json_body; // the layer fragment keys AFTER the opening '{'
+	string data_sql;        // the SQL that produces this layer's data
+};
+
+MarkResult RenderMark(const string &mark, const string &projected_sql) {
+	if (StringUtil::CIEquals(mark, "point")) {
+		MarkResult r;
+		r.layer_json_body =
+		    R"("mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}})";
+		r.data_sql = projected_sql;
+		return r;
+	}
+	throw InvalidInputException("ggsql: unknown mark '%s' (phase 1 supports: point)", mark);
+}
+
+struct CompiledResult {
+	string spec_json;
+	vector<pair<string, string>> layer_sqls;
+};
+
+CompiledResult Compile(const VisualizeStatement &stmt) {
+	if (stmt.layers.size() != 1) {
+		throw InvalidInputException("ggsql phase 1 supports exactly one DRAW clause (got %llu)",
+		                            static_cast<unsigned long long>(stmt.layers.size()));
+	}
+	string projected_sql = BuildProjectedSql(stmt);
+	const auto &layer = stmt.layers[0];
+	string layer_name = "layer_0";
+	auto rendered = RenderMark(layer.mark, projected_sql);
+
+	string spec =
+	    R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":")";
+	spec += layer_name;
+	spec += R"("},)";
+	spec += rendered.layer_json_body;
+
+	CompiledResult out;
+	out.spec_json = std::move(spec);
+	out.layer_sqls.emplace_back(layer_name, std::move(rendered.data_sql));
+	return out;
+}
+
+Value BuildLayerSqlsMap(const vector<pair<string, string>> &pairs) {
+	InsertionOrderPreservingMap<string> kv;
+	for (const auto &p : pairs) {
+		kv.insert(p.first, p.second);
+	}
+	return Value::MAP(kv);
+}
+
+//===--------------------------------------------------------------------===//
+// Parser extension: parse_function -> plan_function -> result TableFunction
+//===--------------------------------------------------------------------===//
+struct GgsqlParseData : public ParserExtensionParseData {
+	VisualizeStatement stmt;
+
+	explicit GgsqlParseData(VisualizeStatement stmt_p) : stmt(std::move(stmt_p)) {
+	}
+
+	unique_ptr<ParserExtensionParseData> Copy() const override {
+		return make_uniq<GgsqlParseData>(stmt);
+	}
+	string ToString() const override {
+		return "ggsql statement";
+	}
+};
+
+struct GgsqlResultBindData : public TableFunctionData {
+	string spec;
+	vector<pair<string, string>> layer_sqls;
+
+	GgsqlResultBindData(string spec_p, vector<pair<string, string>> layer_sqls_p)
+	    : spec(std::move(spec_p)), layer_sqls(std::move(layer_sqls_p)) {
+	}
+};
+
+struct GgsqlResultState : public GlobalTableFunctionState {
+	bool emitted = false;
+};
+
+unique_ptr<FunctionData> GgsqlResultBind(ClientContext &, TableFunctionBindInput &input,
+                                         vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("spec");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("layer_sqls");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+
+	string spec = input.inputs[0].GetValue<string>();
+
+	vector<pair<string, string>> pairs;
+	auto &map_value = input.inputs[1];
+	auto &map_entries = ListValue::GetChildren(map_value);
+	for (auto &entry : map_entries) {
+		auto &kv = StructValue::GetChildren(entry);
+		pairs.emplace_back(kv[0].GetValue<string>(), kv[1].GetValue<string>());
+	}
+	return make_uniq<GgsqlResultBindData>(std::move(spec), std::move(pairs));
+}
+
+unique_ptr<GlobalTableFunctionState> GgsqlResultInit(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<GgsqlResultState>();
+}
+
+void GgsqlResultFunc(ClientContext &, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind = data_p.bind_data->Cast<GgsqlResultBindData>();
+	auto &state = data_p.global_state->Cast<GgsqlResultState>();
+	if (state.emitted) {
+		output.SetCardinality(0);
+		return;
+	}
+	output.SetValue(0, 0, Value(bind.spec));
+	output.SetValue(1, 0, BuildLayerSqlsMap(bind.layer_sqls));
+	output.SetCardinality(1);
+	state.emitted = true;
+}
+
+bool StartsWithIdentifier(const string &lower, const string &keyword) {
+	if (lower.size() < keyword.size()) {
+		return false;
+	}
+	if (lower.compare(0, keyword.size(), keyword) != 0) {
+		return false;
+	}
+	if (lower.size() == keyword.size()) {
+		return true;
+	}
+	auto next = lower[keyword.size()];
+	return next == ' ' || next == '\t' || next == '\n' || next == '\r' || next == ';';
+}
+
+ParserExtensionParseResult GgsqlParse(ParserExtensionInfo *, const string &query) {
+	string trimmed = query;
+	StringUtil::Trim(trimmed);
+	auto lower = StringUtil::Lower(trimmed);
+	if (!StartsWithIdentifier(lower, "visualize")) {
+		return ParserExtensionParseResult();
+	}
+	auto parsed = ParseGgsql(trimmed);
+	if (!parsed.success) {
+		return ParserExtensionParseResult(parsed.error);
+	}
+	return ParserExtensionParseResult(make_uniq<GgsqlParseData>(std::move(parsed.stmt)));
+}
+
+ParserExtensionPlanResult GgsqlPlan(ParserExtensionInfo *, ClientContext &,
+                                    unique_ptr<ParserExtensionParseData> parse_data) {
+	auto &data = (GgsqlParseData &)*parse_data;
+	auto compiled = Compile(data.stmt);
+
+	TableFunction tf;
+	tf.name = "ggsql_result";
+	tf.arguments.push_back(LogicalType::VARCHAR);
+	tf.arguments.push_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	tf.bind = GgsqlResultBind;
+	tf.init_global = GgsqlResultInit;
+	tf.function = GgsqlResultFunc;
+
+	ParserExtensionPlanResult result;
+	result.function = std::move(tf);
+	result.parameters.emplace_back(Value(compiled.spec_json));
+	result.parameters.emplace_back(BuildLayerSqlsMap(compiled.layer_sqls));
+	result.requires_valid_transaction = false;
+	result.return_type = StatementReturnType::QUERY_RESULT;
+	return result;
+}
+
+class GgsqlParserExtension : public ParserExtension {
+public:
+	GgsqlParserExtension() {
+		parse_function = GgsqlParse;
+		plan_function = GgsqlPlan;
+	}
+};
+
+} // namespace
+
+} // namespace ggsql
+
+void RegisterGgsql(ExtensionLoader &loader) {
+	auto &db = loader.GetDatabaseInstance();
+	auto &config = DBConfig::GetConfig(db);
+	ParserExtension::Register(config, ggsql::GgsqlParserExtension());
+}
+
+} // namespace duckdb

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -30,24 +30,69 @@ string BuildProjectedSql(const VisualizeStatement &stmt) {
 	return sql;
 }
 
-// Phase 1: hardcoded mark table. Phase 3 will replace this with a proper
-// registry so external extensions (e.g., bio-stats) can plug in their own marks.
-// Each entry returns the Vega-Lite layer fragment (without $schema or data keys)
+// Hardcoded mark table. Phase 3 will replace this with a proper registry so
+// external extensions (e.g., bio-stats) can plug in their own marks. Each
+// entry returns the Vega-Lite layer fragment (without $schema or data keys)
 // plus the SQL that computes that layer's data.
 struct MarkResult {
 	string layer_json_body; // the layer fragment keys AFTER the opening '{'
 	string data_sql;        // the SQL that produces this layer's data
 };
 
-MarkResult RenderMark(const string &mark, const string &projected_sql) {
+bool HasAesthetic(const VisualizeStatement &stmt, const char *name) {
+	for (const auto &a : stmt.aesthetics) {
+		if (StringUtil::CIEquals(a.aesthetic, name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void RequireAesthetic(const VisualizeStatement &stmt, const string &mark, const char *aesthetic) {
+	if (!HasAesthetic(stmt, aesthetic)) {
+		throw InvalidInputException("ggsql: '%s' requires '%s' aesthetic", mark, aesthetic);
+	}
+}
+
+MarkResult RenderMark(const string &mark, const VisualizeStatement &stmt,
+                      const string &projected_sql) {
 	if (StringUtil::CIEquals(mark, "point")) {
+		RequireAesthetic(stmt, mark, "x");
+		RequireAesthetic(stmt, mark, "y");
 		MarkResult r;
 		r.layer_json_body =
-		    R"("mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}})";
+		    R"("mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
 		r.data_sql = projected_sql;
 		return r;
 	}
-	throw InvalidInputException("ggsql: unknown mark '%s' (phase 1 supports: point)", mark);
+	if (StringUtil::CIEquals(mark, "line")) {
+		RequireAesthetic(stmt, mark, "x");
+		RequireAesthetic(stmt, mark, "y");
+		MarkResult r;
+		r.layer_json_body =
+		    R"("mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
+		r.data_sql = "SELECT * FROM (" + projected_sql + ") ORDER BY x";
+		return r;
+	}
+	if (StringUtil::CIEquals(mark, "bar")) {
+		RequireAesthetic(stmt, mark, "x");
+		RequireAesthetic(stmt, mark, "y");
+		MarkResult r;
+		r.layer_json_body =
+		    R"("mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}})";
+		r.data_sql = "SELECT x, SUM(y) AS y FROM (" + projected_sql + ") GROUP BY x ORDER BY x";
+		return r;
+	}
+	if (StringUtil::CIEquals(mark, "histogram")) {
+		RequireAesthetic(stmt, mark, "x");
+		MarkResult r;
+		r.layer_json_body =
+		    R"("mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}})";
+		r.data_sql = projected_sql;
+		return r;
+	}
+	throw InvalidInputException(
+	    "ggsql: unknown mark '%s' (supported: point, line, bar, histogram)", mark);
 }
 
 struct CompiledResult {
@@ -63,13 +108,14 @@ CompiledResult Compile(const VisualizeStatement &stmt) {
 	string projected_sql = BuildProjectedSql(stmt);
 	const auto &layer = stmt.layers[0];
 	string layer_name = "layer_0";
-	auto rendered = RenderMark(layer.mark, projected_sql);
+	auto rendered = RenderMark(layer.mark, stmt, projected_sql);
 
 	string spec =
 	    R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":")";
 	spec += layer_name;
 	spec += R"("},)";
 	spec += rendered.layer_json_body;
+	spec += "}";
 
 	CompiledResult out;
 	out.spec_json = std::move(spec);

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -57,16 +57,28 @@ MarkResult RenderLayer(ClientContext &context, const VisualizeStatement &stmt,
 	return info.render(ctx);
 }
 
+bool HasFacet(const VisualizeStatement &stmt) {
+	for (const auto &a : stmt.aesthetics) {
+		if (StringUtil::CIEquals(a.aesthetic, "facet")) {
+			return true;
+		}
+	}
+	return false;
+}
+
 CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	if (stmt.layers.empty()) {
 		throw InvalidInputException("ggsql: at least one DRAW clause is required");
 	}
 	string projected_sql = BuildProjectedSql(stmt);
+	bool faceted = HasFacet(stmt);
+	const char *facet_block = "\"facet\":{\"field\":\"facet\",\"type\":\"nominal\"},\"spec\":";
 	CompiledResult out;
 
 	if (stmt.layers.size() == 1) {
 		// Single layer: emit canonical Vega-Lite single-view shape (top-level
-		// data + mark + encoding). Byte-identical to phase 3.
+		// data + mark + encoding). When faceted, wrap mark/encoding inside a
+		// `spec` sibling of `facet`.
 		const string layer_name = "layer_0";
 		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[0], projected_sql);
 
@@ -74,7 +86,14 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		    R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":")";
 		spec += layer_name;
 		spec += R"("},)";
-		spec += rendered.layer_body;
+		if (faceted) {
+			spec += facet_block;
+			spec += "{";
+			spec += rendered.layer_body;
+			spec += "}";
+		} else {
+			spec += rendered.layer_body;
+		}
 		spec += "}";
 
 		out.spec_json = std::move(spec);
@@ -82,24 +101,34 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		return out;
 	}
 
-	// Multi-layer: emit Vega-Lite layer:[...] array. Each layer gets its own
-	// data:{name:"layer_<i>"} binding because layers can have different data_sql
-	// (e.g., point uses raw projected_sql, line wraps with ORDER BY x).
-	string spec = R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[)";
+	// Multi-layer: emit Vega-Lite layer:[...] array. When faceted, wrap the
+	// layer array in a `spec` sibling of `facet`.
+	string layer_array = R"("layer":[)";
 	for (size_t i = 0; i < stmt.layers.size(); i++) {
 		if (i > 0) {
-			spec += ",";
+			layer_array += ",";
 		}
 		string layer_name = "layer_" + std::to_string(i);
 		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[i], projected_sql);
-		spec += R"({"data":{"name":")";
-		spec += layer_name;
-		spec += R"("},)";
-		spec += rendered.layer_body;
-		spec += "}";
+		layer_array += R"({"data":{"name":")";
+		layer_array += layer_name;
+		layer_array += R"("},)";
+		layer_array += rendered.layer_body;
+		layer_array += "}";
 		out.layer_sqls.emplace_back(layer_name, std::move(rendered.data_sql));
 	}
-	spec += "]}";
+	layer_array += "]";
+
+	string spec = R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json",)";
+	if (faceted) {
+		spec += facet_block;
+		spec += "{";
+		spec += layer_array;
+		spec += "}";
+	} else {
+		spec += layer_array;
+	}
+	spec += "}";
 	out.spec_json = std::move(spec);
 	return out;
 }

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -88,6 +88,36 @@ string ApplyScales(string layer_body, const vector<ScaleSpec> &scales) {
 	return layer_body;
 }
 
+// Replace the rendered "type":"..." inside the targeted channel with the user's
+// override. Same lookup pattern as ApplyScales — find the channel block, locate
+// the type field within it, swap the value.
+string ApplyTypeOverrides(string layer_body, const vector<TypeOverride> &overrides) {
+	for (const auto &ov : overrides) {
+		string needle = "\"" + ov.aesthetic + "\":{";
+		size_t pos = layer_body.find(needle);
+		if (pos == string::npos) {
+			continue; // channel not mapped → silently ignore
+		}
+		size_t open_brace = pos + needle.size() - 1;
+		size_t close_brace = layer_body.find('}', open_brace + 1);
+		if (close_brace == string::npos) {
+			continue;
+		}
+		const string type_key = "\"type\":\"";
+		size_t type_pos = layer_body.find(type_key, open_brace);
+		if (type_pos == string::npos || type_pos >= close_brace) {
+			continue;
+		}
+		size_t value_start = type_pos + type_key.size();
+		size_t value_end = layer_body.find('"', value_start);
+		if (value_end == string::npos || value_end >= close_brace) {
+			continue;
+		}
+		layer_body.replace(value_start, value_end - value_start, ov.type);
+	}
+	return layer_body;
+}
+
 CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	if (stmt.layers.empty()) {
 		throw InvalidInputException("ggsql: at least one DRAW clause is required");
@@ -103,6 +133,7 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		// `spec` sibling of `facet`.
 		const string layer_name = "layer_0";
 		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[0], projected_sql);
+		rendered.layer_body = ApplyTypeOverrides(std::move(rendered.layer_body), stmt.type_overrides);
 		rendered.layer_body = ApplyScales(std::move(rendered.layer_body), stmt.scales);
 
 		string spec =
@@ -133,6 +164,7 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		}
 		string layer_name = "layer_" + std::to_string(i);
 		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[i], projected_sql);
+		rendered.layer_body = ApplyTypeOverrides(std::move(rendered.layer_body), stmt.type_overrides);
 		rendered.layer_body = ApplyScales(std::move(rendered.layer_body), stmt.scales);
 		layer_array += R"({"data":{"name":")";
 		layer_array += layer_name;

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -1,6 +1,7 @@
 #include "ggsql.hpp"
 
 #include "ggsql_grammar.hpp"
+#include "ggsql_marks_internal.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/insertion_order_preserving_map.hpp"
@@ -30,16 +31,7 @@ string BuildProjectedSql(const VisualizeStatement &stmt) {
 	return sql;
 }
 
-// Hardcoded mark table. Phase 3 will replace this with a proper registry so
-// external extensions (e.g., bio-stats) can plug in their own marks. Each
-// entry returns the Vega-Lite layer fragment (without $schema or data keys)
-// plus the SQL that computes that layer's data.
-struct MarkResult {
-	string layer_json_body; // the layer fragment keys AFTER the opening '{'
-	string data_sql;        // the SQL that produces this layer's data
-};
-
-bool HasAesthetic(const VisualizeStatement &stmt, const char *name) {
+bool HasAesthetic(const VisualizeStatement &stmt, const string &name) {
 	for (const auto &a : stmt.aesthetics) {
 		if (StringUtil::CIEquals(a.aesthetic, name)) {
 			return true;
@@ -48,59 +40,12 @@ bool HasAesthetic(const VisualizeStatement &stmt, const char *name) {
 	return false;
 }
 
-void RequireAesthetic(const VisualizeStatement &stmt, const string &mark, const char *aesthetic) {
-	if (!HasAesthetic(stmt, aesthetic)) {
-		throw InvalidInputException("ggsql: '%s' requires '%s' aesthetic", mark, aesthetic);
-	}
-}
-
-MarkResult RenderMark(const string &mark, const VisualizeStatement &stmt,
-                      const string &projected_sql) {
-	if (StringUtil::CIEquals(mark, "point")) {
-		RequireAesthetic(stmt, mark, "x");
-		RequireAesthetic(stmt, mark, "y");
-		MarkResult r;
-		r.layer_json_body =
-		    R"("mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
-		r.data_sql = projected_sql;
-		return r;
-	}
-	if (StringUtil::CIEquals(mark, "line")) {
-		RequireAesthetic(stmt, mark, "x");
-		RequireAesthetic(stmt, mark, "y");
-		MarkResult r;
-		r.layer_json_body =
-		    R"("mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
-		r.data_sql = "SELECT * FROM (" + projected_sql + ") ORDER BY x";
-		return r;
-	}
-	if (StringUtil::CIEquals(mark, "bar")) {
-		RequireAesthetic(stmt, mark, "x");
-		RequireAesthetic(stmt, mark, "y");
-		MarkResult r;
-		r.layer_json_body =
-		    R"("mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}})";
-		r.data_sql = "SELECT x, SUM(y) AS y FROM (" + projected_sql + ") GROUP BY x ORDER BY x";
-		return r;
-	}
-	if (StringUtil::CIEquals(mark, "histogram")) {
-		RequireAesthetic(stmt, mark, "x");
-		MarkResult r;
-		r.layer_json_body =
-		    R"("mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}})";
-		r.data_sql = projected_sql;
-		return r;
-	}
-	throw InvalidInputException(
-	    "ggsql: unknown mark '%s' (supported: point, line, bar, histogram)", mark);
-}
-
 struct CompiledResult {
 	string spec_json;
 	vector<pair<string, string>> layer_sqls;
 };
 
-CompiledResult Compile(const VisualizeStatement &stmt) {
+CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	if (stmt.layers.size() != 1) {
 		throw InvalidInputException("ggsql phase 1 supports exactly one DRAW clause (got %llu)",
 		                            static_cast<unsigned long long>(stmt.layers.size()));
@@ -108,13 +53,21 @@ CompiledResult Compile(const VisualizeStatement &stmt) {
 	string projected_sql = BuildProjectedSql(stmt);
 	const auto &layer = stmt.layers[0];
 	string layer_name = "layer_0";
-	auto rendered = RenderMark(layer.mark, stmt, projected_sql);
+
+	const auto &info = LookupMark(context, layer.mark);
+	for (const auto &req : info.required_aesthetics) {
+		if (!HasAesthetic(stmt, req)) {
+			throw InvalidInputException("ggsql: '%s' requires '%s' aesthetic", layer.mark, req);
+		}
+	}
+	MarkContext ctx{stmt.aesthetics, projected_sql};
+	MarkResult rendered = info.render(ctx);
 
 	string spec =
 	    R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":")";
 	spec += layer_name;
 	spec += R"("},)";
-	spec += rendered.layer_json_body;
+	spec += rendered.layer_body;
 	spec += "}";
 
 	CompiledResult out;
@@ -225,10 +178,10 @@ ParserExtensionParseResult GgsqlParse(ParserExtensionInfo *, const string &query
 	return ParserExtensionParseResult(make_uniq<GgsqlParseData>(std::move(parsed.stmt)));
 }
 
-ParserExtensionPlanResult GgsqlPlan(ParserExtensionInfo *, ClientContext &,
+ParserExtensionPlanResult GgsqlPlan(ParserExtensionInfo *, ClientContext &context,
                                     unique_ptr<ParserExtensionParseData> parse_data) {
 	auto &data = (GgsqlParseData &)*parse_data;
-	auto compiled = Compile(data.stmt);
+	auto compiled = Compile(context, data.stmt);
 
 	TableFunction tf;
 	tf.name = "ggsql_result";

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -66,13 +66,26 @@ bool HasFacet(const VisualizeStatement &stmt) {
 	return false;
 }
 
-// Inject `,"scale":{"scheme":"<scheme>"}` into the given encoding channel of a
-// rendered layer_body. Relies on the current encoding format using only
-// primitive sub-properties (no nested objects), so the first '}' after the
-// channel's opening '{' is the closing brace.
+// Inject `,"scale":{<merged-properties>}` into each encoding channel that has
+// at least one matching ScaleSpec. Relies on the current encoding format using
+// only primitive sub-properties (no nested objects), so the first '}' after the
+// channel's opening '{' is the closing brace. Multiple SCALE clauses on the
+// same channel merge into one scale object.
 string ApplyScales(string layer_body, const vector<ScaleSpec> &scales) {
+	// Preserve user-specified order while grouping by channel.
+	std::map<string, string> merged; // channel → comma-separated "key":value list
+	std::vector<string> order;
 	for (const auto &scale : scales) {
-		string needle = "\"" + scale.aesthetic + "\":{";
+		auto it = merged.find(scale.aesthetic);
+		if (it == merged.end()) {
+			merged[scale.aesthetic] = "\"" + scale.property + "\":" + scale.value_json;
+			order.push_back(scale.aesthetic);
+		} else {
+			it->second += ",\"" + scale.property + "\":" + scale.value_json;
+		}
+	}
+	for (const auto &channel : order) {
+		string needle = "\"" + channel + "\":{";
 		size_t pos = layer_body.find(needle);
 		if (pos == string::npos) {
 			continue; // channel not mapped → silently ignore
@@ -82,7 +95,7 @@ string ApplyScales(string layer_body, const vector<ScaleSpec> &scales) {
 		if (close_brace == string::npos) {
 			continue;
 		}
-		string injection = ",\"scale\":{\"scheme\":\"" + scale.scheme + "\"}";
+		string injection = ",\"scale\":{" + merged[channel] + "}";
 		layer_body.insert(close_brace, injection);
 	}
 	return layer_body;

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -45,15 +45,8 @@ struct CompiledResult {
 	vector<pair<string, string>> layer_sqls;
 };
 
-CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
-	if (stmt.layers.size() != 1) {
-		throw InvalidInputException("ggsql phase 1 supports exactly one DRAW clause (got %llu)",
-		                            static_cast<unsigned long long>(stmt.layers.size()));
-	}
-	string projected_sql = BuildProjectedSql(stmt);
-	const auto &layer = stmt.layers[0];
-	string layer_name = "layer_0";
-
+MarkResult RenderLayer(ClientContext &context, const VisualizeStatement &stmt,
+                       const DrawLayer &layer, const string &projected_sql) {
 	const auto &info = LookupMark(context, layer.mark);
 	for (const auto &req : info.required_aesthetics) {
 		if (!HasAesthetic(stmt, req)) {
@@ -61,18 +54,53 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		}
 	}
 	MarkContext ctx{stmt.aesthetics, projected_sql};
-	MarkResult rendered = info.render(ctx);
+	return info.render(ctx);
+}
 
-	string spec =
-	    R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":")";
-	spec += layer_name;
-	spec += R"("},)";
-	spec += rendered.layer_body;
-	spec += "}";
-
+CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
+	if (stmt.layers.empty()) {
+		throw InvalidInputException("ggsql: at least one DRAW clause is required");
+	}
+	string projected_sql = BuildProjectedSql(stmt);
 	CompiledResult out;
+
+	if (stmt.layers.size() == 1) {
+		// Single layer: emit canonical Vega-Lite single-view shape (top-level
+		// data + mark + encoding). Byte-identical to phase 3.
+		const string layer_name = "layer_0";
+		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[0], projected_sql);
+
+		string spec =
+		    R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":")";
+		spec += layer_name;
+		spec += R"("},)";
+		spec += rendered.layer_body;
+		spec += "}";
+
+		out.spec_json = std::move(spec);
+		out.layer_sqls.emplace_back(layer_name, std::move(rendered.data_sql));
+		return out;
+	}
+
+	// Multi-layer: emit Vega-Lite layer:[...] array. Each layer gets its own
+	// data:{name:"layer_<i>"} binding because layers can have different data_sql
+	// (e.g., point uses raw projected_sql, line wraps with ORDER BY x).
+	string spec = R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[)";
+	for (size_t i = 0; i < stmt.layers.size(); i++) {
+		if (i > 0) {
+			spec += ",";
+		}
+		string layer_name = "layer_" + std::to_string(i);
+		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[i], projected_sql);
+		spec += R"({"data":{"name":")";
+		spec += layer_name;
+		spec += R"("},)";
+		spec += rendered.layer_body;
+		spec += "}";
+		out.layer_sqls.emplace_back(layer_name, std::move(rendered.data_sql));
+	}
+	spec += "]}";
 	out.spec_json = std::move(spec);
-	out.layer_sqls.emplace_back(layer_name, std::move(rendered.data_sql));
 	return out;
 }
 

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -66,6 +66,28 @@ bool HasFacet(const VisualizeStatement &stmt) {
 	return false;
 }
 
+// Inject `,"scale":{"scheme":"<scheme>"}` into the given encoding channel of a
+// rendered layer_body. Relies on the current encoding format using only
+// primitive sub-properties (no nested objects), so the first '}' after the
+// channel's opening '{' is the closing brace.
+string ApplyScales(string layer_body, const vector<ScaleSpec> &scales) {
+	for (const auto &scale : scales) {
+		string needle = "\"" + scale.aesthetic + "\":{";
+		size_t pos = layer_body.find(needle);
+		if (pos == string::npos) {
+			continue; // channel not mapped → silently ignore
+		}
+		size_t open_brace = pos + needle.size() - 1;
+		size_t close_brace = layer_body.find('}', open_brace + 1);
+		if (close_brace == string::npos) {
+			continue;
+		}
+		string injection = ",\"scale\":{\"scheme\":\"" + scale.scheme + "\"}";
+		layer_body.insert(close_brace, injection);
+	}
+	return layer_body;
+}
+
 CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	if (stmt.layers.empty()) {
 		throw InvalidInputException("ggsql: at least one DRAW clause is required");
@@ -81,6 +103,7 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		// `spec` sibling of `facet`.
 		const string layer_name = "layer_0";
 		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[0], projected_sql);
+		rendered.layer_body = ApplyScales(std::move(rendered.layer_body), stmt.scales);
 
 		string spec =
 		    R"({"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":")";
@@ -110,6 +133,7 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		}
 		string layer_name = "layer_" + std::to_string(i);
 		MarkResult rendered = RenderLayer(context, stmt, stmt.layers[i], projected_sql);
+		rendered.layer_body = ApplyScales(std::move(rendered.layer_body), stmt.scales);
 		layer_array += R"({"data":{"name":")";
 		layer_array += layer_name;
 		layer_array += R"("},)";

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -64,27 +64,72 @@ ParseResult ParseGgsql(const string &query) {
 		return result;
 	}
 
-	// mapping_list := <ident> AS <ident> (',' <ident> AS <ident>)*
+	// mapping_list := <expr> AS <ident> (',' <expr> AS <ident>)*
+	//
+	// <expr> may span multiple tokens (e.g. `bill_len * 2`, `log(bill_dep)`).
+	// Boundary scan: each mapping consumes tokens until the next top-level `,`,
+	// `FROM`, or `DRAW`. The last token in that range is the aesthetic name; the
+	// token immediately preceding it must be `AS`; everything earlier is the
+	// expression text (concatenated with single spaces — whitespace inside
+	// parens is preserved by DuckDB's downstream parser).
+	//
+	// Limitations (deferred to a paren-aware tokenizer in a later phase):
+	//   - top-level commas inside expressions break the scan (`coalesce(a, b)`)
+	//   - `FROM` / `DRAW` keywords inside subqueries break the scan
+	//   - quoted identifiers `"my col"` are not supported
 	while (true) {
-		if (at_end()) {
-			result.error = "Expected expression after VISUALIZE";
-			return result;
+		// Scan forward to the next mapping boundary at depth 0.
+		size_t boundary = i;
+		while (boundary < tokens.size()) {
+			const string &t = tokens[boundary];
+			if (t == "," || IEqual(t, "FROM") || IEqual(t, "DRAW")) {
+				break;
+			}
+			boundary++;
 		}
-		if (IEqual(peek(), "FROM") || IEqual(peek(), "DRAW") || peek() == ",") {
+
+		if (boundary == i) {
 			result.error = "Expected expression after VISUALIZE (or ',')";
 			return result;
 		}
-		AestheticMapping mapping;
-		mapping.expression = tokens[i++];
-		if (!consume("AS")) {
-			return result;
-		}
-		if (at_end()) {
+
+		// `… AS` with nothing after the AS.
+		if (IEqual(tokens[boundary - 1], "AS")) {
 			result.error = "Expected aesthetic name after 'AS'";
 			return result;
 		}
-		mapping.aesthetic = tokens[i++];
+
+		// Need at least 3 tokens: <something> AS <aesth>. With 2 we either have
+		// no AS at all, or a leading AS with empty expression.
+		if (boundary - i < 3) {
+			if (boundary - i == 2 && IEqual(tokens[i], "AS")) {
+				result.error = "Empty expression before 'AS'";
+			} else {
+				result.error = "Expected 'AS' before aesthetic '" + tokens[boundary - 1] + "'";
+			}
+			return result;
+		}
+
+		size_t aesth_idx = boundary - 1;
+		size_t as_idx = boundary - 2;
+		if (!IEqual(tokens[as_idx], "AS")) {
+			result.error = "Expected 'AS' before aesthetic '" + tokens[aesth_idx] + "'";
+			return result;
+		}
+
+		string expr;
+		for (size_t k = i; k < as_idx; k++) {
+			if (!expr.empty()) {
+				expr += " ";
+			}
+			expr += tokens[k];
+		}
+
+		AestheticMapping mapping;
+		mapping.expression = std::move(expr);
+		mapping.aesthetic = tokens[aesth_idx];
 		result.stmt.aesthetics.push_back(std::move(mapping));
+		i = boundary;
 
 		if (!at_end() && peek() == ",") {
 			i++;

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -259,12 +259,14 @@ ParseResult ParseGgsql(const string &query) {
 		if (!consume("BY")) {
 			return result;
 		}
-		if (at_end() || IEqual(peek(), "SCALE")) {
+		if (at_end() || IEqual(peek(), "SCALE") || IEqual(peek(), "ROWS") ||
+		    IEqual(peek(), "COLS")) {
 			result.error = "Expected expression after 'FACET BY'";
 			return result;
 		}
 		string expr;
-		while (!at_end() && !IEqual(peek(), "SCALE")) {
+		while (!at_end() && !IEqual(peek(), "SCALE") && !IEqual(peek(), "ROWS") &&
+		       !IEqual(peek(), "COLS")) {
 			if (!expr.empty()) {
 				expr += " ";
 			}
@@ -274,6 +276,13 @@ ParseResult ParseGgsql(const string &query) {
 		facet.expression = std::move(expr);
 		facet.aesthetic = "facet";
 		result.stmt.aesthetics.push_back(std::move(facet));
+
+		// Optional layout: ROWS (vertical stack), COLS (horizontal stack), or
+		// nothing (grid — Vega-Lite default).
+		if (!at_end() && (IEqual(peek(), "ROWS") || IEqual(peek(), "COLS"))) {
+			result.stmt.facet_layout = StringUtil::Lower(tokens[i]);
+			i++;
+		}
 	}
 
 	// Optional `SCALE <aesthetic> TO <scheme>` clauses, zero or more.

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -207,7 +207,7 @@ ParseResult ParseGgsql(const string &query) {
 	}
 	result.stmt.from_table = tokens[i++];
 
-	while (!at_end() && !IEqual(peek(), "FACET")) {
+	while (!at_end() && !IEqual(peek(), "FACET") && !IEqual(peek(), "SCALE")) {
 		if (!consume("DRAW")) {
 			return result;
 		}
@@ -233,12 +233,12 @@ ParseResult ParseGgsql(const string &query) {
 		if (!consume("BY")) {
 			return result;
 		}
-		if (at_end()) {
+		if (at_end() || IEqual(peek(), "SCALE")) {
 			result.error = "Expected expression after 'FACET BY'";
 			return result;
 		}
 		string expr;
-		while (!at_end()) {
+		while (!at_end() && !IEqual(peek(), "SCALE")) {
 			if (!expr.empty()) {
 				expr += " ";
 			}
@@ -248,6 +248,31 @@ ParseResult ParseGgsql(const string &query) {
 		facet.expression = std::move(expr);
 		facet.aesthetic = "facet";
 		result.stmt.aesthetics.push_back(std::move(facet));
+	}
+
+	// Optional `SCALE <aesthetic> TO <scheme>` clauses, zero or more.
+	while (!at_end() && IEqual(peek(), "SCALE")) {
+		i++;
+		if (at_end()) {
+			result.error = "Expected aesthetic name after 'SCALE'";
+			return result;
+		}
+		ScaleSpec scale;
+		scale.aesthetic = tokens[i++];
+		if (!consume("TO")) {
+			return result;
+		}
+		if (at_end()) {
+			result.error = "Expected scheme name after 'SCALE <aesthetic> TO'";
+			return result;
+		}
+		scale.scheme = tokens[i++];
+		result.stmt.scales.push_back(std::move(scale));
+	}
+
+	if (!at_end()) {
+		result.error = "Unexpected token '" + tokens[i] + "' after VISUALIZE clause";
+		return result;
 	}
 
 	result.success = true;

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -7,19 +7,67 @@ namespace ggsql {
 
 namespace {
 
-// Tokenizer: splits on whitespace, emits commas as their own token, drops trailing
-// semicolons. Quoted identifiers and string literals are NOT supported in phase 1.
-vector<string> Tokenize(const string &input) {
+struct TokenizeResult {
 	vector<string> tokens;
+	string error;
+};
+
+// Tokenizer: at depth 0, splits on whitespace and emits commas as their own
+// token. Inside parens or quotes (single or double) all characters are
+// accumulated into the current token so that `coalesce(a, b)`, `"my col"`,
+// `'don''t'`, and `(SELECT max(x) FROM t)` all become single tokens. SQL
+// doubled-quote escapes (`''` and `""`) are handled. Trailing semicolons are
+// dropped.
+TokenizeResult Tokenize(const string &input) {
+	TokenizeResult out;
+	auto &tokens = out.tokens;
 	string current;
+	int paren_depth = 0;
+	char quote_char = 0;
+
 	auto flush = [&]() {
 		if (!current.empty()) {
 			tokens.push_back(std::move(current));
 			current.clear();
 		}
 	};
-	for (char c : input) {
-		if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+
+	for (size_t i = 0; i < input.size(); i++) {
+		char c = input[i];
+
+		if (quote_char != 0) {
+			current += c;
+			if (c == quote_char) {
+				if (i + 1 < input.size() && input[i + 1] == quote_char) {
+					current += input[++i]; // SQL '' / "" escape
+				} else {
+					quote_char = 0;
+				}
+			}
+			continue;
+		}
+
+		if (c == '\'' || c == '"') {
+			current += c;
+			quote_char = c;
+			continue;
+		}
+
+		if (paren_depth > 0) {
+			if (c == '(') {
+				paren_depth++;
+			} else if (c == ')') {
+				paren_depth--;
+			}
+			current += c;
+			continue;
+		}
+
+		// Outside parens, outside quotes.
+		if (c == '(') {
+			paren_depth++;
+			current += c;
+		} else if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
 			flush();
 		} else if (c == ',') {
 			flush();
@@ -31,7 +79,14 @@ vector<string> Tokenize(const string &input) {
 		}
 	}
 	flush();
-	return tokens;
+
+	if (quote_char != 0) {
+		out.error = string("Unterminated string literal or quoted identifier (missing closing ") +
+		            quote_char + ")";
+	} else if (paren_depth != 0) {
+		out.error = "Unbalanced parentheses in input";
+	}
+	return out;
 }
 
 bool IEqual(const string &tok, const char *kw) {
@@ -42,7 +97,12 @@ bool IEqual(const string &tok, const char *kw) {
 
 ParseResult ParseGgsql(const string &query) {
 	ParseResult result;
-	auto tokens = Tokenize(query);
+	auto tokenized = Tokenize(query);
+	if (!tokenized.error.empty()) {
+		result.error = tokenized.error;
+		return result;
+	}
+	auto &tokens = tokenized.tokens;
 	size_t i = 0;
 
 	auto at_end = [&]() { return i >= tokens.size(); };

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -1,0 +1,128 @@
+#include "ggsql_grammar.hpp"
+
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+namespace ggsql {
+
+namespace {
+
+// Tokenizer: splits on whitespace, emits commas as their own token, drops trailing
+// semicolons. Quoted identifiers and string literals are NOT supported in phase 1.
+vector<string> Tokenize(const string &input) {
+	vector<string> tokens;
+	string current;
+	auto flush = [&]() {
+		if (!current.empty()) {
+			tokens.push_back(std::move(current));
+			current.clear();
+		}
+	};
+	for (char c : input) {
+		if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+			flush();
+		} else if (c == ',') {
+			flush();
+			tokens.emplace_back(",");
+		} else if (c == ';') {
+			flush();
+		} else {
+			current += c;
+		}
+	}
+	flush();
+	return tokens;
+}
+
+bool IEqual(const string &tok, const char *kw) {
+	return StringUtil::CIEquals(tok, kw);
+}
+
+} // namespace
+
+ParseResult ParseGgsql(const string &query) {
+	ParseResult result;
+	auto tokens = Tokenize(query);
+	size_t i = 0;
+
+	auto at_end = [&]() { return i >= tokens.size(); };
+	auto peek = [&]() -> const string & {
+		static const string empty;
+		return at_end() ? empty : tokens[i];
+	};
+	auto consume = [&](const char *kw) -> bool {
+		if (at_end() || !IEqual(tokens[i], kw)) {
+			result.error = string("Expected '") + kw + "', got " +
+			               (at_end() ? "end of input" : "'" + tokens[i] + "'");
+			return false;
+		}
+		i++;
+		return true;
+	};
+
+	if (!consume("VISUALIZE")) {
+		return result;
+	}
+
+	// mapping_list := <ident> AS <ident> (',' <ident> AS <ident>)*
+	while (true) {
+		if (at_end()) {
+			result.error = "Expected expression after VISUALIZE";
+			return result;
+		}
+		if (IEqual(peek(), "FROM") || IEqual(peek(), "DRAW") || peek() == ",") {
+			result.error = "Expected expression after VISUALIZE (or ',')";
+			return result;
+		}
+		AestheticMapping mapping;
+		mapping.expression = tokens[i++];
+		if (!consume("AS")) {
+			return result;
+		}
+		if (at_end()) {
+			result.error = "Expected aesthetic name after 'AS'";
+			return result;
+		}
+		mapping.aesthetic = tokens[i++];
+		result.stmt.aesthetics.push_back(std::move(mapping));
+
+		if (!at_end() && peek() == ",") {
+			i++;
+			continue;
+		}
+		break;
+	}
+
+	if (!consume("FROM")) {
+		return result;
+	}
+	if (at_end()) {
+		result.error = "Expected table name after 'FROM'";
+		return result;
+	}
+	result.stmt.from_table = tokens[i++];
+
+	while (!at_end()) {
+		if (!consume("DRAW")) {
+			return result;
+		}
+		if (at_end()) {
+			result.error = "Expected mark name after 'DRAW'";
+			return result;
+		}
+		DrawLayer layer;
+		layer.mark = tokens[i++];
+		result.stmt.layers.push_back(std::move(layer));
+	}
+
+	if (result.stmt.layers.empty()) {
+		result.error = "At least one 'DRAW <mark>' clause is required";
+		return result;
+	}
+
+	result.success = true;
+	return result;
+}
+
+} // namespace ggsql
+} // namespace duckdb

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -207,7 +207,7 @@ ParseResult ParseGgsql(const string &query) {
 	}
 	result.stmt.from_table = tokens[i++];
 
-	while (!at_end()) {
+	while (!at_end() && !IEqual(peek(), "FACET")) {
 		if (!consume("DRAW")) {
 			return result;
 		}
@@ -223,6 +223,31 @@ ParseResult ParseGgsql(const string &query) {
 	if (result.stmt.layers.empty()) {
 		result.error = "At least one 'DRAW <mark>' clause is required";
 		return result;
+	}
+
+	// Optional `FACET BY <expr>`. Stored as a synthetic aesthetic named "facet";
+	// "facet" is reserved — Compile() detects it to wrap the spec in a Vega-Lite
+	// facet operator and BuildProjectedSql carries it through.
+	if (!at_end() && IEqual(peek(), "FACET")) {
+		i++; // consume FACET (case-insensitive — already verified)
+		if (!consume("BY")) {
+			return result;
+		}
+		if (at_end()) {
+			result.error = "Expected expression after 'FACET BY'";
+			return result;
+		}
+		string expr;
+		while (!at_end()) {
+			if (!expr.empty()) {
+				expr += " ";
+			}
+			expr += tokens[i++];
+		}
+		AestheticMapping facet;
+		facet.expression = std::move(expr);
+		facet.aesthetic = "facet";
+		result.stmt.aesthetics.push_back(std::move(facet));
 	}
 
 	result.success = true;

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -285,7 +285,11 @@ ParseResult ParseGgsql(const string &query) {
 		}
 	}
 
-	// Optional `SCALE <aesthetic> TO <scheme>` clauses, zero or more.
+	// Optional `SCALE <aesthetic> <op> <args...>` clauses, zero or more.
+	// Supported ops:
+	//   TO <scheme>             — color scheme name
+	//   ZERO <true|false>       — include zero in quantitative scale
+	//   DOMAIN <num1> <num2>    — explicit numeric domain
 	while (!at_end() && IEqual(peek(), "SCALE")) {
 		i++;
 		if (at_end()) {
@@ -294,14 +298,52 @@ ParseResult ParseGgsql(const string &query) {
 		}
 		ScaleSpec scale;
 		scale.aesthetic = tokens[i++];
-		if (!consume("TO")) {
-			return result;
-		}
 		if (at_end()) {
-			result.error = "Expected scheme name after 'SCALE <aesthetic> TO'";
+			result.error = "Expected SCALE operator (TO / ZERO / DOMAIN) after aesthetic";
 			return result;
 		}
-		scale.scheme = tokens[i++];
+		string op = tokens[i++];
+		if (IEqual(op, "TO")) {
+			if (at_end()) {
+				result.error = "Expected scheme name after 'SCALE <aesthetic> TO'";
+				return result;
+			}
+			scale.property = "scheme";
+			scale.value_json = "\"" + tokens[i++] + "\"";
+		} else if (IEqual(op, "ZERO")) {
+			if (at_end()) {
+				result.error = "Expected boolean (true/false) after 'SCALE <aesthetic> ZERO'";
+				return result;
+			}
+			string v = tokens[i++];
+			if (IEqual(v, "true")) {
+				scale.value_json = "true";
+			} else if (IEqual(v, "false")) {
+				scale.value_json = "false";
+			} else {
+				result.error = "Expected 'true' or 'false' after 'SCALE <aesthetic> ZERO', got '" +
+				               v + "'";
+				return result;
+			}
+			scale.property = "zero";
+		} else if (IEqual(op, "DOMAIN")) {
+			if (at_end()) {
+				result.error = "Expected two numeric bounds after 'SCALE <aesthetic> DOMAIN'";
+				return result;
+			}
+			string lo = tokens[i++];
+			if (at_end()) {
+				result.error = "Expected upper bound after 'SCALE <aesthetic> DOMAIN <lo>'";
+				return result;
+			}
+			string hi = tokens[i++];
+			scale.property = "domain";
+			scale.value_json = "[" + lo + "," + hi + "]";
+		} else {
+			result.error = "Unknown SCALE operator '" + op +
+			               "' (expected TO / ZERO / DOMAIN)";
+			return result;
+		}
 		result.stmt.scales.push_back(std::move(scale));
 	}
 

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -185,10 +185,36 @@ ParseResult ParseGgsql(const string &query) {
 			expr += tokens[k];
 		}
 
+		// Aesthetic may carry a `:type` suffix (e.g. `color:nominal`) — split it.
+		string aesth_token = tokens[aesth_idx];
+		size_t colon = aesth_token.find(':');
+		string type_override;
+		if (colon != string::npos) {
+			type_override = aesth_token.substr(colon + 1);
+			aesth_token = aesth_token.substr(0, colon);
+			if (aesth_token.empty()) {
+				result.error = "Empty aesthetic name before ':'";
+				return result;
+			}
+			if (type_override != "quantitative" && type_override != "ordinal" &&
+			    type_override != "nominal" && type_override != "temporal") {
+				result.error =
+				    "Invalid aesthetic type '" + type_override +
+				    "' (expected quantitative, ordinal, nominal, or temporal)";
+				return result;
+			}
+		}
+
 		AestheticMapping mapping;
 		mapping.expression = std::move(expr);
-		mapping.aesthetic = tokens[aesth_idx];
+		mapping.aesthetic = aesth_token;
 		result.stmt.aesthetics.push_back(std::move(mapping));
+		if (!type_override.empty()) {
+			TypeOverride ov;
+			ov.aesthetic = aesth_token;
+			ov.type = std::move(type_override);
+			result.stmt.type_overrides.push_back(std::move(ov));
+		}
 		i = boundary;
 
 		if (!at_end() && peek() == ",") {

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -8,6 +8,8 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
+#include <map>
+
 namespace duckdb {
 namespace ggsql {
 
@@ -40,21 +42,91 @@ void MarkIntrospectionStub(DataChunk &args, ExpressionState &state, Vector &resu
 }
 
 //===--------------------------------------------------------------------===//
-// Built-in mark renderers (ported verbatim from phase 2 RenderMark).
+// Encoding helpers (Phase 4b).
+//===--------------------------------------------------------------------===//
+
+struct ChannelDefault {
+	const char *name;
+	const char *vega_type;
+};
+
+// Canonical encoding-channel order used for byte-stable output. New channels
+// can be appended without breaking existing fixtures.
+static const vector<ChannelDefault> kStandardChannels = {
+    {"x", "quantitative"},       {"y", "quantitative"},     {"color", "nominal"},
+    {"fill", "nominal"},         {"stroke", "nominal"},     {"shape", "nominal"},
+    {"size", "quantitative"},    {"opacity", "quantitative"}, {"tooltip", "nominal"},
+};
+
+bool HasAesthetic(const MarkContext &ctx, const string &channel) {
+	for (const auto &a : ctx.aesthetics) {
+		if (StringUtil::CIEquals(a.aesthetic, channel)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// Returns "" if the user did not map this aesthetic, otherwise:
+//   "<channel>":{"field":"<channel>","type":"<vega_type>"<extras>}
+// `extras` is appended verbatim (must already start with "," when non-empty).
+string BuildChannel(const MarkContext &ctx, const string &channel,
+                    const string &vega_type, const string &extras) {
+	if (!HasAesthetic(ctx, channel)) {
+		return "";
+	}
+	string out = "\"" + channel + "\":{\"field\":\"" + channel + "\",\"type\":\"" + vega_type + "\"";
+	out += extras;
+	out += "}";
+	return out;
+}
+
+// Builds a complete "{...}" encoding object from a channel-default table,
+// applying per-mark overrides for type and for inserted extras.
+string BuildEncoding(const MarkContext &ctx, const vector<ChannelDefault> &channel_table,
+                     const std::map<string, string> &type_overrides = {},
+                     const std::map<string, string> &extras_overrides = {}) {
+	string out = "{";
+	bool first = true;
+	for (const auto &ch : channel_table) {
+		string vega_type = ch.vega_type;
+		auto type_it = type_overrides.find(ch.name);
+		if (type_it != type_overrides.end()) {
+			vega_type = type_it->second;
+		}
+		string extras;
+		auto extras_it = extras_overrides.find(ch.name);
+		if (extras_it != extras_overrides.end()) {
+			extras = extras_it->second;
+		}
+		string fragment = BuildChannel(ctx, ch.name, vega_type, extras);
+		if (fragment.empty()) {
+			continue;
+		}
+		if (!first) {
+			out += ",";
+		}
+		out += fragment;
+		first = false;
+	}
+	out += "}";
+	return out;
+}
+
+//===--------------------------------------------------------------------===//
+// Built-in mark renderers.
 //===--------------------------------------------------------------------===//
 
 MarkResult RenderPoint(const MarkContext &ctx) {
 	MarkResult r;
-	r.layer_body =
-	    R"("mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
+	r.layer_body = "\"mark\":\"point\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
 	r.data_sql = ctx.projected_sql;
 	return r;
 }
 
 MarkResult RenderLine(const MarkContext &ctx) {
 	MarkResult r;
-	r.layer_body =
-	    R"("mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
+	r.layer_body = "\"mark\":\"line\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
 	r.data_sql = "SELECT * FROM (" + ctx.projected_sql + ") ORDER BY x";
 	return r;
 }
@@ -62,15 +134,30 @@ MarkResult RenderLine(const MarkContext &ctx) {
 MarkResult RenderBar(const MarkContext &ctx) {
 	MarkResult r;
 	r.layer_body =
-	    R"("mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}})";
+	    "\"mark\":\"bar\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels, {{"x", "ordinal"}});
 	r.data_sql = "SELECT x, SUM(y) AS y FROM (" + ctx.projected_sql + ") GROUP BY x ORDER BY x";
 	return r;
 }
 
 MarkResult RenderHistogram(const MarkContext &ctx) {
+	// Histogram's x is binned and y is computed (aggregate:count, no field).
+	// Optional channels (color, opacity, ...) come from kStandardChannels but x
+	// and y are spliced manually.
+	string encoding = "{\"x\":{\"field\":\"x\",\"type\":\"quantitative\",\"bin\":true},"
+	                  "\"y\":{\"aggregate\":\"count\",\"type\":\"quantitative\"}";
+	for (const auto &ch : kStandardChannels) {
+		string name = ch.name;
+		if (name == "x" || name == "y") {
+			continue;
+		}
+		string fragment = BuildChannel(ctx, name, ch.vega_type, "");
+		if (!fragment.empty()) {
+			encoding += "," + fragment;
+		}
+	}
+	encoding += "}";
 	MarkResult r;
-	r.layer_body =
-	    R"("mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}})";
+	r.layer_body = "\"mark\":\"bar\",\"encoding\":" + encoding;
 	r.data_sql = ctx.projected_sql;
 	return r;
 }

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -133,10 +133,15 @@ MarkResult RenderLine(const MarkContext &ctx) {
 }
 
 MarkResult RenderBar(const MarkContext &ctx) {
+	// When faceting is active, the `facet` column rides through projected_sql
+	// and must be carried through bar's GROUP BY so each facet partition keeps
+	// its own ordinal x bins.
+	string group_by = HasAesthetic(ctx, "facet") ? string("x, facet") : string("x");
 	MarkResult r;
 	r.layer_body =
 	    "\"mark\":\"bar\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels, {{"x", "ordinal"}});
-	r.data_sql = "SELECT x, SUM(y) AS y FROM (" + ctx.projected_sql + ") GROUP BY x ORDER BY x";
+	r.data_sql = "SELECT " + group_by + ", SUM(y) AS y FROM (" + ctx.projected_sql + ") GROUP BY " +
+	             group_by + " ORDER BY x";
 	return r;
 }
 

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -56,7 +56,7 @@ static const vector<ChannelDefault> kStandardChannels = {
     {"x", "quantitative"},       {"y", "quantitative"},     {"color", "nominal"},
     {"fill", "nominal"},         {"stroke", "nominal"},     {"shape", "nominal"},
     {"size", "quantitative"},    {"opacity", "quantitative"}, {"tooltip", "nominal"},
-    {"text", "nominal"},
+    {"text", "nominal"},         {"x2", "quantitative"},    {"y2", "quantitative"},
 };
 
 bool HasAesthetic(const MarkContext &ctx, const string &channel) {
@@ -173,6 +173,27 @@ MarkResult RenderTick(const MarkContext &ctx) {
 	return r;
 }
 
+MarkResult RenderErrorbar(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body = "\"mark\":\"errorbar\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
+MarkResult RenderErrorband(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body = "\"mark\":\"errorband\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
+	r.data_sql = "SELECT * FROM (" + ctx.projected_sql + ") ORDER BY x";
+	return r;
+}
+
+MarkResult RenderBoxplot(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body = "\"mark\":\"boxplot\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
 MarkResult RenderHistogram(const MarkContext &ctx) {
 	// Histogram's x is binned and y is computed (aggregate:count, no field).
 	// Optional channels (color, opacity, ...) come from kStandardChannels but x
@@ -248,6 +269,12 @@ void RegisterBuiltinMarks(ExtensionLoader &loader) {
 	// with whatever the user maps; aesthetic validation stays minimal.
 	RegisterMark(loader, "rule", {}, RenderRule);
 	RegisterMark(loader, "tick", {}, RenderTick);
+	// Stats marks: errorbar/errorband consume the y2 channel for the upper
+	// bound; boxplot's quartile/outlier computation is server-side via
+	// Vega-Lite once x and y are mapped.
+	RegisterMark(loader, "errorbar", {"x", "y"}, RenderErrorbar);
+	RegisterMark(loader, "errorband", {"x", "y"}, RenderErrorband);
+	RegisterMark(loader, "boxplot", {"x", "y"}, RenderBoxplot);
 }
 
 } // namespace ggsql

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -152,6 +152,27 @@ MarkResult RenderText(const MarkContext &ctx) {
 	return r;
 }
 
+MarkResult RenderArea(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body = "\"mark\":\"area\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
+	r.data_sql = "SELECT * FROM (" + ctx.projected_sql + ") ORDER BY x";
+	return r;
+}
+
+MarkResult RenderRule(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body = "\"mark\":\"rule\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
+MarkResult RenderTick(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body = "\"mark\":\"tick\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
 MarkResult RenderHistogram(const MarkContext &ctx) {
 	// Histogram's x is binned and y is computed (aggregate:count, no field).
 	// Optional channels (color, opacity, ...) come from kStandardChannels but x
@@ -221,6 +242,12 @@ void RegisterBuiltinMarks(ExtensionLoader &loader) {
 	RegisterMark(loader, "bar", {"x", "y"}, RenderBar);
 	RegisterMark(loader, "histogram", {"x"}, RenderHistogram);
 	RegisterMark(loader, "text", {"x", "y", "text"}, RenderText);
+	RegisterMark(loader, "area", {"x", "y"}, RenderArea);
+	// `rule` and `tick` accept any subset of x/y so a single mark serves the
+	// vline / hline / segment / rug-plot use cases. Vega-Lite renders sensibly
+	// with whatever the user maps; aesthetic validation stays minimal.
+	RegisterMark(loader, "rule", {}, RenderRule);
+	RegisterMark(loader, "tick", {}, RenderTick);
 }
 
 } // namespace ggsql

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -1,0 +1,126 @@
+#include "ggsql_marks_internal.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+namespace ggsql {
+
+namespace {
+
+string CatalogName(const string &mark_name) {
+	return GGSQL_MARK_PREFIX + StringUtil::Lower(mark_name);
+}
+
+string BuildIntrospectionString(const string &name, const vector<string> &required_aesthetics) {
+	string out = "{\"name\":\"" + name + "\",\"required_aesthetics\":[";
+	for (size_t i = 0; i < required_aesthetics.size(); i++) {
+		if (i > 0) {
+			out += ",";
+		}
+		out += "\"" + required_aesthetics[i] + "\"";
+	}
+	out += "]}";
+	return out;
+}
+
+void MarkIntrospectionStub(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &info = func_expr.function.GetExtraFunctionInfo().Cast<MarkInfo>();
+	auto desc = BuildIntrospectionString(info.name, info.required_aesthetics);
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	auto data = ConstantVector::GetData<string_t>(result);
+	data[0] = StringVector::AddString(result, desc);
+	(void)args;
+}
+
+//===--------------------------------------------------------------------===//
+// Built-in mark renderers (ported verbatim from phase 2 RenderMark).
+//===--------------------------------------------------------------------===//
+
+MarkResult RenderPoint(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body =
+	    R"("mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
+MarkResult RenderLine(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body =
+	    R"("mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}})";
+	r.data_sql = "SELECT * FROM (" + ctx.projected_sql + ") ORDER BY x";
+	return r;
+}
+
+MarkResult RenderBar(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body =
+	    R"("mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}})";
+	r.data_sql = "SELECT x, SUM(y) AS y FROM (" + ctx.projected_sql + ") GROUP BY x ORDER BY x";
+	return r;
+}
+
+MarkResult RenderHistogram(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body =
+	    R"("mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}})";
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
+} // namespace
+
+void RegisterMark(ExtensionLoader &loader, const string &name,
+                  vector<string> required_aesthetics, mark_render_t render) {
+	ScalarFunction func(CatalogName(name), {}, LogicalType::VARCHAR, MarkIntrospectionStub);
+
+	auto info = make_shared_ptr<MarkInfo>();
+	info->abi_version = GGSQL_MARK_ABI_VERSION;
+	info->name = name;
+	info->required_aesthetics = std::move(required_aesthetics);
+	info->render = render;
+	func.SetExtraFunctionInfo(std::move(info));
+
+	loader.RegisterFunction(std::move(func));
+}
+
+const MarkInfo &LookupMark(ClientContext &context, const string &name) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto entry = catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA,
+	                              CatalogName(name), OnEntryNotFound::RETURN_NULL);
+	if (!entry) {
+		throw InvalidInputException("ggsql: unknown mark '%s'", name);
+	}
+	auto &func_entry = entry->Cast<ScalarFunctionCatalogEntry>();
+	if (func_entry.functions.Size() == 0) {
+		throw InvalidInputException("ggsql: unknown mark '%s'", name);
+	}
+	auto &func = func_entry.functions.GetFunctionReferenceByOffset(0);
+	if (!func.HasExtraFunctionInfo()) {
+		throw InvalidInputException("ggsql: '%s' is not a registered mark", name);
+	}
+	auto &info = func.GetExtraFunctionInfo().Cast<MarkInfo>();
+	if (info.abi_version != GGSQL_MARK_ABI_VERSION) {
+		throw InvalidInputException(
+		    "ggsql: mark '%s' uses ABI version %u but this build expects %u", name,
+		    info.abi_version, GGSQL_MARK_ABI_VERSION);
+	}
+	return info;
+}
+
+void RegisterBuiltinMarks(ExtensionLoader &loader) {
+	RegisterMark(loader, "point", {"x", "y"}, RenderPoint);
+	RegisterMark(loader, "line", {"x", "y"}, RenderLine);
+	RegisterMark(loader, "bar", {"x", "y"}, RenderBar);
+	RegisterMark(loader, "histogram", {"x"}, RenderHistogram);
+}
+
+} // namespace ggsql
+} // namespace duckdb

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -51,11 +51,12 @@ struct ChannelDefault {
 };
 
 // Canonical encoding-channel order used for byte-stable output. New channels
-// can be appended without breaking existing fixtures.
+// must be appended (not inserted) to keep fixtures stable.
 static const vector<ChannelDefault> kStandardChannels = {
     {"x", "quantitative"},       {"y", "quantitative"},     {"color", "nominal"},
     {"fill", "nominal"},         {"stroke", "nominal"},     {"shape", "nominal"},
     {"size", "quantitative"},    {"opacity", "quantitative"}, {"tooltip", "nominal"},
+    {"text", "nominal"},
 };
 
 bool HasAesthetic(const MarkContext &ctx, const string &channel) {
@@ -139,6 +140,13 @@ MarkResult RenderBar(const MarkContext &ctx) {
 	return r;
 }
 
+MarkResult RenderText(const MarkContext &ctx) {
+	MarkResult r;
+	r.layer_body = "\"mark\":\"text\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels);
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
 MarkResult RenderHistogram(const MarkContext &ctx) {
 	// Histogram's x is binned and y is computed (aggregate:count, no field).
 	// Optional channels (color, opacity, ...) come from kStandardChannels but x
@@ -207,6 +215,7 @@ void RegisterBuiltinMarks(ExtensionLoader &loader) {
 	RegisterMark(loader, "line", {"x", "y"}, RenderLine);
 	RegisterMark(loader, "bar", {"x", "y"}, RenderBar);
 	RegisterMark(loader, "histogram", {"x"}, RenderHistogram);
+	RegisterMark(loader, "text", {"x", "y", "text"}, RenderText);
 }
 
 } // namespace ggsql

--- a/src/include/ggsql.hpp
+++ b/src/include/ggsql.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace duckdb {
+
+class ExtensionLoader;
+
+void RegisterGgsql(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -12,10 +12,16 @@ struct DrawLayer {
 	string mark;
 };
 
+struct ScaleSpec {
+	string aesthetic; // channel name to scale (color, fill, ...)
+	string scheme;    // Vega-Lite scheme name (accent, viridis, category10, ...)
+};
+
 struct VisualizeStatement {
 	vector<AestheticMapping> aesthetics;
 	string from_table;
 	vector<DrawLayer> layers;
+	vector<ScaleSpec> scales;
 };
 
 struct ParseResult {

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -3,14 +3,10 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
+#include "ggsql_marks.hpp"
 
 namespace duckdb {
 namespace ggsql {
-
-struct AestheticMapping {
-	string expression;
-	string aesthetic;
-};
 
 struct DrawLayer {
 	string mark;

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -13,8 +13,9 @@ struct DrawLayer {
 };
 
 struct ScaleSpec {
-	string aesthetic; // channel name to scale (color, fill, ...)
-	string scheme;    // Vega-Lite scheme name (accent, viridis, category10, ...)
+	string aesthetic;  // channel to scale (x, y, color, ...)
+	string property;   // Vega-Lite scale property: "scheme", "domain", "zero", ...
+	string value_json; // value formatted as JSON ('"viridis"', '[0,100]', 'false', ...)
 };
 
 struct TypeOverride {

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -17,11 +17,17 @@ struct ScaleSpec {
 	string scheme;    // Vega-Lite scheme name (accent, viridis, category10, ...)
 };
 
+struct TypeOverride {
+	string aesthetic; // channel name (color, x, ...)
+	string type;      // quantitative | ordinal | nominal | temporal
+};
+
 struct VisualizeStatement {
 	vector<AestheticMapping> aesthetics;
 	string from_table;
 	vector<DrawLayer> layers;
 	vector<ScaleSpec> scales;
+	vector<TypeOverride> type_overrides;
 };
 
 struct ParseResult {

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -28,6 +28,7 @@ struct VisualizeStatement {
 	vector<DrawLayer> layers;
 	vector<ScaleSpec> scales;
 	vector<TypeOverride> type_overrides;
+	string facet_layout; // "" (grid), "rows", or "cols" — only meaningful when a facet aesthetic is present
 };
 
 struct ParseResult {

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+namespace ggsql {
+
+struct AestheticMapping {
+	string expression;
+	string aesthetic;
+};
+
+struct DrawLayer {
+	string mark;
+};
+
+struct VisualizeStatement {
+	vector<AestheticMapping> aesthetics;
+	string from_table;
+	vector<DrawLayer> layers;
+};
+
+struct ParseResult {
+	bool success = false;
+	VisualizeStatement stmt;
+	string error;
+};
+
+ParseResult ParseGgsql(const string &query);
+
+} // namespace ggsql
+} // namespace duckdb

--- a/src/include/ggsql_marks.hpp
+++ b/src/include/ggsql_marks.hpp
@@ -1,0 +1,61 @@
+// ggsql_marks.hpp — public ABI for plugging chart marks into the ggsql parser
+// extension at runtime.
+//
+// This header is the boundary between stats_duck (which hosts the VISUALIZE
+// parser extension) and any other extension that wants to register additional
+// marks — e.g. a "bio-stats" extension shipping Kaplan-Meier or forest-plot
+// marks. Such an extension should vendor a copy of THIS header, link only
+// against DuckDB (never against stats_duck), and rendezvous via the catalog.
+//
+// ABI stability rules (read these before changing anything):
+//   - The layout of MarkInfo is FROZEN for ABI v1. New optional fields go in
+//     a parallel MarkInfoV2 (with a new prefix `ggsql_mark_v2_`), never as
+//     bare struct members.
+//   - The first member of MarkInfo is `abi_version`. LookupMark verifies it.
+//   - The function-name prefix `ggsql_mark_v1_` encodes the version: a
+//     consumer targeting v1 simply does not find v2 marks, and vice versa.
+//   - Bumping the ABI is a major-version event; coordinate cross-extension.
+
+#pragma once
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/function/scalar_function.hpp"
+
+#include <cstdint>
+
+namespace duckdb {
+namespace ggsql {
+
+#define GGSQL_MARK_ABI_VERSION 1u
+
+constexpr const char *GGSQL_MARK_PREFIX = "ggsql_mark_v1_";
+
+struct AestheticMapping {
+	string expression; // SQL expression text (phase 1: identifier only)
+	string aesthetic;  // "x", "y", "color", ...
+};
+
+struct MarkContext {
+	const vector<AestheticMapping> &aesthetics;
+	const string &projected_sql; // already-built "SELECT <expr> AS <aesth>... FROM <table>"
+};
+
+struct MarkResult {
+	string layer_body; // Vega-Lite layer body, e.g. "\"mark\":\"point\",\"encoding\":{...}"
+	string data_sql;   // SQL whose Arrow rows feed this layer's `data` block
+};
+
+typedef MarkResult (*mark_render_t)(const MarkContext &);
+
+// Stashed on ScalarFunction.function_info for catalog-mediated dispatch.
+// FROZEN layout for ABI v1. Do not reorder, insert, or grow.
+struct MarkInfo : public ScalarFunctionInfo {
+	uint32_t abi_version = GGSQL_MARK_ABI_VERSION;
+	string name;
+	vector<string> required_aesthetics;
+	mark_render_t render;
+};
+
+} // namespace ggsql
+} // namespace duckdb

--- a/src/include/ggsql_marks_internal.hpp
+++ b/src/include/ggsql_marks_internal.hpp
@@ -1,0 +1,31 @@
+// ggsql_marks_internal.hpp — stats_duck-internal helpers used by ggsql.cpp to
+// register and look up marks via the catalog. NOT part of the public ABI;
+// downstream extensions (bio-stats etc.) should NOT include this header.
+
+#pragma once
+
+#include "ggsql_marks.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class ExtensionLoader;
+
+namespace ggsql {
+
+// Registers a no-arg scalar function `ggsql_mark_v1_<name>` whose
+// function_info carries a MarkInfo. The function's executable callback is
+// only a debug stub: invoking it via `SELECT ggsql_mark_v1_point()` returns a
+// (name, required_aesthetics) introspection struct.
+void RegisterMark(ExtensionLoader &loader, const string &name,
+                  vector<string> required_aesthetics, mark_render_t render);
+
+// Resolves a mark by name through the catalog. Throws InvalidInputException
+// if the mark is not registered or carries an incompatible ABI version.
+const MarkInfo &LookupMark(ClientContext &context, const string &name);
+
+// Registers the four built-in marks (point, line, bar, histogram).
+void RegisterBuiltinMarks(ExtensionLoader &loader);
+
+} // namespace ggsql
+} // namespace duckdb

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -11,6 +11,7 @@
 #include "anova_function.hpp"
 #include "chisq_function.hpp"
 #include "read_stat_function.hpp"
+#include "ggsql.hpp"
 
 #include "duckdb/main/extension/extension_loader.hpp"
 
@@ -36,6 +37,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Data import
 	RegisterReadStat(loader);
+
+	// ggsql: Grammar of Graphics for SQL (parser extension + marks)
+	RegisterGgsql(loader);
 }
 
 void StatsDuckExtension::Load(ExtensionLoader &loader) {

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -12,6 +12,7 @@
 #include "chisq_function.hpp"
 #include "read_stat_function.hpp"
 #include "ggsql.hpp"
+#include "ggsql_marks_internal.hpp"
 
 #include "duckdb/main/extension/extension_loader.hpp"
 
@@ -40,6 +41,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// ggsql: Grammar of Graphics for SQL (parser extension + marks)
 	RegisterGgsql(loader);
+	ggsql::RegisterBuiltinMarks(loader);
 }
 
 void StatsDuckExtension::Load(ExtensionLoader &loader) {

--- a/test/sql/ggsql_mark_registry.test
+++ b/test/sql/ggsql_mark_registry.test
@@ -30,11 +30,14 @@ query T rowsort
 SELECT function_name FROM duckdb_functions()
 WHERE function_name LIKE 'ggsql_mark_v1_%'
 ----
+ggsql_mark_v1_area
 ggsql_mark_v1_bar
 ggsql_mark_v1_histogram
 ggsql_mark_v1_line
 ggsql_mark_v1_point
+ggsql_mark_v1_rule
 ggsql_mark_v1_text
+ggsql_mark_v1_tick
 
 # Unknown mark — registry lookup fails cleanly.
 statement ok

--- a/test/sql/ggsql_mark_registry.test
+++ b/test/sql/ggsql_mark_registry.test
@@ -1,0 +1,53 @@
+# name: test/sql/ggsql_mark_registry.test
+# description: Phase 3 — built-in marks are registered through the ggsql_mark_v1_* catalog registry
+# group: [stats_duck]
+
+require stats_duck
+
+# Each built-in mark is a no-arg scalar function returning an introspection JSON.
+query T
+SELECT ggsql_mark_v1_point()
+----
+{"name":"point","required_aesthetics":["x","y"]}
+
+query T
+SELECT ggsql_mark_v1_line()
+----
+{"name":"line","required_aesthetics":["x","y"]}
+
+query T
+SELECT ggsql_mark_v1_bar()
+----
+{"name":"bar","required_aesthetics":["x","y"]}
+
+query T
+SELECT ggsql_mark_v1_histogram()
+----
+{"name":"histogram","required_aesthetics":["x"]}
+
+# All four marks are visible in the catalog under the v1 prefix.
+query T rowsort
+SELECT function_name FROM duckdb_functions()
+WHERE function_name LIKE 'ggsql_mark_v1_%'
+----
+ggsql_mark_v1_bar
+ggsql_mark_v1_histogram
+ggsql_mark_v1_line
+ggsql_mark_v1_point
+
+# Unknown mark — registry lookup fails cleanly.
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7), (39.5, 17.4)) AS t(bill_len, bill_dep);
+
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW kaplan_meier
+----
+unknown mark 'kaplan_meier'
+
+# Built-in dispatch through the registry produces byte-identical output to the
+# pre-registry implementation (regression check against the phase-2 fixtures).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}

--- a/test/sql/ggsql_mark_registry.test
+++ b/test/sql/ggsql_mark_registry.test
@@ -32,6 +32,9 @@ WHERE function_name LIKE 'ggsql_mark_v1_%'
 ----
 ggsql_mark_v1_area
 ggsql_mark_v1_bar
+ggsql_mark_v1_boxplot
+ggsql_mark_v1_errorband
+ggsql_mark_v1_errorbar
 ggsql_mark_v1_histogram
 ggsql_mark_v1_line
 ggsql_mark_v1_point

--- a/test/sql/ggsql_mark_registry.test
+++ b/test/sql/ggsql_mark_registry.test
@@ -25,7 +25,7 @@ SELECT ggsql_mark_v1_histogram()
 ----
 {"name":"histogram","required_aesthetics":["x"]}
 
-# All four marks are visible in the catalog under the v1 prefix.
+# All built-in marks are visible in the catalog under the v1 prefix.
 query T rowsort
 SELECT function_name FROM duckdb_functions()
 WHERE function_name LIKE 'ggsql_mark_v1_%'
@@ -34,6 +34,7 @@ ggsql_mark_v1_bar
 ggsql_mark_v1_histogram
 ggsql_mark_v1_line
 ggsql_mark_v1_point
+ggsql_mark_v1_text
 
 # Unknown mark — registry lookup fails cleanly.
 statement ok

--- a/test/sql/ggsql_visualize_aesthetics.test
+++ b/test/sql/ggsql_visualize_aesthetics.test
@@ -1,0 +1,51 @@
+# name: test/sql/ggsql_visualize_aesthetics.test
+# description: Phase 4b — additional aesthetic channels (color, fill, stroke, shape, size, opacity, tooltip)
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7, 'Adelie', 3.5), (39.5, 17.4, 'Adelie', 3.4), (44.0, 18.0, 'Gentoo', 5.5)) AS t(bill_len, bill_dep, species, mass);
+
+# Point with x/y/color — color defaults to nominal.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins'}
+
+# Point with all 9 standard channels — output order is canonical (x, y, color, fill, stroke, shape, size, opacity, tooltip).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color, species AS fill, species AS stroke, species AS shape, mass AS size, mass AS opacity, species AS tooltip FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"},"fill":{"field":"fill","type":"nominal"},"stroke":{"field":"stroke","type":"nominal"},"shape":{"field":"shape","type":"nominal"},"size":{"field":"size","type":"quantitative"},"opacity":{"field":"opacity","type":"quantitative"},"tooltip":{"field":"tooltip","type":"nominal"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color, species AS fill, species AS stroke, species AS shape, mass AS size, mass AS opacity, species AS tooltip FROM penguins'}
+
+# Bar inherits the ordinal-x override and accepts color.
+query TT
+VISUALIZE species AS x, mass AS y, species AS color FROM penguins DRAW bar
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT x, SUM(y) AS y FROM (SELECT species AS x, mass AS y, species AS color FROM penguins) GROUP BY x ORDER BY x'}
+
+# Line accepts color + size; data_sql still wraps with ORDER BY x.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color, mass AS size FROM penguins DRAW line
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"},"size":{"field":"size","type":"quantitative"}}}	{layer_0='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y, species AS color, mass AS size FROM penguins) ORDER BY x'}
+
+# Histogram keeps its computed bin-x and aggregate-count y; optional channels still apply.
+query TT
+VISUALIZE bill_len AS x, species AS color FROM penguins DRAW histogram
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT bill_len AS x, species AS color FROM penguins'}
+
+# Histogram + user-mapped y is still silently dropped from encoding (count wins) but color is honoured.
+query TT
+VISUALIZE bill_len AS x, bill_len AS y, species AS color FROM penguins DRAW histogram
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT bill_len AS x, bill_len AS y, species AS color FROM penguins'}
+
+# Multi-layer + extra aesthetics — color propagates to both layers.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point DRAW line
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins) ORDER BY x'}

--- a/test/sql/ggsql_visualize_bar.test
+++ b/test/sql/ggsql_visualize_bar.test
@@ -1,0 +1,19 @@
+# name: test/sql/ggsql_visualize_bar.test
+# description: ggsql DRAW bar — produces Vega-Lite bar spec, server-side GROUP BY + SUM
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE sales AS
+SELECT * FROM (VALUES ('a', 10), ('b', 20), ('a', 5)) AS t(cat, val);
+
+query TT
+VISUALIZE cat AS x, val AS y FROM sales DRAW bar
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT x, SUM(y) AS y FROM (SELECT cat AS x, val AS y FROM sales) GROUP BY x ORDER BY x'}
+
+statement error
+VISUALIZE cat AS x FROM sales DRAW bar
+----
+'bar' requires 'y' aesthetic

--- a/test/sql/ggsql_visualize_expressions.test
+++ b/test/sql/ggsql_visualize_expressions.test
@@ -1,0 +1,53 @@
+# name: test/sql/ggsql_visualize_expressions.test
+# description: Phase 4c — multi-token SQL expressions in aesthetic mappings
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7, 'Adelie'), (39.5, 17.4, 'Adelie'), (44.0, 18.0, 'Gentoo')) AS t(bill_len, bill_dep, species);
+
+# Arithmetic expressions on both sides of the mapping list.
+query TT
+VISUALIZE bill_len * 2 AS x, bill_dep + 1 AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len * 2 AS x, bill_dep + 1 AS y FROM penguins'}
+
+# Function call without inline commas works (parens preserved as separate tokens, joined with spaces).
+query TT
+VISUALIZE bill_len AS x, log(bill_dep) AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, log(bill_dep) AS y FROM penguins'}
+
+# Boolean expression maps to the color aesthetic.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, bill_len > 40 AS color FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, bill_len > 40 AS color FROM penguins'}
+
+# Expression mixed with multi-layer (4a × 4c interaction).
+query TT
+VISUALIZE bill_len + bill_dep AS x, bill_dep AS y FROM penguins DRAW point DRAW line
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT bill_len + bill_dep AS x, bill_dep AS y FROM penguins', layer_1='SELECT * FROM (SELECT bill_len + bill_dep AS x, bill_dep AS y FROM penguins) ORDER BY x'}
+
+# Empty expression before AS — clean error.
+statement error
+VISUALIZE AS x FROM penguins DRAW point
+----
+Empty expression before 'AS'
+
+# Documented limitation: top-level commas inside expressions break the boundary
+# scan. `coalesce(bill_len, bill_dep)` would parse as two separate mappings; the
+# error surfaces from the first mapping (which is missing AS).
+statement error
+VISUALIZE coalesce(bill_len, bill_dep) AS x, bill_dep AS y FROM penguins DRAW point
+----
+Expected 'AS' before aesthetic 'coalesce(bill_len'
+
+# Trailing AS without aesthetic — clean error.
+statement error
+VISUALIZE bill_len AS FROM penguins DRAW point
+----
+Expected aesthetic name after 'AS'

--- a/test/sql/ggsql_visualize_expressions.test
+++ b/test/sql/ggsql_visualize_expressions.test
@@ -38,14 +38,6 @@ VISUALIZE AS x FROM penguins DRAW point
 ----
 Empty expression before 'AS'
 
-# Documented limitation: top-level commas inside expressions break the boundary
-# scan. `coalesce(bill_len, bill_dep)` would parse as two separate mappings; the
-# error surfaces from the first mapping (which is missing AS).
-statement error
-VISUALIZE coalesce(bill_len, bill_dep) AS x, bill_dep AS y FROM penguins DRAW point
-----
-Expected 'AS' before aesthetic 'coalesce(bill_len'
-
 # Trailing AS without aesthetic — clean error.
 statement error
 VISUALIZE bill_len AS FROM penguins DRAW point

--- a/test/sql/ggsql_visualize_facet.test
+++ b/test/sql/ggsql_visualize_facet.test
@@ -44,3 +44,27 @@ statement error
 VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET species
 ----
 Expected 'BY'
+
+# Phase 9: explicit ROWS layout — vertical stack via Vega-Lite "facet":{"row":...}.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species ROWS
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"row":{"field":"facet","type":"nominal"}},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet FROM penguins'}
+
+# Phase 9: explicit COLS layout — horizontal stack via "facet":{"column":...}.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species COLS
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"column":{"field":"facet","type":"nominal"}},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet FROM penguins'}
+
+# Layout composes with SCALE — ROWS layout retained, scale injected into the matching channel.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point FACET BY species ROWS SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"row":{"field":"facet","type":"nominal"}},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color, species AS facet FROM penguins'}
+
+# `ROWS` / `COLS` are reserved tokens after `FACET BY`. Bare `FACET BY ROWS` (no expression) errors.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY ROWS
+----
+Expected expression after 'FACET BY'

--- a/test/sql/ggsql_visualize_facet.test
+++ b/test/sql/ggsql_visualize_facet.test
@@ -1,0 +1,46 @@
+# name: test/sql/ggsql_visualize_facet.test
+# description: Phase 6b — FACET BY <expr> wraps the inner spec in a Vega-Lite facet operator
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7, 'Adelie'), (39.5, 17.4, 'Adelie'), (44.0, 18.0, 'Gentoo')) AS t(bill_len, bill_dep, species);
+
+# Single-layer faceted: data stays top-level, mark/encoding move into `spec`
+# alongside the `facet` definition.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"field":"facet","type":"nominal"},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet FROM penguins'}
+
+# Bar's GROUP BY extends to (x, facet) so each facet partition keeps its own ordinal x bins.
+query TT
+VISUALIZE species AS x, bill_dep AS y FROM penguins DRAW bar FACET BY species
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"field":"facet","type":"nominal"},"spec":{"mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT x, facet, SUM(y) AS y FROM (SELECT species AS x, bill_dep AS y, species AS facet FROM penguins) GROUP BY x, facet ORDER BY x'}
+
+# Multi-layer faceted: data:per-layer; the layer:[...] array sits inside the facet operator's `spec`.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW line FACET BY species
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","facet":{"field":"facet","type":"nominal"},"spec":{"layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y, species AS facet FROM penguins) ORDER BY x'}
+
+# Histogram + facet: bin/count happen inside each facet partition.
+query TT
+VISUALIZE bill_len AS x FROM penguins DRAW histogram FACET BY species
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"field":"facet","type":"nominal"},"spec":{"mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}}}}	{layer_0='SELECT bill_len AS x, species AS facet FROM penguins'}
+
+# Missing expression after FACET BY — clean error.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY
+----
+Expected expression after 'FACET BY'
+
+# FACET without BY — clean error.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET species
+----
+Expected 'BY'

--- a/test/sql/ggsql_visualize_histogram.test
+++ b/test/sql/ggsql_visualize_histogram.test
@@ -1,0 +1,25 @@
+# name: test/sql/ggsql_visualize_histogram.test
+# description: ggsql DRAW histogram — Vega-Lite bar mark with bin:true; data passes raw x
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1), (39.5), (40.3), (36.7), (39.3), (44.0)) AS t(bill_len);
+
+query TT
+VISUALIZE bill_len AS x FROM penguins DRAW histogram
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}}}	{layer_0=SELECT bill_len AS x FROM penguins}
+
+# y aesthetic is silently ignored for histogram (vega-lite computes count)
+query TT
+VISUALIZE bill_len AS x, bill_len AS y FROM penguins DRAW histogram
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_len AS y FROM penguins'}
+
+statement error
+VISUALIZE bill_len AS y FROM penguins DRAW histogram
+----
+'histogram' requires 'x' aesthetic

--- a/test/sql/ggsql_visualize_line.test
+++ b/test/sql/ggsql_visualize_line.test
@@ -1,0 +1,19 @@
+# name: test/sql/ggsql_visualize_line.test
+# description: ggsql DRAW line — produces Vega-Lite line spec with ORDER BY x in data SQL
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7), (39.5, 17.4), (40.3, 18.0)) AS t(bill_len, bill_dep);
+
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW line
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y FROM penguins) ORDER BY x'}
+
+statement error
+VISUALIZE bill_len AS x FROM penguins DRAW line
+----
+'line' requires 'y' aesthetic

--- a/test/sql/ggsql_visualize_multi_layer.test
+++ b/test/sql/ggsql_visualize_multi_layer.test
@@ -1,0 +1,46 @@
+# name: test/sql/ggsql_visualize_multi_layer.test
+# description: Phase 4a — multiple DRAW clauses emit Vega-Lite layer:[...] shape
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7), (39.5, 17.4), (40.3, 18.0)) AS t(bill_len, bill_dep);
+
+# Two-layer overlay: scatter + line. Each layer keeps its own data binding +
+# its own data_sql (point=raw, line=ordered).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW line
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y FROM penguins) ORDER BY x'}
+
+# Same mark twice → identical bodies but distinct positional layer names.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins', layer_1='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Three layers with distinct data_sql shapes (point=raw, line=ordered, bar=grouped+summed).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW line DRAW bar
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_2"},"mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y FROM penguins) ORDER BY x', layer_2='SELECT x, SUM(y) AS y FROM (SELECT bill_len AS x, bill_dep AS y FROM penguins) GROUP BY x ORDER BY x'}
+
+# Histogram only requires x; can coexist with marks needing x+y when both are mapped.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW histogram
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"bar","encoding":{"x":{"field":"x","type":"quantitative","bin":true},"y":{"aggregate":"count","type":"quantitative"}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins', layer_1='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Per-layer aesthetic validation: error originates from whichever layer's mark fails first.
+statement error
+VISUALIZE bill_len AS x FROM penguins DRAW point DRAW bar
+----
+'point' requires 'y' aesthetic
+
+# Same statement reordered — error reports the failing mark, not the position.
+statement error
+VISUALIZE bill_len AS x FROM penguins DRAW histogram DRAW bar
+----
+'bar' requires 'y' aesthetic

--- a/test/sql/ggsql_visualize_other_marks.test
+++ b/test/sql/ggsql_visualize_other_marks.test
@@ -1,0 +1,57 @@
+# name: test/sql/ggsql_visualize_other_marks.test
+# description: Phase 7 — area, rule, tick marks
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7), (39.5, 17.4), (40.3, 18.0), (44.0, 18.0)) AS t(bill_len, bill_dep);
+
+# area: filled region under the curve, same x/y requirement and ORDER-BY-x
+# data SQL as line.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW area
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"area","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y FROM penguins) ORDER BY x'}
+
+# rule with x only renders a vertical reference line.
+query TT
+VISUALIZE 40 AS x FROM penguins DRAW rule
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"rule","encoding":{"x":{"field":"x","type":"quantitative"}}}	{layer_0=SELECT 40 AS x FROM penguins}
+
+# rule with y only renders a horizontal threshold line.
+query TT
+VISUALIZE 18 AS y FROM penguins DRAW rule
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"rule","encoding":{"y":{"field":"y","type":"quantitative"}}}	{layer_0=SELECT 18 AS y FROM penguins}
+
+# rule with both x and y renders a segment.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW rule
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"rule","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# tick with x only — useful for marginal rug plots.
+query TT
+VISUALIZE bill_len AS x FROM penguins DRAW tick
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"tick","encoding":{"x":{"field":"x","type":"quantitative"}}}	{layer_0=SELECT bill_len AS x FROM penguins}
+
+# Common pattern: scatter overlaid with a reference line.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW rule
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"rule","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins', layer_1='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Introspection: rule and tick declare empty required_aesthetics.
+query T
+SELECT ggsql_mark_v1_rule() AS info
+----
+{"name":"rule","required_aesthetics":[]}
+
+query T
+SELECT ggsql_mark_v1_tick() AS info
+----
+{"name":"tick","required_aesthetics":[]}

--- a/test/sql/ggsql_visualize_point.test
+++ b/test/sql/ggsql_visualize_point.test
@@ -1,0 +1,44 @@
+# name: test/sql/ggsql_visualize_point.test
+# description: ggsql phase 1 — VISUALIZE ... DRAW point produces Vega-Lite scatter spec
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7), (39.5, 17.4), (40.3, 18.0)) AS t(bill_len, bill_dep);
+
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Lowercase keywords work
+query TT
+visualize bill_len as x, bill_dep as y from penguins draw point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Trailing semicolon tolerated
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point;
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Unknown mark — phase 1 only supports "point"
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW nope
+----
+unknown mark 'nope'
+
+# Missing DRAW clause
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins
+----
+At least one 'DRAW <mark>' clause is required
+
+# Missing AS
+statement error
+VISUALIZE bill_len x, bill_dep AS y FROM penguins DRAW point
+----
+Expected 'AS'

--- a/test/sql/ggsql_visualize_point.test
+++ b/test/sql/ggsql_visualize_point.test
@@ -25,11 +25,17 @@ VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point;
 ----
 {"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
 
-# Unknown mark — phase 1 only supports "point"
+# Unknown mark
 statement error
 VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW nope
 ----
 unknown mark 'nope'
+
+# Aesthetic validation: point requires x and y
+statement error
+VISUALIZE bill_len AS x FROM penguins DRAW point
+----
+'point' requires 'y' aesthetic
 
 # Missing DRAW clause
 statement error

--- a/test/sql/ggsql_visualize_scale.test
+++ b/test/sql/ggsql_visualize_scale.test
@@ -1,0 +1,51 @@
+# name: test/sql/ggsql_visualize_scale.test
+# description: Phase 6c — SCALE <aesthetic> TO <scheme> attaches a Vega-Lite color scheme to the targeted channel
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7, 'Adelie'), (39.5, 17.4, 'Adelie'), (44.0, 18.0, 'Gentoo')) AS t(bill_len, bill_dep, species);
+
+# Single SCALE injects scale:{scheme:...} into the matching channel.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins'}
+
+# Multiple SCALE clauses each target their own channel.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color, species AS fill FROM penguins DRAW point SCALE color TO viridis SCALE fill TO accent
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}},"fill":{"field":"fill","type":"nominal","scale":{"scheme":"accent"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color, species AS fill FROM penguins'}
+
+# SCALE on a channel that was never mapped is a silent no-op (warning-friendly).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# FACET BY composes with SCALE — both clauses present, both applied.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point FACET BY species SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"field":"facet","type":"nominal"},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color, species AS facet FROM penguins'}
+
+# Multi-layer + SCALE applies the scheme to every layer that has the channel mapped.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point DRAW line SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins) ORDER BY x'}
+
+# SCALE without TO — clean error.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point SCALE color viridis
+----
+Expected 'TO'
+
+# SCALE TO without scheme name — clean error.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point SCALE color TO
+----
+Expected scheme name after 'SCALE <aesthetic> TO'

--- a/test/sql/ggsql_visualize_scale.test
+++ b/test/sql/ggsql_visualize_scale.test
@@ -38,14 +38,38 @@ VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW poin
 ----
 {"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins) ORDER BY x'}
 
-# SCALE without TO — clean error.
+# Unknown SCALE operator — clean error listing the valid options.
 statement error
 VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point SCALE color viridis
 ----
-Expected 'TO'
+Unknown SCALE operator 'viridis'
 
 # SCALE TO without scheme name — clean error.
 statement error
 VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point SCALE color TO
 ----
 Expected scheme name after 'SCALE <aesthetic> TO'
+
+# Phase 11: SCALE y ZERO false — exclude zero from the scale.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE y ZERO false
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative","scale":{"zero":false}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Phase 11: SCALE x DOMAIN <lo> <hi> — explicit numeric domain.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x DOMAIN 30 50
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative","scale":{"domain":[30,50]}},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Phase 11: multiple SCALE clauses on the same channel merge into one scale block.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x DOMAIN 30 50 SCALE x ZERO false
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative","scale":{"domain":[30,50],"zero":false}},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Invalid bool after ZERO — clean error.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE y ZERO yes
+----
+Expected 'true' or 'false'

--- a/test/sql/ggsql_visualize_stats_marks.test
+++ b/test/sql/ggsql_visualize_stats_marks.test
@@ -1,0 +1,44 @@
+# name: test/sql/ggsql_visualize_stats_marks.test
+# description: Phase 10 — errorbar / errorband / boxplot for uncertainty + distribution
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE measurements AS
+SELECT * FROM (VALUES (1.0, 5.0, 4.0, 6.0), (2.0, 6.0, 5.5, 6.5), (3.0, 7.0, 6.0, 8.0)) AS t(group_id, mean, lo, hi);
+
+# errorbar: pre-aggregated lower/upper via y/y2.
+query TT
+VISUALIZE group_id AS x, lo AS y, hi AS y2 FROM measurements DRAW errorbar
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"errorbar","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"y2":{"field":"y2","type":"quantitative"}}}	{layer_0='SELECT group_id AS x, lo AS y, hi AS y2 FROM measurements'}
+
+# errorband: same range encoding as errorbar but draws a filled region; data
+# SQL orders by x like line/area for clean filling.
+query TT
+VISUALIZE group_id AS x, lo AS y, hi AS y2 FROM measurements DRAW errorband
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"errorband","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"y2":{"field":"y2","type":"quantitative"}}}	{layer_0='SELECT * FROM (SELECT group_id AS x, lo AS y, hi AS y2 FROM measurements) ORDER BY x'}
+
+# boxplot: x and y suffice — Vega-Lite computes quartiles + outliers.
+query TT
+VISUALIZE group_id AS x, mean AS y FROM measurements DRAW boxplot
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"boxplot","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT group_id AS x, mean AS y FROM measurements'}
+
+# Introspection: required_aesthetics = [x, y] for all three.
+query T
+SELECT ggsql_mark_v1_errorbar() AS info
+----
+{"name":"errorbar","required_aesthetics":["x","y"]}
+
+query T
+SELECT ggsql_mark_v1_errorband() AS info
+----
+{"name":"errorband","required_aesthetics":["x","y"]}
+
+query T
+SELECT ggsql_mark_v1_boxplot() AS info
+----
+{"name":"boxplot","required_aesthetics":["x","y"]}

--- a/test/sql/ggsql_visualize_text.test
+++ b/test/sql/ggsql_visualize_text.test
@@ -1,0 +1,39 @@
+# name: test/sql/ggsql_visualize_text.test
+# description: Phase 6a — text mark renders labels at (x,y); requires the text aesthetic
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE labels AS
+SELECT * FROM (VALUES (1.0, 2.0, 'A'), (3.0, 4.0, 'B')) AS t(x, y, label);
+
+# Required aesthetics: x, y, text.
+query TT
+VISUALIZE x AS x, y AS y, label AS text FROM labels DRAW text
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"text","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"text":{"field":"text","type":"nominal"}}}	{layer_0='SELECT x AS x, y AS y, label AS text FROM labels'}
+
+# Missing text aesthetic surfaces the standard required-aesthetic error.
+statement error
+VISUALIZE x AS x, y AS y FROM labels DRAW text
+----
+'text' requires 'text' aesthetic
+
+# Introspection lists all three required aesthetics.
+query T
+SELECT ggsql_mark_v1_text() AS info
+----
+{"name":"text","required_aesthetics":["x","y","text"]}
+
+# Other marks accept text as an optional channel — useful for tooltipping points.
+query TT
+VISUALIZE x AS x, y AS y, label AS text FROM labels DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"text":{"field":"text","type":"nominal"}}}	{layer_0='SELECT x AS x, y AS y, label AS text FROM labels'}
+
+# Common pattern: scatter with text labels overlaid as a second layer.
+query TT
+VISUALIZE x AS x, y AS y, label AS text FROM labels DRAW point DRAW text
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"text":{"field":"text","type":"nominal"}}},{"data":{"name":"layer_1"},"mark":"text","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"text":{"field":"text","type":"nominal"}}}]}	{layer_0='SELECT x AS x, y AS y, label AS text FROM labels', layer_1='SELECT x AS x, y AS y, label AS text FROM labels'}

--- a/test/sql/ggsql_visualize_tokenizer.test
+++ b/test/sql/ggsql_visualize_tokenizer.test
@@ -1,0 +1,68 @@
+# name: test/sql/ggsql_visualize_tokenizer.test
+# description: Phase 5 — paren-aware and quote-aware tokenizer
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7, 'Adelie'), (39.5, 17.4, 'Adelie'), (44.0, 18.0, 'Gentoo')) AS t(bill_len, bill_dep, species);
+
+# Top-level comma inside parens is no longer a boundary — `coalesce(a, b)` parses
+# as a single expression. Closes the phase-4c documented limitation.
+query TT
+VISUALIZE coalesce(bill_len, bill_dep) AS x, bill_dep AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT coalesce(bill_len, bill_dep) AS x, bill_dep AS y FROM penguins'}
+
+# Nested parens with internal commas at multiple depths.
+query TT
+VISUALIZE log(coalesce(bill_len, bill_dep)) AS x, bill_dep AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT log(coalesce(bill_len, bill_dep)) AS x, bill_dep AS y FROM penguins'}
+
+# Subquery with internal FROM is protected by the paren-depth check — the inner
+# FROM no longer terminates the boundary scan.
+query TT
+VISUALIZE bill_len AS x, (SELECT max(bill_dep) FROM penguins) AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, (SELECT max(bill_dep) FROM penguins) AS y FROM penguins'}
+
+# Quoted identifier with internal space.
+statement ok
+CREATE TABLE q AS SELECT 1 AS "my col", 2 AS y;
+
+query TT
+VISUALIZE "my col" AS x, y AS y FROM q DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT "my col" AS x, y AS y FROM q'}
+
+# String literal with internal space (no longer split on whitespace inside quotes).
+query TT
+VISUALIZE 'big size' AS x, y AS y FROM q DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT \'big size\' AS x, y AS y FROM q'}
+
+# Multi-layer + paren-aware expressions.
+query TT
+VISUALIZE coalesce(bill_len, 0) AS x, bill_dep AS y FROM penguins DRAW point DRAW line
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT coalesce(bill_len, 0) AS x, bill_dep AS y FROM penguins', layer_1='SELECT * FROM (SELECT coalesce(bill_len, 0) AS x, bill_dep AS y FROM penguins) ORDER BY x'}
+
+# Unbalanced opening paren produces a clear tokenizer error.
+statement error
+VISUALIZE log( AS x FROM penguins DRAW point
+----
+Unbalanced parentheses in input
+
+# Unterminated string literal produces a clear error naming the missing quote.
+statement error
+VISUALIZE 'open AS x FROM penguins DRAW point
+----
+Unterminated string literal or quoted identifier
+
+# Unterminated quoted identifier likewise.
+statement error
+VISUALIZE "open AS x FROM penguins DRAW point
+----
+Unterminated string literal or quoted identifier

--- a/test/sql/ggsql_visualize_type_overrides.test
+++ b/test/sql/ggsql_visualize_type_overrides.test
@@ -1,0 +1,46 @@
+# name: test/sql/ggsql_visualize_type_overrides.test
+# description: Phase 8 — `<expr> AS <aesthetic>:<type>` overrides Vega-Lite's default channel type
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7, 'Adelie', 2018), (39.5, 17.4, 'Adelie', 2019), (44.0, 18.0, 'Gentoo', 2020)) AS t(bill_len, bill_dep, species, year);
+
+# Numeric column as ordinal (override the default nominal-for-color).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, year AS color:ordinal FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"ordinal"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, year AS color FROM penguins'}
+
+# String column forced to quantitative (Vega-Lite will likely reject at render but
+# the parser doesn't second-guess — the user knows their data).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color:quantitative FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins'}
+
+# Type override composes with SCALE (override applied first, then scale injection).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, year AS color:ordinal FROM penguins DRAW point SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"ordinal","scale":{"scheme":"viridis"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, year AS color FROM penguins'}
+
+# x and y can also be overridden — sometimes you want a categorical x on a point chart.
+query TT
+VISUALIZE bill_len AS x:nominal, bill_dep AS y FROM penguins DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"nominal"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Invalid type literal — clean error.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color:bogus FROM penguins DRAW point
+----
+Invalid aesthetic type 'bogus'
+
+# Empty aesthetic name before colon — clean error.
+statement error
+VISUALIZE bill_len AS :nominal FROM penguins DRAW point
+----
+Empty aesthetic name before ':'


### PR DESCRIPTION
## Summary

Implements Posit's "ggsql" Grammar of Graphics SQL syntax (announced 2026-04-20) as a DuckDB parser extension. `VISUALIZE x AS x, y AS y FROM t DRAW point` compiles at plan time to a Vega-Lite v5 spec + per-layer data SQL strings (Arrow-handoff: client runs the SQL, feeds Arrow to vega-embed `datasets`).

- **Catalog-mediated mark registry** — marks register as `ggsql_mark_v1_<name>` scalar functions whose `function_info` carries a `MarkInfo` struct. A separate extension (planned: bio-stats with Kaplan-Meier / forest-plot) can plug in marks at runtime without modifying stats_duck. Verified end-to-end across two WASM modules in DuckDB-WASM (see `spike/marks_demo/`).
- **11 built-in marks**: `point`, `line`, `bar`, `histogram`, `text`, `area`, `rule`, `tick`, `errorbar`, `errorband`, `boxplot`.
- **12 encoding channels**: `x`, `y`, `color`, `fill`, `stroke`, `shape`, `size`, `opacity`, `tooltip`, `text`, `x2`, `y2` — built via shared `BuildEncoding` helper with per-mark type/extras overrides.
- **Composable**: multi-layer overlays (`DRAW point DRAW line`), faceting (`FACET BY species [ROWS|COLS]`), scales (`SCALE color TO viridis`, `SCALE x DOMAIN 0 100`, `SCALE y ZERO false`), type overrides (`species AS color:nominal`), multi-token SQL expressions in mappings (`bill_len * 2 AS x`, `coalesce(a, b) AS y`, subqueries) via paren/quote-aware tokenizer.
- **WASM build pins** baked in: DuckDB v1.5.1 submodule + `-sWASM_BIGINT=0` link flag — matches the deployed `@duckdb/duckdb-wasm` 1.33.x runtime ABI. (Earlier v1.5.2 / `WASM_BIGINT=1` builds failed at module instantiation; the pins are encoded in `CMakeLists.txt` so future `make wasm_eh` runs don't repeat the failure.)

Builds on the spike in #1 (parser extension loads in DuckDB-WASM, GGSQL PING → 'pong'); that branch is preserved separately for history. This PR is the actual feature and supersedes the design questions raised there.

181 ggsql assertions across 15 SQL fixtures, all green locally on Windows debug build. Existing `ttest_*` / `mannwhitney` / `wilcoxon` / `read_stat` suites unchanged. Bedevere agent verified phase 3 (single-extension + cross-extension) end-to-end in the browser; phases 4–11 are local-only — CI will confirm build + tests, browser verification on the new marks can come post-merge.

The 16 commits on this branch are kept as a sequence (phases 1 → 11) so the diff stays reviewable per feature; no squash needed unless preferred.

## Test plan

- [ ] CI: Linux + Mac + Windows native builds clean
- [ ] CI: WASM build clean
- [ ] CI: full sqllogic test suite passes (181 ggsql + ~330 stats)
- [ ] (Optional, post-merge) Bedevere browser smoke on the new marks: errorbar, errorband, boxplot, area, rule, tick, FACET ROWS/COLS, SCALE DOMAIN/ZERO, type overrides, multi-token expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)