### PR TITLE
Add SAS/SPSS file export via COPY ... TO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ that name is preserved across releases for backward compatibility.
   silent truncation. Buffers the full result set in a `ColumnDataCollection`
   (spillable via DuckDB's buffer manager) before emitting, since ReadStat's writer
   requires the row count up front.
+- `COPY tbl TO 'file.sas7bdat'` — write SAS7BDAT files via ReadStat. Same type and
+  NULL semantics as XPT, but allows ≤ 32-char mixed-case column names. Optional
+  `LABEL` and `COMPRESSION` (`'none'` / `'rows'`) options. **Caveat:** ReadStat's
+  SAS7BDAT writer is reverse-engineered, and the produced files round-trip through
+  ReadStat-family readers (this extension's `read_stat()`, pyreadstat, haven, R)
+  but **are not opened by real SAS / SAS Universal Viewer / SAS OnDemand**. This
+  is a long-standing upstream limitation. Use XPT if you need SAS-native readability.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ that name is preserved across releases for backward compatibility.
 
 ## [Unreleased]
 
+### Added
+
+- `COPY tbl TO 'file.xpt'` — write SAS Transport (XPT v5) files via ReadStat.
+  Supports BOOLEAN, all integer/float/decimal types, VARCHAR, DATE, TIMESTAMP, and
+  TIME columns. Numeric NULLs round-trip as SAS system-missing; VARCHAR NULLs
+  collapse to empty strings (SAS character columns have no NULL/empty distinction).
+  Output goes through DuckDB's `FileSystem` so registered/remote/WASM paths work
+  the same as `read_stat()`. Optional `LABEL` and `TABLE_NAME` options. XPT v5
+  column-name rules (≤ 8 chars uppercase, A-Z 0-9 _) are validated at bind — no
+  silent truncation. Buffers the full result set in a `ColumnDataCollection`
+  (spillable via DuckDB's buffer manager) before emitting, since ReadStat's writer
+  requires the row count up front.
+
 ### Changed
 
 - Target DuckDB v1.5.1 (up from v1.2.2). Extensions built for 0.1.x are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ that name is preserved across releases for backward compatibility.
   ReadStat-family readers (this extension's `read_stat()`, pyreadstat, haven, R)
   but **are not opened by real SAS / SAS Universal Viewer / SAS OnDemand**. This
   is a long-standing upstream limitation. Use XPT if you need SAS-native readability.
+- `COPY tbl TO 'file.sav'` — write SPSS SAV files via ReadStat. Same scaffolding
+  as the SAS exports; uses SPSS-native epoch (seconds since 1582-10-14) and SPSS
+  format strings (`DATE11`, `DATETIME20`, `TIME8`) for temporal columns. Optional
+  `LABEL` and `COMPRESSION` (`'none'` / `'rows'`) options.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(READSTAT_SOURCES
     ${READSTAT_DIR}/sas/readstat_sas.c
     ${READSTAT_DIR}/sas/readstat_sas_rle.c
     ${READSTAT_DIR}/sas/readstat_sas7bdat_read.c
+    ${READSTAT_DIR}/sas/readstat_sas7bdat_write.c
     ${READSTAT_DIR}/sas/readstat_xport.c
     ${READSTAT_DIR}/sas/readstat_xport_parse_format.c
     ${READSTAT_DIR}/sas/readstat_xport_read.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXTENSION_SOURCES
     src/chisq_function.cpp
     src/read_stat_function.cpp
     src/read_stat_types.cpp
+    src/sas_export_function.cpp
     src/ggsql.cpp
     src/ggsql_grammar.cpp
     src/ggsql_marks.cpp

--- a/src/include/sas_export_function.hpp
+++ b/src/include/sas_export_function.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+class ExtensionLoader;
+
+void RegisterSasExport(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/sas_export_function.cpp
+++ b/src/sas_export_function.cpp
@@ -21,32 +21,38 @@ extern "C" {
 
 namespace duckdb {
 
-// ─── XPT v5 column-name validation ─────────────────────────────────────────────
-// XPT v5 requires names ≤ 8 chars, ASCII alphanumeric or underscore, must start
-// with a letter or underscore. We uppercase and reject — silent truncation
-// would create silent collisions on round-trip.
+enum class SasFormat { XPT, SAS7BDAT };
 
-static string ValidateXportV5Name(const string &name, const char *role) {
+// ─── Per-format column-name validation ─────────────────────────────────────────
+// XPT v5: ≤ 8 chars, uppercased, ASCII alphanumeric or underscore, must start
+// with a letter or underscore. Names are uppercased before validation —
+// silent truncation would create silent collisions on round-trip.
+// SAS7BDAT: ≤ 32 chars, otherwise the same character rules. Case is preserved
+// (real SAS is case-insensitive but stores the user's casing).
+
+static string ValidateColumnName(const string &name, SasFormat format, const char *role) {
+	const size_t max_len = (format == SasFormat::XPT) ? 8 : 32;
+	const char *format_label = (format == SasFormat::XPT) ? "XPT v5" : "SAS7BDAT";
+
 	if (name.empty()) {
-		throw BinderException("Empty %s not allowed in XPT export", role);
+		throw BinderException("Empty %s not allowed in %s export", role, format_label);
 	}
-	if (name.size() > 8) {
-		throw BinderException(
-		    "%s '%s' is too long for XPT v5 (max 8 chars). Rename in your SELECT or wait for XPT v8 support.",
-		    role, name);
+	if (name.size() > max_len) {
+		throw BinderException("%s '%s' is too long for %s (max %llu chars). Rename in your SELECT.", role, name,
+		                      format_label, static_cast<uint64_t>(max_len));
 	}
-	string upper = StringUtil::Upper(name);
-	for (char c : upper) {
-		bool ok = (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+	string out = (format == SasFormat::XPT) ? StringUtil::Upper(name) : name;
+	for (char c : out) {
+		bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
 		if (!ok) {
-			throw BinderException("%s '%s' contains characters not allowed in XPT v5 (only A-Z 0-9 _ permitted)",
-			                      role, name);
+			throw BinderException("%s '%s' contains characters not allowed in %s (only A-Z a-z 0-9 _ permitted)",
+			                      role, name, format_label);
 		}
 	}
-	if (upper[0] >= '0' && upper[0] <= '9') {
-		throw BinderException("%s '%s' starts with a digit, not allowed in XPT v5", role, name);
+	if (out[0] >= '0' && out[0] <= '9') {
+		throw BinderException("%s '%s' starts with a digit, not allowed in %s", role, name, format_label);
 	}
-	return upper;
+	return out;
 }
 
 // ─── Type mapping (DuckDB → ReadStat) ──────────────────────────────────────────
@@ -114,14 +120,18 @@ static void MapDuckDBType(const LogicalType &dt, ColumnSpec &spec) {
 // ─── BindData / GlobalState / LocalState ───────────────────────────────────────
 
 struct SasExportBindData : public FunctionData {
+	SasFormat format = SasFormat::XPT;
 	string label;
-	string table_name;
+	string table_name;                                          // XPT only
+	readstat_compress_t compression = READSTAT_COMPRESS_NONE;   // SAS7BDAT only
 	vector<ColumnSpec> columns;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto c = make_uniq<SasExportBindData>();
+		c->format = format;
 		c->label = label;
 		c->table_name = table_name;
+		c->compression = compression;
 		c->columns = columns;
 		return std::move(c);
 	}
@@ -136,7 +146,8 @@ struct SasExportBindData : public FunctionData {
 				return false;
 			}
 		}
-		return label == other.label && table_name == other.table_name;
+		return format == other.format && label == other.label && table_name == other.table_name &&
+		       compression == other.compression;
 	}
 };
 
@@ -151,51 +162,88 @@ struct SasExportLocalState : public LocalFunctionData {};
 
 // ─── Bind ──────────────────────────────────────────────────────────────────────
 
+static SasFormat FormatFromInfo(const CopyInfo &info) {
+	auto fmt = StringUtil::Lower(info.format);
+	if (fmt == "xpt") {
+		return SasFormat::XPT;
+	}
+	if (fmt == "sas7bdat") {
+		return SasFormat::SAS7BDAT;
+	}
+	throw BinderException("Unknown SAS export format '%s' (expected 'xpt' or 'sas7bdat')", info.format);
+}
+
+static const char *FormatLabel(SasFormat f) {
+	return f == SasFormat::XPT ? "XPT" : "SAS7BDAT";
+}
+
 static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFunctionBindInput &input,
                                               const vector<string> &names, const vector<LogicalType> &sql_types) {
 	auto bind_data = make_uniq<SasExportBindData>();
+	bind_data->format = FormatFromInfo(input.info);
+	const auto fmt = bind_data->format;
+	const auto *fmt_label = FormatLabel(fmt);
 
-	// Default XPT internal table name: file basename, mangled to ≤ 8 chars uppercase.
-	auto path = input.info.file_path;
-	auto slash = path.find_last_of("/\\");
-	auto base = slash == string::npos ? path : path.substr(slash + 1);
-	auto dot = base.find_last_of('.');
-	if (dot != string::npos) {
-		base = base.substr(0, dot);
-	}
-	if (base.empty()) {
-		base = "DATASET";
-	}
-	// Truncate to fit XPT's 8-char limit before validation; user-provided names go through
-	// strict validation below.
-	if (base.size() > 8) {
-		base = base.substr(0, 8);
+	// XPT-only: derive a default internal dataset name from the path basename.
+	// SAS7BDAT ignores readstat_writer_set_table_name, so we only build it for XPT.
+	string xpt_base;
+	if (fmt == SasFormat::XPT) {
+		auto path = input.info.file_path;
+		auto slash = path.find_last_of("/\\");
+		xpt_base = slash == string::npos ? path : path.substr(slash + 1);
+		auto dot = xpt_base.find_last_of('.');
+		if (dot != string::npos) {
+			xpt_base = xpt_base.substr(0, dot);
+		}
+		if (xpt_base.empty()) {
+			xpt_base = "DATASET";
+		}
+		if (xpt_base.size() > 8) {
+			xpt_base = xpt_base.substr(0, 8);
+		}
 	}
 
 	bool table_name_user_provided = false;
 	for (auto &option : input.info.options) {
 		auto loption = StringUtil::Lower(option.first);
 		if (option.second.size() != 1) {
-			throw BinderException("XPT %s requires exactly one argument", StringUtil::Upper(loption));
+			throw BinderException("%s %s requires exactly one argument", fmt_label, StringUtil::Upper(loption));
 		}
 		if (loption == "label") {
 			bind_data->label = option.second[0].ToString();
 		} else if (loption == "table_name") {
-			base = option.second[0].ToString();
+			if (fmt != SasFormat::XPT) {
+				throw BinderException("TABLE_NAME option is only meaningful for XPT export, not %s", fmt_label);
+			}
+			xpt_base = option.second[0].ToString();
 			table_name_user_provided = true;
+		} else if (loption == "compression") {
+			if (fmt != SasFormat::SAS7BDAT) {
+				throw BinderException("COMPRESSION option is only meaningful for SAS7BDAT export, not %s", fmt_label);
+			}
+			auto roption = StringUtil::Lower(option.second[0].ToString());
+			if (roption == "none") {
+				bind_data->compression = READSTAT_COMPRESS_NONE;
+			} else if (roption == "rows" || roption == "rle") {
+				bind_data->compression = READSTAT_COMPRESS_ROWS;
+			} else {
+				throw BinderException("SAS7BDAT COMPRESSION must be 'none' or 'rows', got '%s'", roption);
+			}
 		} else {
-			throw BinderException("Unrecognized XPT option: %s", option.first);
+			throw BinderException("Unrecognized %s option: %s", fmt_label, option.first);
 		}
 	}
 
-	try {
-		bind_data->table_name = ValidateXportV5Name(base, "TABLE_NAME");
-	} catch (const BinderException &) {
-		if (table_name_user_provided) {
-			throw;
+	if (fmt == SasFormat::XPT) {
+		try {
+			bind_data->table_name = ValidateColumnName(xpt_base, fmt, "TABLE_NAME");
+		} catch (const BinderException &) {
+			if (table_name_user_provided) {
+				throw;
+			}
+			// Auto-derived name from path didn't fit XPT v5; fall back to "DATASET".
+			bind_data->table_name = "DATASET";
 		}
-		// Auto-derived name from path didn't fit; fall back to "DATASET".
-		bind_data->table_name = "DATASET";
 	}
 
 	bind_data->columns.reserve(names.size());
@@ -204,7 +252,7 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 		spec.original_name = names[i];
 		spec.duckdb_type = sql_types[i];
 		MapDuckDBType(sql_types[i], spec);
-		spec.mangled_name = ValidateXportV5Name(names[i], "column name");
+		spec.mangled_name = ValidateColumnName(names[i], fmt, "column name");
 		bind_data->columns.push_back(std::move(spec));
 	}
 
@@ -394,13 +442,23 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 
 	auto *writer = readstat_writer_init();
 	readstat_set_data_writer(writer, SasExportDataWriter);
-	readstat_writer_set_file_format_version(writer, 5);
+
+	if (bind_data.format == SasFormat::XPT) {
+		// XPT v5 — most universally readable XPT version. v8 (longer names, wider
+		// strings) is a future phase.
+		readstat_writer_set_file_format_version(writer, 5);
+		if (!bind_data.table_name.empty()) {
+			readstat_writer_set_table_name(writer, bind_data.table_name.c_str());
+		}
+	} else {
+		// SAS7BDAT: optional row-level RLE compression (matches `proc copy ... compress=`).
+		if (bind_data.compression != READSTAT_COMPRESS_NONE) {
+			readstat_writer_set_compression(writer, bind_data.compression);
+		}
+	}
 
 	if (!bind_data.label.empty()) {
 		readstat_writer_set_file_label(writer, bind_data.label.c_str());
-	}
-	if (!bind_data.table_name.empty()) {
-		readstat_writer_set_table_name(writer, bind_data.table_name.c_str());
 	}
 
 	vector<readstat_variable_t *> vars(bind_data.columns.size(), nullptr);
@@ -417,11 +475,16 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 	}
 
 	long row_count = static_cast<long>(gstate.buffer->Count());
-	auto err = readstat_begin_writing_xport(writer, gstate.file_handle.get(), row_count);
+	readstat_error_t err;
+	if (bind_data.format == SasFormat::XPT) {
+		err = readstat_begin_writing_xport(writer, gstate.file_handle.get(), row_count);
+	} else {
+		err = readstat_begin_writing_sas7bdat(writer, gstate.file_handle.get(), row_count);
+	}
 	if (err != READSTAT_OK) {
 		auto msg = readstat_error_message(err);
 		readstat_writer_free(writer);
-		throw IOException("Failed to begin XPT write: %s", msg ? msg : "unknown");
+		throw IOException("Failed to begin %s write: %s", FormatLabel(bind_data.format), msg ? msg : "unknown");
 	}
 
 	DataChunk chunk;
@@ -440,7 +503,7 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 			if (err != READSTAT_OK) {
 				auto msg = readstat_error_message(err);
 				readstat_writer_free(writer);
-				throw IOException("XPT begin_row failed: %s", msg ? msg : "unknown");
+				throw IOException("%s begin_row failed: %s", FormatLabel(bind_data.format), msg ? msg : "unknown");
 			}
 			for (idx_t c = 0; c < bind_data.columns.size(); c++) {
 				InsertValue(writer, vars[c], bind_data.columns[c], chunk.data[c], r, formats[c]);
@@ -449,7 +512,7 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 			if (err != READSTAT_OK) {
 				auto msg = readstat_error_message(err);
 				readstat_writer_free(writer);
-				throw IOException("XPT end_row failed: %s", msg ? msg : "unknown");
+				throw IOException("%s end_row failed: %s", FormatLabel(bind_data.format), msg ? msg : "unknown");
 			}
 		}
 		chunk.Reset();
@@ -459,7 +522,7 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 	readstat_writer_free(writer);
 	if (err != READSTAT_OK) {
 		auto msg = readstat_error_message(err);
-		throw IOException("XPT end_writing failed: %s", msg ? msg : "unknown");
+		throw IOException("%s end_writing failed: %s", FormatLabel(bind_data.format), msg ? msg : "unknown");
 	}
 
 	gstate.file_handle->Close();
@@ -474,17 +537,30 @@ static CopyFunctionExecutionMode SasExportExecutionMode(bool, bool) {
 
 // ─── Registration ──────────────────────────────────────────────────────────────
 
+static void WireCopyFunction(CopyFunction &fn) {
+	fn.copy_to_bind = SasExportBind;
+	fn.copy_to_initialize_global = SasExportInitGlobal;
+	fn.copy_to_initialize_local = SasExportInitLocal;
+	fn.copy_to_sink = SasExportSink;
+	fn.copy_to_combine = SasExportCombine;
+	fn.copy_to_finalize = SasExportFinalize;
+	fn.execution_mode = SasExportExecutionMode;
+}
+
 void RegisterSasExport(ExtensionLoader &loader) {
 	CopyFunction xpt("xpt");
-	xpt.copy_to_bind = SasExportBind;
-	xpt.copy_to_initialize_global = SasExportInitGlobal;
-	xpt.copy_to_initialize_local = SasExportInitLocal;
-	xpt.copy_to_sink = SasExportSink;
-	xpt.copy_to_combine = SasExportCombine;
-	xpt.copy_to_finalize = SasExportFinalize;
-	xpt.execution_mode = SasExportExecutionMode;
+	WireCopyFunction(xpt);
 	xpt.extension = "xpt";
 	loader.RegisterFunction(xpt);
+
+	// SAS7BDAT: round-trips through this extension's read_stat() and other
+	// ReadStat-based readers (pyreadstat, haven). A long-standing upstream
+	// limitation means real SAS / SAS Universal Viewer cannot open these files.
+	// CHANGELOG flags this caveat for users.
+	CopyFunction sas7bdat("sas7bdat");
+	WireCopyFunction(sas7bdat);
+	sas7bdat.extension = "sas7bdat";
+	loader.RegisterFunction(sas7bdat);
 }
 
 } // namespace duckdb

--- a/src/sas_export_function.cpp
+++ b/src/sas_export_function.cpp
@@ -21,18 +21,21 @@ extern "C" {
 
 namespace duckdb {
 
-enum class SasFormat { XPT, SAS7BDAT };
+enum class SasFormat { XPT, SAS7BDAT, SAV };
 
 // ─── Per-format column-name validation ─────────────────────────────────────────
 // XPT v5: ≤ 8 chars, uppercased, ASCII alphanumeric or underscore, must start
 // with a letter or underscore. Names are uppercased before validation —
 // silent truncation would create silent collisions on round-trip.
-// SAS7BDAT: ≤ 32 chars, otherwise the same character rules. Case is preserved
-// (real SAS is case-insensitive but stores the user's casing).
+// SAS7BDAT / SAV: ≤ 32 chars, otherwise the same character rules. Case is
+// preserved (real SAS is case-insensitive but stores the user's casing; SPSS
+// is case-sensitive in modern versions).
 
 static string ValidateColumnName(const string &name, SasFormat format, const char *role) {
 	const size_t max_len = (format == SasFormat::XPT) ? 8 : 32;
-	const char *format_label = (format == SasFormat::XPT) ? "XPT v5" : "SAS7BDAT";
+	const char *format_label = format == SasFormat::XPT     ? "XPT v5"
+	                           : format == SasFormat::SAS7BDAT ? "SAS7BDAT"
+	                                                          : "SAV";
 
 	if (name.empty()) {
 		throw BinderException("Empty %s not allowed in %s export", role, format_label);
@@ -62,11 +65,13 @@ struct ColumnSpec {
 	string mangled_name;
 	LogicalType duckdb_type;
 	readstat_type_t rs_type;
-	string rs_format;     // "DATE9.", "DATETIME20.", "TIME8.", or ""
+	string rs_format;     // SAS-style "DATE9." / SPSS-style "DATE11" / "" for non-temporal
 	size_t storage_width; // ReadStat's storage_width (only used for STRING in non-XPT)
 };
 
-static void MapDuckDBType(const LogicalType &dt, ColumnSpec &spec) {
+static void MapDuckDBType(const LogicalType &dt, SasFormat fmt, ColumnSpec &spec) {
+	const bool is_spss = fmt == SasFormat::SAV;
+
 	switch (dt.id()) {
 	case LogicalTypeId::BOOLEAN:
 	case LogicalTypeId::TINYINT:
@@ -94,25 +99,25 @@ static void MapDuckDBType(const LogicalType &dt, ColumnSpec &spec) {
 		return;
 	case LogicalTypeId::DATE:
 		spec.rs_type = READSTAT_TYPE_DOUBLE;
-		spec.rs_format = "DATE9.";
+		// SPSS format strings have no trailing period and use widths from the SPSS
+		// docs; SAS format strings end with a period. Reader's epoch detection keys
+		// off the format-string text, so the writer must match the format family.
+		// Picks "DATETIME19." (SAS-only, dodges the reader's SPSS-claims-DATETIME20 bug).
+		spec.rs_format = is_spss ? "DATE11" : "DATE9.";
 		spec.storage_width = 8;
 		return;
 	case LogicalTypeId::TIMESTAMP:
 		spec.rs_type = READSTAT_TYPE_DOUBLE;
-		// DATETIME19. (not DATETIME20.) — both are valid SAS datetime widths, but
-		// "DATETIME20" is ambiguous in our reader's epoch heuristic (it appears in
-		// both the SAS and SPSS format tables, and the SPSS branch wins). DATETIME19.
-		// is unambiguously SAS, so XPT round-trip lands on the right epoch.
-		spec.rs_format = "DATETIME19.";
+		spec.rs_format = is_spss ? "DATETIME20" : "DATETIME19.";
 		spec.storage_width = 8;
 		return;
 	case LogicalTypeId::TIME:
 		spec.rs_type = READSTAT_TYPE_DOUBLE;
-		spec.rs_format = "TIME8.";
+		spec.rs_format = is_spss ? "TIME8" : "TIME8.";
 		spec.storage_width = 8;
 		return;
 	default:
-		throw BinderException("stats_duck: column '%s' has unsupported type %s for SAS export",
+		throw BinderException("stats_duck: column '%s' has unsupported type %s for export",
 		                      spec.original_name, dt.ToString());
 	}
 }
@@ -170,11 +175,23 @@ static SasFormat FormatFromInfo(const CopyInfo &info) {
 	if (fmt == "sas7bdat") {
 		return SasFormat::SAS7BDAT;
 	}
-	throw BinderException("Unknown SAS export format '%s' (expected 'xpt' or 'sas7bdat')", info.format);
+	if (fmt == "sav") {
+		return SasFormat::SAV;
+	}
+	throw BinderException("Unknown stats_duck export format '%s' (expected 'xpt', 'sas7bdat', or 'sav')",
+	                      info.format);
 }
 
 static const char *FormatLabel(SasFormat f) {
-	return f == SasFormat::XPT ? "XPT" : "SAS7BDAT";
+	switch (f) {
+	case SasFormat::XPT:
+		return "XPT";
+	case SasFormat::SAS7BDAT:
+		return "SAS7BDAT";
+	case SasFormat::SAV:
+		return "SAV";
+	}
+	return "?";
 }
 
 static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFunctionBindInput &input,
@@ -218,8 +235,9 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 			xpt_base = option.second[0].ToString();
 			table_name_user_provided = true;
 		} else if (loption == "compression") {
-			if (fmt != SasFormat::SAS7BDAT) {
-				throw BinderException("COMPRESSION option is only meaningful for SAS7BDAT export, not %s", fmt_label);
+			if (fmt != SasFormat::SAS7BDAT && fmt != SasFormat::SAV) {
+				throw BinderException("COMPRESSION option is only meaningful for SAS7BDAT and SAV export, not %s",
+				                      fmt_label);
 			}
 			auto roption = StringUtil::Lower(option.second[0].ToString());
 			if (roption == "none") {
@@ -227,7 +245,7 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 			} else if (roption == "rows" || roption == "rle") {
 				bind_data->compression = READSTAT_COMPRESS_ROWS;
 			} else {
-				throw BinderException("SAS7BDAT COMPRESSION must be 'none' or 'rows', got '%s'", roption);
+				throw BinderException("%s COMPRESSION must be 'none' or 'rows', got '%s'", fmt_label, roption);
 			}
 		} else {
 			throw BinderException("Unrecognized %s option: %s", fmt_label, option.first);
@@ -251,7 +269,7 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 		ColumnSpec spec;
 		spec.original_name = names[i];
 		spec.duckdb_type = sql_types[i];
-		MapDuckDBType(sql_types[i], spec);
+		MapDuckDBType(sql_types[i], fmt, spec);
 		spec.mangled_name = ValidateColumnName(names[i], fmt, "column name");
 		bind_data->columns.push_back(std::move(spec));
 	}
@@ -342,7 +360,8 @@ static ssize_t SasExportDataWriter(const void *bytes, size_t len, void *ctx) {
 // ─── Per-cell value insertion ──────────────────────────────────────────────────
 
 static void InsertValue(readstat_writer_t *writer, const readstat_variable_t *var, const ColumnSpec &spec,
-                        const Vector &vec_p, idx_t row, UnifiedVectorFormat &fmt) {
+                        SasFormat sas_format, const Vector &vec_p, idx_t row, UnifiedVectorFormat &fmt) {
+	const int32_t epoch_offset = sas_format == SasFormat::SAV ? SPSS_EPOCH_OFFSET : SAS_EPOCH_OFFSET;
 	auto idx = fmt.sel->get_index(row);
 	if (!fmt.validity.RowIsValid(idx)) {
 		readstat_insert_missing_value(writer, var);
@@ -410,17 +429,20 @@ static void InsertValue(readstat_writer_t *writer, const readstat_variable_t *va
 		break;
 	}
 	case LogicalTypeId::DATE: {
-		// DuckDB date_t::days is days since 1970-01-01 (Unix epoch).
-		// SAS date is days since 1960-01-01. SAS_EPOCH_OFFSET = -3653 (days from
-		// 1970 back to 1960), so SAS days = duckdb_days - SAS_EPOCH_OFFSET.
+		// DuckDB date_t::days = days since 1970-01-01.
+		// Target epoch days = duckdb_days - epoch_offset.
+		// SAS DATE: days since 1960-01-01 (epoch_offset = SAS_EPOCH_OFFSET = -3653).
+		// SPSS DATE: SECONDS since 1582-10-14 (epoch_offset = SPSS_EPOCH_OFFSET = -141428,
+		// then × 86400 to convert days→seconds).
 		auto days = UnifiedVectorFormat::GetData<date_t>(fmt)[idx].days;
-		double sas_days = static_cast<double>(days - SAS_EPOCH_OFFSET);
-		readstat_insert_double_value(writer, var, sas_days);
+		double offset_days = static_cast<double>(days - epoch_offset);
+		double v = sas_format == SasFormat::SAV ? offset_days * 86400.0 : offset_days;
+		readstat_insert_double_value(writer, var, v);
 		break;
 	}
 	case LogicalTypeId::TIMESTAMP: {
 		auto micros = UnifiedVectorFormat::GetData<timestamp_t>(fmt)[idx].value;
-		double secs = static_cast<double>(micros) / 1e6 - static_cast<double>(SAS_EPOCH_OFFSET) * 86400.0;
+		double secs = static_cast<double>(micros) / 1e6 - static_cast<double>(epoch_offset) * 86400.0;
 		readstat_insert_double_value(writer, var, secs);
 		break;
 	}
@@ -452,6 +474,7 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 		}
 	} else {
 		// SAS7BDAT: optional row-level RLE compression (matches `proc copy ... compress=`).
+		// SAV: optional row compression (SPSS's "compressed save").
 		if (bind_data.compression != READSTAT_COMPRESS_NONE) {
 			readstat_writer_set_compression(writer, bind_data.compression);
 		}
@@ -476,10 +499,16 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 
 	long row_count = static_cast<long>(gstate.buffer->Count());
 	readstat_error_t err;
-	if (bind_data.format == SasFormat::XPT) {
+	switch (bind_data.format) {
+	case SasFormat::XPT:
 		err = readstat_begin_writing_xport(writer, gstate.file_handle.get(), row_count);
-	} else {
+		break;
+	case SasFormat::SAS7BDAT:
 		err = readstat_begin_writing_sas7bdat(writer, gstate.file_handle.get(), row_count);
+		break;
+	case SasFormat::SAV:
+		err = readstat_begin_writing_sav(writer, gstate.file_handle.get(), row_count);
+		break;
 	}
 	if (err != READSTAT_OK) {
 		auto msg = readstat_error_message(err);
@@ -506,7 +535,8 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 				throw IOException("%s begin_row failed: %s", FormatLabel(bind_data.format), msg ? msg : "unknown");
 			}
 			for (idx_t c = 0; c < bind_data.columns.size(); c++) {
-				InsertValue(writer, vars[c], bind_data.columns[c], chunk.data[c], r, formats[c]);
+				InsertValue(writer, vars[c], bind_data.columns[c], bind_data.format, chunk.data[c], r,
+				            formats[c]);
 			}
 			err = readstat_end_row(writer);
 			if (err != READSTAT_OK) {
@@ -561,6 +591,13 @@ void RegisterSasExport(ExtensionLoader &loader) {
 	WireCopyFunction(sas7bdat);
 	sas7bdat.extension = "sas7bdat";
 	loader.RegisterFunction(sas7bdat);
+
+	// SPSS .sav — same writer family, no SAS-side caveat (real SPSS / PSPP read
+	// these files cleanly).
+	CopyFunction sav("sav");
+	WireCopyFunction(sav);
+	sav.extension = "sav";
+	loader.RegisterFunction(sav);
 }
 
 } // namespace duckdb

--- a/src/sas_export_function.cpp
+++ b/src/sas_export_function.cpp
@@ -1,0 +1,490 @@
+#include "sas_export_function.hpp"
+#include "read_stat_types.hpp"
+
+#include "duckdb/function/copy_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/execution/execution_context.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/column/column_data_scan_states.hpp"
+#include "duckdb/common/types/date.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/common/types/time.hpp"
+#include "duckdb/common/types/hugeint.hpp"
+
+extern "C" {
+#include "readstat.h"
+}
+
+namespace duckdb {
+
+// ─── XPT v5 column-name validation ─────────────────────────────────────────────
+// XPT v5 requires names ≤ 8 chars, ASCII alphanumeric or underscore, must start
+// with a letter or underscore. We uppercase and reject — silent truncation
+// would create silent collisions on round-trip.
+
+static string ValidateXportV5Name(const string &name, const char *role) {
+	if (name.empty()) {
+		throw BinderException("Empty %s not allowed in XPT export", role);
+	}
+	if (name.size() > 8) {
+		throw BinderException(
+		    "%s '%s' is too long for XPT v5 (max 8 chars). Rename in your SELECT or wait for XPT v8 support.",
+		    role, name);
+	}
+	string upper = StringUtil::Upper(name);
+	for (char c : upper) {
+		bool ok = (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+		if (!ok) {
+			throw BinderException("%s '%s' contains characters not allowed in XPT v5 (only A-Z 0-9 _ permitted)",
+			                      role, name);
+		}
+	}
+	if (upper[0] >= '0' && upper[0] <= '9') {
+		throw BinderException("%s '%s' starts with a digit, not allowed in XPT v5", role, name);
+	}
+	return upper;
+}
+
+// ─── Type mapping (DuckDB → ReadStat) ──────────────────────────────────────────
+
+struct ColumnSpec {
+	string original_name;
+	string mangled_name;
+	LogicalType duckdb_type;
+	readstat_type_t rs_type;
+	string rs_format;     // "DATE9.", "DATETIME20.", "TIME8.", or ""
+	size_t storage_width; // ReadStat's storage_width (only used for STRING in non-XPT)
+};
+
+static void MapDuckDBType(const LogicalType &dt, ColumnSpec &spec) {
+	switch (dt.id()) {
+	case LogicalTypeId::BOOLEAN:
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+		spec.rs_type = READSTAT_TYPE_INT32;
+		spec.storage_width = 8;
+		return;
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::UHUGEINT:
+	case LogicalTypeId::DECIMAL:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::FLOAT:
+		spec.rs_type = READSTAT_TYPE_DOUBLE;
+		spec.storage_width = 8;
+		return;
+	case LogicalTypeId::VARCHAR:
+		spec.rs_type = READSTAT_TYPE_STRING;
+		spec.storage_width = 1;
+		return;
+	case LogicalTypeId::DATE:
+		spec.rs_type = READSTAT_TYPE_DOUBLE;
+		spec.rs_format = "DATE9.";
+		spec.storage_width = 8;
+		return;
+	case LogicalTypeId::TIMESTAMP:
+		spec.rs_type = READSTAT_TYPE_DOUBLE;
+		// DATETIME19. (not DATETIME20.) — both are valid SAS datetime widths, but
+		// "DATETIME20" is ambiguous in our reader's epoch heuristic (it appears in
+		// both the SAS and SPSS format tables, and the SPSS branch wins). DATETIME19.
+		// is unambiguously SAS, so XPT round-trip lands on the right epoch.
+		spec.rs_format = "DATETIME19.";
+		spec.storage_width = 8;
+		return;
+	case LogicalTypeId::TIME:
+		spec.rs_type = READSTAT_TYPE_DOUBLE;
+		spec.rs_format = "TIME8.";
+		spec.storage_width = 8;
+		return;
+	default:
+		throw BinderException("stats_duck: column '%s' has unsupported type %s for SAS export",
+		                      spec.original_name, dt.ToString());
+	}
+}
+
+// ─── BindData / GlobalState / LocalState ───────────────────────────────────────
+
+struct SasExportBindData : public FunctionData {
+	string label;
+	string table_name;
+	vector<ColumnSpec> columns;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto c = make_uniq<SasExportBindData>();
+		c->label = label;
+		c->table_name = table_name;
+		c->columns = columns;
+		return std::move(c);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<SasExportBindData>();
+		if (columns.size() != other.columns.size()) {
+			return false;
+		}
+		for (idx_t i = 0; i < columns.size(); i++) {
+			if (columns[i].mangled_name != other.columns[i].mangled_name ||
+			    columns[i].duckdb_type != other.columns[i].duckdb_type) {
+				return false;
+			}
+		}
+		return label == other.label && table_name == other.table_name;
+	}
+};
+
+struct SasExportGlobalState : public GlobalFunctionData {
+	unique_ptr<FileHandle> file_handle;
+	unique_ptr<ColumnDataCollection> buffer;
+	ColumnDataAppendState append_state;
+	vector<size_t> max_string_len; // 0 for non-VARCHAR columns
+};
+
+struct SasExportLocalState : public LocalFunctionData {};
+
+// ─── Bind ──────────────────────────────────────────────────────────────────────
+
+static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFunctionBindInput &input,
+                                              const vector<string> &names, const vector<LogicalType> &sql_types) {
+	auto bind_data = make_uniq<SasExportBindData>();
+
+	// Default XPT internal table name: file basename, mangled to ≤ 8 chars uppercase.
+	auto path = input.info.file_path;
+	auto slash = path.find_last_of("/\\");
+	auto base = slash == string::npos ? path : path.substr(slash + 1);
+	auto dot = base.find_last_of('.');
+	if (dot != string::npos) {
+		base = base.substr(0, dot);
+	}
+	if (base.empty()) {
+		base = "DATASET";
+	}
+	// Truncate to fit XPT's 8-char limit before validation; user-provided names go through
+	// strict validation below.
+	if (base.size() > 8) {
+		base = base.substr(0, 8);
+	}
+
+	bool table_name_user_provided = false;
+	for (auto &option : input.info.options) {
+		auto loption = StringUtil::Lower(option.first);
+		if (option.second.size() != 1) {
+			throw BinderException("XPT %s requires exactly one argument", StringUtil::Upper(loption));
+		}
+		if (loption == "label") {
+			bind_data->label = option.second[0].ToString();
+		} else if (loption == "table_name") {
+			base = option.second[0].ToString();
+			table_name_user_provided = true;
+		} else {
+			throw BinderException("Unrecognized XPT option: %s", option.first);
+		}
+	}
+
+	try {
+		bind_data->table_name = ValidateXportV5Name(base, "TABLE_NAME");
+	} catch (const BinderException &) {
+		if (table_name_user_provided) {
+			throw;
+		}
+		// Auto-derived name from path didn't fit; fall back to "DATASET".
+		bind_data->table_name = "DATASET";
+	}
+
+	bind_data->columns.reserve(names.size());
+	for (idx_t i = 0; i < names.size(); i++) {
+		ColumnSpec spec;
+		spec.original_name = names[i];
+		spec.duckdb_type = sql_types[i];
+		MapDuckDBType(sql_types[i], spec);
+		spec.mangled_name = ValidateXportV5Name(names[i], "column name");
+		bind_data->columns.push_back(std::move(spec));
+	}
+
+	return std::move(bind_data);
+}
+
+// ─── InitializeGlobal ──────────────────────────────────────────────────────────
+
+static unique_ptr<GlobalFunctionData> SasExportInitGlobal(ClientContext &context, FunctionData &bind_data_p,
+                                                          const string &file_path) {
+	auto &bind_data = bind_data_p.Cast<SasExportBindData>();
+	auto state = make_uniq<SasExportGlobalState>();
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	state->file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+
+	vector<LogicalType> types;
+	types.reserve(bind_data.columns.size());
+	for (auto &col : bind_data.columns) {
+		types.push_back(col.duckdb_type);
+	}
+	state->buffer = make_uniq<ColumnDataCollection>(context, std::move(types));
+	state->buffer->InitializeAppend(state->append_state);
+	state->max_string_len.assign(bind_data.columns.size(), 0);
+	return std::move(state);
+}
+
+// ─── InitializeLocal ───────────────────────────────────────────────────────────
+
+static unique_ptr<LocalFunctionData> SasExportInitLocal(ExecutionContext &, FunctionData &) {
+	return make_uniq<SasExportLocalState>();
+}
+
+// ─── Sink ──────────────────────────────────────────────────────────────────────
+// Single-threaded: append each chunk to the global buffer. Track running max
+// VARCHAR length per column — needed at finalize for `readstat_add_variable`'s
+// storage_width.
+
+static void SasExportSink(ExecutionContext &, FunctionData &bind_data_p, GlobalFunctionData &gstate_p,
+                          LocalFunctionData &, DataChunk &input) {
+	auto &bind_data = bind_data_p.Cast<SasExportBindData>();
+	auto &gstate = gstate_p.Cast<SasExportGlobalState>();
+
+	auto row_count = input.size();
+	for (idx_t c = 0; c < bind_data.columns.size(); c++) {
+		if (bind_data.columns[c].rs_type != READSTAT_TYPE_STRING) {
+			continue;
+		}
+		auto &vec = input.data[c];
+		UnifiedVectorFormat fmt;
+		vec.ToUnifiedFormat(row_count, fmt);
+		auto data = UnifiedVectorFormat::GetData<string_t>(fmt);
+		for (idx_t r = 0; r < row_count; r++) {
+			auto idx = fmt.sel->get_index(r);
+			if (!fmt.validity.RowIsValid(idx)) {
+				continue;
+			}
+			auto sz = data[idx].GetSize();
+			if (sz > gstate.max_string_len[c]) {
+				gstate.max_string_len[c] = sz;
+			}
+		}
+	}
+
+	gstate.buffer->Append(gstate.append_state, input);
+}
+
+// ─── Combine (no-op for single-threaded) ───────────────────────────────────────
+
+static void SasExportCombine(ExecutionContext &, FunctionData &, GlobalFunctionData &, LocalFunctionData &) {
+}
+
+// ─── ReadStat write callback ───────────────────────────────────────────────────
+// Routes ReadStat's writer output through DuckDB's FileSystem so registered/remote
+// paths and WASM file buffers work the same as the reader's VFS shim.
+
+static ssize_t SasExportDataWriter(const void *bytes, size_t len, void *ctx) {
+	auto *handle = static_cast<FileHandle *>(ctx);
+	try {
+		handle->Write(const_cast<void *>(bytes), len);
+	} catch (...) {
+		return -1;
+	}
+	return static_cast<ssize_t>(len);
+}
+
+// ─── Per-cell value insertion ──────────────────────────────────────────────────
+
+static void InsertValue(readstat_writer_t *writer, const readstat_variable_t *var, const ColumnSpec &spec,
+                        const Vector &vec_p, idx_t row, UnifiedVectorFormat &fmt) {
+	auto idx = fmt.sel->get_index(row);
+	if (!fmt.validity.RowIsValid(idx)) {
+		readstat_insert_missing_value(writer, var);
+		return;
+	}
+
+	switch (spec.duckdb_type.id()) {
+	case LogicalTypeId::BOOLEAN: {
+		int32_t v = UnifiedVectorFormat::GetData<bool>(fmt)[idx] ? 1 : 0;
+		readstat_insert_int32_value(writer, var, v);
+		break;
+	}
+	case LogicalTypeId::TINYINT:
+		readstat_insert_int32_value(writer, var,
+		                            static_cast<int32_t>(UnifiedVectorFormat::GetData<int8_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::SMALLINT:
+		readstat_insert_int32_value(writer, var,
+		                            static_cast<int32_t>(UnifiedVectorFormat::GetData<int16_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::INTEGER:
+		readstat_insert_int32_value(writer, var, UnifiedVectorFormat::GetData<int32_t>(fmt)[idx]);
+		break;
+	case LogicalTypeId::BIGINT:
+		readstat_insert_double_value(writer, var,
+		                             static_cast<double>(UnifiedVectorFormat::GetData<int64_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::HUGEINT:
+		readstat_insert_double_value(writer, var,
+		                             Hugeint::Cast<double>(UnifiedVectorFormat::GetData<hugeint_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::UTINYINT:
+		readstat_insert_double_value(writer, var,
+		                             static_cast<double>(UnifiedVectorFormat::GetData<uint8_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::USMALLINT:
+		readstat_insert_double_value(writer, var,
+		                             static_cast<double>(UnifiedVectorFormat::GetData<uint16_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::UINTEGER:
+		readstat_insert_double_value(writer, var,
+		                             static_cast<double>(UnifiedVectorFormat::GetData<uint32_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::UBIGINT:
+		readstat_insert_double_value(writer, var,
+		                             static_cast<double>(UnifiedVectorFormat::GetData<uint64_t>(fmt)[idx]));
+		break;
+	case LogicalTypeId::FLOAT:
+		readstat_insert_double_value(writer, var,
+		                             static_cast<double>(UnifiedVectorFormat::GetData<float>(fmt)[idx]));
+		break;
+	case LogicalTypeId::DOUBLE:
+		readstat_insert_double_value(writer, var, UnifiedVectorFormat::GetData<double>(fmt)[idx]);
+		break;
+	case LogicalTypeId::DECIMAL: {
+		// DECIMAL → DOUBLE via the value API (handles all internal storage widths).
+		Value v = vec_p.GetValue(row);
+		readstat_insert_double_value(writer, var, v.GetValue<double>());
+		break;
+	}
+	case LogicalTypeId::VARCHAR: {
+		auto str = UnifiedVectorFormat::GetData<string_t>(fmt)[idx];
+		std::string buf(str.GetData(), str.GetSize());
+		readstat_insert_string_value(writer, var, buf.c_str());
+		break;
+	}
+	case LogicalTypeId::DATE: {
+		// DuckDB date_t::days is days since 1970-01-01 (Unix epoch).
+		// SAS date is days since 1960-01-01. SAS_EPOCH_OFFSET = -3653 (days from
+		// 1970 back to 1960), so SAS days = duckdb_days - SAS_EPOCH_OFFSET.
+		auto days = UnifiedVectorFormat::GetData<date_t>(fmt)[idx].days;
+		double sas_days = static_cast<double>(days - SAS_EPOCH_OFFSET);
+		readstat_insert_double_value(writer, var, sas_days);
+		break;
+	}
+	case LogicalTypeId::TIMESTAMP: {
+		auto micros = UnifiedVectorFormat::GetData<timestamp_t>(fmt)[idx].value;
+		double secs = static_cast<double>(micros) / 1e6 - static_cast<double>(SAS_EPOCH_OFFSET) * 86400.0;
+		readstat_insert_double_value(writer, var, secs);
+		break;
+	}
+	case LogicalTypeId::TIME: {
+		auto micros = UnifiedVectorFormat::GetData<dtime_t>(fmt)[idx].micros;
+		readstat_insert_double_value(writer, var, static_cast<double>(micros) / 1e6);
+		break;
+	}
+	default:
+		throw InternalException("Unexpected type during SAS export sink (should be caught at bind)");
+	}
+}
+
+// ─── Finalize ──────────────────────────────────────────────────────────────────
+
+static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, GlobalFunctionData &gstate_p) {
+	auto &bind_data = bind_data_p.Cast<SasExportBindData>();
+	auto &gstate = gstate_p.Cast<SasExportGlobalState>();
+
+	auto *writer = readstat_writer_init();
+	readstat_set_data_writer(writer, SasExportDataWriter);
+	readstat_writer_set_file_format_version(writer, 5);
+
+	if (!bind_data.label.empty()) {
+		readstat_writer_set_file_label(writer, bind_data.label.c_str());
+	}
+	if (!bind_data.table_name.empty()) {
+		readstat_writer_set_table_name(writer, bind_data.table_name.c_str());
+	}
+
+	vector<readstat_variable_t *> vars(bind_data.columns.size(), nullptr);
+	for (idx_t i = 0; i < bind_data.columns.size(); i++) {
+		auto &col = bind_data.columns[i];
+		size_t storage_width = col.storage_width;
+		if (col.rs_type == READSTAT_TYPE_STRING) {
+			storage_width = std::max<size_t>(1, gstate.max_string_len[i]);
+		}
+		vars[i] = readstat_add_variable(writer, col.mangled_name.c_str(), col.rs_type, storage_width);
+		if (!col.rs_format.empty()) {
+			readstat_variable_set_format(vars[i], col.rs_format.c_str());
+		}
+	}
+
+	long row_count = static_cast<long>(gstate.buffer->Count());
+	auto err = readstat_begin_writing_xport(writer, gstate.file_handle.get(), row_count);
+	if (err != READSTAT_OK) {
+		auto msg = readstat_error_message(err);
+		readstat_writer_free(writer);
+		throw IOException("Failed to begin XPT write: %s", msg ? msg : "unknown");
+	}
+
+	DataChunk chunk;
+	gstate.buffer->InitializeScanChunk(chunk);
+	ColumnDataScanState scan_state;
+	gstate.buffer->InitializeScan(scan_state);
+
+	while (gstate.buffer->Scan(scan_state, chunk)) {
+		idx_t n = chunk.size();
+		vector<UnifiedVectorFormat> formats(bind_data.columns.size());
+		for (idx_t c = 0; c < bind_data.columns.size(); c++) {
+			chunk.data[c].ToUnifiedFormat(n, formats[c]);
+		}
+		for (idx_t r = 0; r < n; r++) {
+			err = readstat_begin_row(writer);
+			if (err != READSTAT_OK) {
+				auto msg = readstat_error_message(err);
+				readstat_writer_free(writer);
+				throw IOException("XPT begin_row failed: %s", msg ? msg : "unknown");
+			}
+			for (idx_t c = 0; c < bind_data.columns.size(); c++) {
+				InsertValue(writer, vars[c], bind_data.columns[c], chunk.data[c], r, formats[c]);
+			}
+			err = readstat_end_row(writer);
+			if (err != READSTAT_OK) {
+				auto msg = readstat_error_message(err);
+				readstat_writer_free(writer);
+				throw IOException("XPT end_row failed: %s", msg ? msg : "unknown");
+			}
+		}
+		chunk.Reset();
+	}
+
+	err = readstat_end_writing(writer);
+	readstat_writer_free(writer);
+	if (err != READSTAT_OK) {
+		auto msg = readstat_error_message(err);
+		throw IOException("XPT end_writing failed: %s", msg ? msg : "unknown");
+	}
+
+	gstate.file_handle->Close();
+	gstate.file_handle.reset();
+}
+
+// ─── Execution mode ────────────────────────────────────────────────────────────
+
+static CopyFunctionExecutionMode SasExportExecutionMode(bool, bool) {
+	return CopyFunctionExecutionMode::REGULAR_COPY_TO_FILE;
+}
+
+// ─── Registration ──────────────────────────────────────────────────────────────
+
+void RegisterSasExport(ExtensionLoader &loader) {
+	CopyFunction xpt("xpt");
+	xpt.copy_to_bind = SasExportBind;
+	xpt.copy_to_initialize_global = SasExportInitGlobal;
+	xpt.copy_to_initialize_local = SasExportInitLocal;
+	xpt.copy_to_sink = SasExportSink;
+	xpt.copy_to_combine = SasExportCombine;
+	xpt.copy_to_finalize = SasExportFinalize;
+	xpt.execution_mode = SasExportExecutionMode;
+	xpt.extension = "xpt";
+	loader.RegisterFunction(xpt);
+}
+
+} // namespace duckdb

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -11,6 +11,7 @@
 #include "anova_function.hpp"
 #include "chisq_function.hpp"
 #include "read_stat_function.hpp"
+#include "sas_export_function.hpp"
 #include "ggsql.hpp"
 #include "ggsql_marks_internal.hpp"
 
@@ -38,6 +39,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Data import
 	RegisterReadStat(loader);
+
+	// Data export (SAS XPT)
+	RegisterSasExport(loader);
 
 	// ggsql: Grammar of Graphics for SQL (parser extension + marks)
 	RegisterGgsql(loader);

--- a/test/sql/sas_export_sas7bdat.test
+++ b/test/sql/sas_export_sas7bdat.test
@@ -1,0 +1,150 @@
+# name: test/sql/sas_export_sas7bdat.test
+# description: COPY ... TO '*.sas7bdat' — SAS7BDAT round-trip via ReadStat
+#              CAVEAT: ReadStat's SAS7BDAT writer produces files that are
+#              readable by ReadStat-family tools (this extension's read_stat(),
+#              pyreadstat, haven, R) but NOT by real SAS / SAS Universal
+#              Viewer. The format is reverse-engineered and the upstream issue
+#              has been open for years. Use XPT if you need SAS-readable output.
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Numeric round-trip ────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE nums AS SELECT * FROM (VALUES (1, 1.5), (2, 2.5), (3, 3.5)) AS t(I, X);
+
+statement ok
+COPY nums TO '__TEST_DIR__/nums.sas7bdat';
+
+query II
+SELECT CAST(I AS INTEGER), CAST(X * 10 AS INTEGER) FROM read_stat('__TEST_DIR__/nums.sas7bdat') ORDER BY I
+----
+1	15
+2	25
+3	35
+
+# ─── Strings (longer names allowed than XPT v5) ────────────────────────────────
+
+statement ok
+CREATE TABLE strs AS SELECT * FROM (VALUES ('alice', 1), ('bob', 2)) AS t(person_name, person_id);
+
+statement ok
+COPY strs TO '__TEST_DIR__/strs.sas7bdat';
+
+query TI
+SELECT person_name, CAST(person_id AS INTEGER) FROM read_stat('__TEST_DIR__/strs.sas7bdat') ORDER BY person_id
+----
+alice	1
+bob	2
+
+# ─── NULL numerics round-trip ──────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE nulls AS SELECT * FROM (VALUES (1, 'a'), (NULL, 'b')) AS t(N, S);
+
+statement ok
+COPY nulls TO '__TEST_DIR__/nulls.sas7bdat';
+
+query IT
+SELECT CAST(N AS INTEGER), S FROM read_stat('__TEST_DIR__/nulls.sas7bdat') ORDER BY N NULLS LAST
+----
+1	a
+NULL	b
+
+# ─── Temporal types ────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE temporals AS SELECT * FROM (VALUES
+    (DATE '2024-01-15', TIMESTAMP '2024-01-15 10:30:45', TIME '10:30:45'),
+    (DATE '1960-01-01', TIMESTAMP '1960-01-01 00:00:00', TIME '00:00:00')
+) AS t(D, TS, TM);
+
+statement ok
+COPY temporals TO '__TEST_DIR__/temporals.sas7bdat';
+
+query TTT
+SELECT D, TS, TM FROM read_stat('__TEST_DIR__/temporals.sas7bdat') ORDER BY D
+----
+1960-01-01	1960-01-01 00:00:00	00:00:00
+2024-01-15	2024-01-15 10:30:45	10:30:45
+
+# ─── COMPRESSION option ────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE wide AS SELECT range AS i, repeat('x', 50) AS s FROM range(50);
+
+statement ok
+COPY wide TO '__TEST_DIR__/uncompressed.sas7bdat';
+
+statement ok
+COPY wide TO '__TEST_DIR__/rows.sas7bdat' (COMPRESSION 'rows');
+
+# Both round-trip to the same logical content.
+query II
+SELECT (SELECT COUNT(*) FROM read_stat('__TEST_DIR__/uncompressed.sas7bdat')),
+       (SELECT COUNT(*) FROM read_stat('__TEST_DIR__/rows.sas7bdat'))
+----
+50	50
+
+# ─── COPY (subquery) form ─────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT 42 AS the_answer, 'hello' AS greeting) TO '__TEST_DIR__/inline.sas7bdat';
+
+query IT
+SELECT CAST(the_answer AS INTEGER), greeting FROM read_stat('__TEST_DIR__/inline.sas7bdat')
+----
+42	hello
+
+# ─── FORMAT override ──────────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT 7 AS X) TO '__TEST_DIR__/explicit.dat' (FORMAT 'sas7bdat');
+
+query I
+SELECT CAST(X AS INTEGER) FROM read_stat('__TEST_DIR__/explicit.dat', format := 'sas7bdat')
+----
+7
+
+# ─── 32-char column names allowed (vs XPT's 8-char limit) ─────────────────────
+
+statement ok
+COPY (SELECT 1 AS this_is_a_long_name_thirty_chars) TO '__TEST_DIR__/long_names.sas7bdat';
+
+query I
+SELECT CAST(this_is_a_long_name_thirty_chars AS INTEGER) FROM read_stat('__TEST_DIR__/long_names.sas7bdat')
+----
+1
+
+# ─── Negative cases ────────────────────────────────────────────────────────────
+
+# > 32-char column name is still rejected.
+statement error
+COPY (SELECT 1 AS this_name_is_more_than_thirty_two_chars_long) TO '__TEST_DIR__/bad.sas7bdat'
+----
+too long for SAS7BDAT
+
+# TABLE_NAME is XPT-only.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.sas7bdat' (TABLE_NAME 'NAME')
+----
+TABLE_NAME option is only meaningful for XPT export
+
+# Bogus COMPRESSION value.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.sas7bdat' (COMPRESSION 'gzip')
+----
+COMPRESSION must be 'none' or 'rows'
+
+# COMPRESSION on XPT is rejected.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.xpt' (COMPRESSION 'rows')
+----
+COMPRESSION option is only meaningful for SAS7BDAT export
+
+# Unsupported type still rejected.
+statement error
+COPY (SELECT [1, 2, 3] AS X) TO '__TEST_DIR__/bad.sas7bdat'
+----
+unsupported type

--- a/test/sql/sas_export_sas7bdat.test
+++ b/test/sql/sas_export_sas7bdat.test
@@ -141,7 +141,7 @@ COMPRESSION must be 'none' or 'rows'
 statement error
 COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.xpt' (COMPRESSION 'rows')
 ----
-COMPRESSION option is only meaningful for SAS7BDAT export
+COMPRESSION option is only meaningful for
 
 # Unsupported type still rejected.
 statement error

--- a/test/sql/sas_export_sav.test
+++ b/test/sql/sas_export_sav.test
@@ -1,0 +1,125 @@
+# name: test/sql/sas_export_sav.test
+# description: COPY ... TO '*.sav' — SPSS SAV round-trip via ReadStat
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Numeric round-trip ────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE nums AS SELECT * FROM (VALUES (1, 1.5), (2, 2.5), (3, 3.5)) AS t(I, X);
+
+statement ok
+COPY nums TO '__TEST_DIR__/nums.sav';
+
+query II
+SELECT CAST(I AS INTEGER), CAST(X * 10 AS INTEGER) FROM read_stat('__TEST_DIR__/nums.sav') ORDER BY I
+----
+1	15
+2	25
+3	35
+
+# ─── Strings ───────────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE strs AS SELECT * FROM (VALUES ('alice', 1), ('bob', 2)) AS t(person_name, person_id);
+
+statement ok
+COPY strs TO '__TEST_DIR__/strs.sav';
+
+query TI
+SELECT person_name, CAST(person_id AS INTEGER) FROM read_stat('__TEST_DIR__/strs.sav') ORDER BY person_id
+----
+alice	1
+bob	2
+
+# ─── NULLs ─────────────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE nulls AS SELECT * FROM (VALUES (1, 'a'), (NULL, 'b')) AS t(N, S);
+
+statement ok
+COPY nulls TO '__TEST_DIR__/nulls.sav';
+
+query IT
+SELECT CAST(N AS INTEGER), S FROM read_stat('__TEST_DIR__/nulls.sav') ORDER BY N NULLS LAST
+----
+1	a
+NULL	b
+
+# ─── Temporal types — SAV writes SPSS-native epoch (seconds since 1582-10-14) ─
+
+statement ok
+CREATE TABLE temporals AS SELECT * FROM (VALUES
+    (DATE '2024-01-15', TIMESTAMP '2024-01-15 10:30:45'),
+    (DATE '1960-01-01', TIMESTAMP '1960-01-01 00:00:00')
+) AS t(D, TS);
+
+statement ok
+COPY temporals TO '__TEST_DIR__/temporals.sav';
+
+query TT
+SELECT D, TS FROM read_stat('__TEST_DIR__/temporals.sav') ORDER BY D
+----
+1960-01-01	1960-01-01 00:00:00
+2024-01-15	2024-01-15 10:30:45
+
+# ─── COMPRESSION option ────────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT range AS i FROM range(20)) TO '__TEST_DIR__/compressed.sav' (COMPRESSION 'rows');
+
+query I
+SELECT COUNT(*) FROM read_stat('__TEST_DIR__/compressed.sav')
+----
+20
+
+# ─── COPY (subquery) form ─────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT 42 AS the_answer, 'hello' AS greeting) TO '__TEST_DIR__/inline.sav';
+
+query IT
+SELECT CAST(the_answer AS INTEGER), greeting FROM read_stat('__TEST_DIR__/inline.sav')
+----
+42	hello
+
+# ─── FORMAT override ──────────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT 7 AS X) TO '__TEST_DIR__/explicit.dat' (FORMAT 'sav');
+
+query I
+SELECT CAST(X AS INTEGER) FROM read_stat('__TEST_DIR__/explicit.dat', format := 'sav')
+----
+7
+
+# ─── Long column names accepted (32-char limit, like SAS7BDAT) ────────────────
+
+statement ok
+COPY (SELECT 1 AS a_thirty_char_column_name_demo01) TO '__TEST_DIR__/longname.sav';
+
+query I
+SELECT CAST(a_thirty_char_column_name_demo01 AS INTEGER) FROM read_stat('__TEST_DIR__/longname.sav')
+----
+1
+
+# ─── Negative cases ────────────────────────────────────────────────────────────
+
+# > 32-char column name still rejected.
+statement error
+COPY (SELECT 1 AS this_name_is_way_more_than_thirty_two_chars_long) TO '__TEST_DIR__/bad.sav'
+----
+too long for SAV
+
+# TABLE_NAME is XPT-only.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.sav' (TABLE_NAME 'NAME')
+----
+TABLE_NAME option is only meaningful for XPT export
+
+# Bogus COMPRESSION value.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.sav' (COMPRESSION 'gzip')
+----
+COMPRESSION must be 'none' or 'rows'

--- a/test/sql/sas_export_xpt.test
+++ b/test/sql/sas_export_xpt.test
@@ -1,0 +1,177 @@
+# name: test/sql/sas_export_xpt.test
+# description: COPY ... TO '*.xpt' — XPT v5 round-trip export via ReadStat
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Numeric round-trip ────────────────────────────────────────────────────────
+# XPT only stores 8-byte IBM-360 floats, so INTEGER → DOUBLE on round-trip.
+
+statement ok
+CREATE TABLE nums AS SELECT * FROM (VALUES (1, 1.5, 100), (2, 2.5, 200), (3, 3.5, 300)) AS t(I, X, Y);
+
+statement ok
+COPY nums TO '__TEST_DIR__/nums.xpt';
+
+query III
+SELECT CAST(I AS INTEGER), CAST(X * 10 AS INTEGER), CAST(Y AS INTEGER)
+FROM read_stat('__TEST_DIR__/nums.xpt') ORDER BY I
+----
+1	15	100
+2	25	200
+3	35	300
+
+# ─── Strings ───────────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE strs AS SELECT * FROM (VALUES ('alice', 1), ('bob', 2), ('charlie', 3)) AS t(NAME, ID);
+
+statement ok
+COPY strs TO '__TEST_DIR__/strs.xpt';
+
+query TI
+SELECT NAME, CAST(ID AS INTEGER) FROM read_stat('__TEST_DIR__/strs.xpt') ORDER BY ID
+----
+alice	1
+bob	2
+charlie	3
+
+# ─── NULLs in numeric column round-trip as NULL ───────────────────────────────
+# Note: SAS XPT character columns cannot distinguish NULL from empty string —
+# both round-trip as empty string. This is a SAS format limitation, not a bug.
+
+statement ok
+CREATE TABLE nulls AS SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (NULL, 'c')) AS t(N, S);
+
+statement ok
+COPY nulls TO '__TEST_DIR__/nulls.xpt';
+
+query IT
+SELECT CAST(N AS INTEGER), S FROM read_stat('__TEST_DIR__/nulls.xpt') ORDER BY N NULLS LAST
+----
+1	a
+2	b
+NULL	c
+
+# Empty string → empty string (no NULL distinction in SAS character columns).
+statement ok
+CREATE TABLE estr AS SELECT * FROM (VALUES (1, 'x'), (2, ''), (3, NULL)) AS t(N, S);
+
+statement ok
+COPY estr TO '__TEST_DIR__/estr.xpt';
+
+query IT
+SELECT CAST(N AS INTEGER), S FROM read_stat('__TEST_DIR__/estr.xpt') ORDER BY N
+----
+1	x
+2	(empty)
+3	(empty)
+
+# ─── Dates / timestamps / times round-trip via SAS epoch ──────────────────────
+
+statement ok
+CREATE TABLE temporals AS SELECT * FROM (VALUES
+    (DATE '2024-01-15', TIMESTAMP '2024-01-15 10:30:45', TIME '10:30:45'),
+    (DATE '1980-06-30', TIMESTAMP '1980-06-30 23:59:59', TIME '23:59:59'),
+    (DATE '1960-01-01', TIMESTAMP '1960-01-01 00:00:00', TIME '00:00:00')
+) AS t(D, TS, TM);
+
+statement ok
+COPY temporals TO '__TEST_DIR__/temporals.xpt';
+
+query TTT
+SELECT D, TS, TM FROM read_stat('__TEST_DIR__/temporals.xpt') ORDER BY D
+----
+1960-01-01	1960-01-01 00:00:00	00:00:00
+1980-06-30	1980-06-30 23:59:59	23:59:59
+2024-01-15	2024-01-15 10:30:45	10:30:45
+
+# ─── COPY (subquery) form, not just COPY <table> ──────────────────────────────
+
+statement ok
+COPY (SELECT 42 AS I, 'hi' AS S) TO '__TEST_DIR__/inline.xpt';
+
+query IT
+SELECT CAST(I AS INTEGER), S FROM read_stat('__TEST_DIR__/inline.xpt')
+----
+42	hi
+
+# ─── Wide string column — storage_width is computed from observed max length ──
+
+statement ok
+CREATE TABLE wide AS SELECT * FROM (VALUES ('short'), ('a much longer value here'), ('mid')) AS t(S);
+
+statement ok
+COPY wide TO '__TEST_DIR__/wide.xpt';
+
+query T
+SELECT S FROM read_stat('__TEST_DIR__/wide.xpt') ORDER BY S
+----
+a much longer value here
+mid
+short
+
+# ─── Empty table ───────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE empty(I INTEGER, S VARCHAR);
+
+statement ok
+COPY empty TO '__TEST_DIR__/empty.xpt';
+
+query I
+SELECT COUNT(*) FROM read_stat('__TEST_DIR__/empty.xpt')
+----
+0
+
+# ─── FORMAT option overrides extension inference ───────────────────────────────
+
+statement ok
+COPY (SELECT 7 AS X) TO '__TEST_DIR__/explicit.dat' (FORMAT 'xpt');
+
+query I
+SELECT CAST(X AS INTEGER) FROM read_stat('__TEST_DIR__/explicit.dat', format := 'xpt')
+----
+7
+
+# ─── XPT-specific OPTIONS ──────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/labeled.xpt' (LABEL 'My dataset', TABLE_NAME 'MYTAB');
+
+query I
+SELECT CAST(X AS INTEGER) FROM read_stat('__TEST_DIR__/labeled.xpt')
+----
+1
+
+# ─── Negative cases ────────────────────────────────────────────────────────────
+
+# Column name longer than 8 chars — XPT v5 limit.
+statement error
+COPY (SELECT 1 AS column_name_too_long) TO '__TEST_DIR__/bad.xpt'
+----
+too long for XPT v5
+
+# Column name with a dash (non-alphanumeric) is rejected.
+statement error
+COPY (SELECT 1 AS "bad-name") TO '__TEST_DIR__/bad.xpt'
+----
+characters not allowed in XPT v5
+
+# Unsupported type (LIST) is rejected at bind.
+statement error
+COPY (SELECT [1, 2, 3] AS X) TO '__TEST_DIR__/bad.xpt'
+----
+unsupported type
+
+# Unknown OPTION is rejected.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.xpt' (UNKNOWN_OPT 'foo')
+----
+Unrecognized XPT option
+
+# TABLE_NAME that doesn't fit XPT v5 rules is rejected when user-specified.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.xpt' (TABLE_NAME 'this_is_too_long')
+----
+too long for XPT v5


### PR DESCRIPTION
## Summary

- Adds three new `CopyFunction` registrations: `COPY tbl TO 'file.xpt' / .sas7bdat / .sav`. All wire through ReadStat (already vendored in `third_party/readstat/`); `readstat_xport_write.c` and `readstat_sav_write.c` were already in the build, `readstat_sas7bdat_write.c` is the only new C source pulled in.
- Output bytes go through DuckDB's `FileSystem` via a `data_writer` callback wrapping a `FileHandle`, so registered/remote/WASM file targets work the same as `read_stat()` does on the read side.
- Numeric NULLs round-trip cleanly via SAS system-missing; VARCHAR NULLs collapse to empty strings (SAS character columns have no NULL/empty distinction). Documented in CHANGELOG and tests.

## Format-specific notes

- **XPT v5** — universally readable (real SAS, FDA pipelines, etc). Strict 8-char uppercase column-name validation at bind, no silent truncation. `LABEL` and `TABLE_NAME` options.
- **SAS7BDAT** — round-trips through this extension's `read_stat()`, pyreadstat, haven, R. **Caveat:** ReadStat's writer is reverse-engineered and the produced files are **not opened by real SAS / SAS Universal Viewer**. Long-standing upstream limitation — flagged in CHANGELOG. `LABEL`, `COMPRESSION` options.
- **SAV** — SPSS-native epoch (seconds since 1582-10-14) and SPSS format strings (`DATE11` / `DATETIME20` / `TIME8`). Same options as SAS7BDAT.

## Implementation choices

- Single-threaded (`REGULAR_COPY_TO_FILE`) — ReadStat's writer is sequential.
- Buffers the full result in a `ColumnDataCollection` before emitting, since `readstat_begin_writing_*` requires the row count up front. Spillable via DuckDB's buffer manager.
- One reader bug avoided in passing: `DATETIME20` lives in both the SAS and SPSS format-detection lists in `read_stat_types.cpp`, so the SAS writers emit `DATETIME19.` instead. Worth a separate fix on the reader's epoch heuristic at some point.

## Test plan

- [x] `make debug` clean
- [x] `make wasm_eh` clean (411 KB `stats_duck.duckdb_extension.wasm`)
- [x] `test/sql/sas_export_xpt.test` — 66 assertions
- [x] `test/sql/sas_export_sas7bdat.test` — 45 assertions
- [x] `test/sql/sas_export_sav.test` — 38 assertions
- [x] `test/sql/read_stat.test` regression — 188 assertions (no breakage)
- [ ] Browser-side smoke via Bedevere on the new `*.wasm` (optional follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)