### PR TITLE
Prepare v0.2.0 (bring-out-your-dead) release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,23 @@ that name is preserved across releases for backward compatibility.
 
 ## [Unreleased]
 
+## [0.2.0-bring-out-your-dead] - 2026-05-03
+
 ### Added
 
+- **ggsql — Grammar of Graphics for SQL.** New `VISUALIZE … FROM <table> DRAW <mark>`
+  parser extension that compiles at plan time into a Vega-Lite v5 spec plus one SQL
+  string per layer, returned as `(spec VARCHAR, layer_sqls MAP(VARCHAR, VARCHAR))`.
+  Clients (e.g. Bedevere Wise in DuckDB-WASM) execute each layer's SQL and feed Arrow
+  rows into vega-embed via the `datasets` API — no server-side rendering. Supports
+  11 marks (`point`, `line`, `bar`, `histogram`, `text`, `area`, `rule`, `tick`,
+  `errorbar`, `errorband`, `boxplot`), 12 aesthetic channels, multi-layer overlays
+  (`DRAW point DRAW line`), `FACET BY <expr> [ROWS|COLS]`, `SCALE` clauses
+  (`TO <scheme>` for color schemes, `ZERO true|false`, `DOMAIN <lo> <hi>`),
+  type-annotated aesthetics (`year AS color:ordinal`), and SQL expressions in
+  mappings (`bill_len * 2 AS x`, `coalesce(a, b) AS x`). Marks are registered
+  through a catalog-mediated registry (`ggsql_mark_v1_<name>` scalar functions),
+  so other extensions can ship custom marks without modifying stats_duck.
 - `COPY tbl TO 'file.xpt'` — write SAS Transport (XPT v5) files via ReadStat.
   Supports BOOLEAN, all integer/float/decimal types, VARCHAR, DATE, TIMESTAMP, and
   TIME columns. Numeric NULLs round-trip as SAS system-missing; VARCHAR NULLs
@@ -88,4 +103,5 @@ First public release.
 - `linux_amd64_musl` is excluded due to a known upstream issue in the v1.2.2 extension-ci-tools Alpine Dockerfile.
 - WASM binaries served via GitHub Pages at `https://caerbannogwhite.github.io/the-stats-duck`.
 
+[0.2.0-bring-out-your-dead]: https://github.com/caerbannogwhite/the-stats-duck/releases/tag/v0.2.0
 [0.1.0-mortician]: https://github.com/caerbannogwhite/the-stats-duck/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,18 +4,19 @@ title: "The Stats Duck: A statistical computing toolkit for DuckDB"
 abstract: >-
   The Stats Duck is an open-source DuckDB extension that brings statistical
   computing — descriptive statistics, hypothesis tests, distribution
-  functions, and first-class readers for SAS, SPSS, and Stata files —
-  directly into SQL. Computations are implemented as streaming aggregates
-  and scalar functions so they scale to billion-row datasets and also run
-  in DuckDB-WASM in the browser.
+  functions, grammar-of-graphics visualization (ggsql), and first-class
+  readers and writers for SAS, SPSS, and Stata files — directly into SQL.
+  Computations are implemented as streaming aggregates and scalar functions
+  so they scale to billion-row datasets and also run in DuckDB-WASM in the
+  browser.
 type: software
 authors:
   - family-names: Meneghello
     given-names: Massimo
 repository-code: "https://github.com/caerbannogwhite/the-stats-duck"
 url: "https://github.com/caerbannogwhite/the-stats-duck"
-version: 0.1.0-mortician
-date-released: "2026-04-13"
+version: 0.2.0-bring-out-your-dead
+date-released: "2026-05-03"
 license: Apache-2.0
 keywords:
   - duckdb
@@ -30,3 +31,7 @@ keywords:
   - stata
   - readstat
   - wasm
+  - grammar-of-graphics
+  - ggplot2
+  - vega-lite
+  - data-visualization

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A statistical computing toolkit for DuckDB.
 
 The Stats Duck brings statistical workflows — descriptive statistics, hypothesis
-tests, and direct readers for SAS, SPSS, and Stata files — into SQL. Functions
-are implemented as streaming aggregates and scalar primitives, so they scale
-from local notebooks to billion-row warehouses and also run inside DuckDB-WASM
-in the browser.
+tests, grammar-of-graphics visualization, and direct readers/writers for SAS,
+SPSS, and Stata files — into SQL. Functions are implemented as streaming
+aggregates and scalar primitives, so they scale from local notebooks to
+billion-row warehouses and also run inside DuckDB-WASM in the browser.
 
 > The extension installs and loads in DuckDB under the technical name
 > `stats_duck` (matching the binary, the SQL function namespace, and the
@@ -16,13 +16,18 @@ in the browser.
 ## Scope
 
 The Stats Duck is meant to cover the everyday work of a general-purpose
-statistician without leaving SQL. The current release focuses on three areas:
+statistician without leaving SQL. The current release covers four areas:
 
 - **Hypothesis tests** — parametric and non-parametric, with effect sizes and
   confidence intervals returned alongside the test statistic.
-- **Statistical file I/O** — first-class readers for SAS, SPSS, and Stata
-  files, integrated with DuckDB's virtual file system so they work transparently
-  with local paths, `httpfs://`, `s3://`, and registered WASM file buffers.
+- **Visualizations (ggsql)** — `VISUALIZE … FROM <table> DRAW <mark>`, a
+  Posit-published Grammar-of-Graphics SQL dialect compiled to Vega-Lite v5.
+  No server-side rendering: the extension emits a spec + per-layer SQL, and
+  the client (browser, notebook, …) runs the SQL and feeds the rows to vega.
+- **Statistical file I/O** — first-class readers AND writers for SAS, SPSS, and
+  Stata files, integrated with DuckDB's virtual file system so they work
+  transparently with local paths, `httpfs://`, `s3://`, and registered WASM
+  file buffers.
 - **Streaming aggregates** — every test is a single-pass aggregate over the
   data, so it composes naturally with `GROUP BY`, window frames, and DuckDB's
   parallel execution.
@@ -75,9 +80,49 @@ p-value, and relevant effect sizes / confidence intervals.
 
 ### Data import (table function)
 
-| Function                              | Description                 |
-| ------------------------------------- | --------------------------- |
+| Function                                | Description                   |
+| --------------------------------------- | ----------------------------- |
 | `read_stat(path, [format], [encoding])` | Read SAS / SPSS / Stata files |
+
+### Data export (COPY function)
+
+| Statement                                  | Description                      |
+| ------------------------------------------ | -------------------------------- |
+| `COPY <table> TO 'file.xpt'`               | Write SAS Transport (XPT v5)     |
+| `COPY <table> TO 'file.sas7bdat'`          | Write SAS7BDAT (see caveat below)|
+| `COPY <table> TO 'file.sav'`               | Write SPSS SAV                   |
+
+> **SAS7BDAT caveat.** ReadStat's SAS7BDAT writer is reverse-engineered: files
+> round-trip through ReadStat-family readers (this extension's `read_stat()`,
+> pyreadstat, haven, R) but are **not opened by real SAS / SAS Universal
+> Viewer / SAS OnDemand**. Use XPT for SAS-native readability.
+
+### Visualizations (ggsql parser extension)
+
+A Grammar-of-Graphics SQL dialect: `VISUALIZE` returns a single row with two
+columns — `spec` (a complete Vega-Lite v5 JSON spec) and `layer_sqls` (a
+`MAP(VARCHAR, VARCHAR)` of named SQL strings, one per layer). The client
+runs each layer's SQL and feeds the rows to vega-embed via the `datasets` API.
+
+```
+VISUALIZE <expr> AS <aesthetic> [: <type>] (, <expr> AS <aesthetic> ...)
+FROM <table>
+DRAW <mark> (DRAW <mark>)*
+[FACET BY <expr> [ROWS | COLS]]
+[SCALE <channel> {TO <scheme> | ZERO true|false | DOMAIN <lo> <hi>}]*
+```
+
+**Marks:** `point`, `line`, `bar`, `histogram`, `text`, `area`, `rule`, `tick`,
+`errorbar`, `errorband`, `boxplot`. Custom marks register as `ggsql_mark_v1_<name>`
+scalar functions and are discovered via DuckDB's catalog, so other extensions can
+ship their own marks without modifying stats_duck.
+
+**Aesthetic channels:** `x`, `y`, `color`, `fill`, `stroke`, `shape`, `size`,
+`opacity`, `tooltip`, `text`, `x2`, `y2`. Unknown channels are silently dropped.
+
+**Type overrides:** append `:quantitative`, `:ordinal`, `:nominal`, or
+`:temporal` to an aesthetic to force its Vega-Lite type
+(e.g. `year AS color:ordinal`).
 
 **t-test result fields:** `test_type`, `t_statistic`, `df`, `p_value`, `alternative`, `mean_diff`, `ci_lower`, `ci_upper`, `cohens_d`
 
@@ -224,6 +269,87 @@ works against:
 - remote files (with the `httpfs` extension loaded): `read_stat('https://…/survey.sav')`
 - object stores: `read_stat('s3://bucket/survey.sav')`
 - in-browser DuckDB-WASM file buffers registered via `registerFileBuffer()`
+
+#### Writing statistical file formats
+
+The same VFS-backed writers, exposed as DuckDB `COPY` functions:
+
+```sql
+-- SAS Transport (XPT v5) — universally readable, FDA / pharma standard
+COPY survey TO 'survey.xpt';
+
+-- SAS7BDAT — round-trips through stats_duck and pyreadstat (NOT real SAS, see caveat)
+COPY survey TO 'survey.sas7bdat' (COMPRESSION 'rows');
+
+-- SPSS SAV
+COPY survey TO 'survey.sav';
+
+-- COPY <subquery> form works too
+COPY (SELECT * FROM huge_table WHERE region = 'EU') TO 'eu.xpt';
+```
+
+NULL handling differs by storage format: numeric NULLs round-trip as
+SAS/SPSS system-missing, but VARCHAR NULLs collapse to empty strings (these
+formats have no NULL/empty distinction for character columns).
+
+### Visualizations (ggsql)
+
+```sql
+-- Set up — penguin morphology, classic ggplot2 demo data
+CREATE TABLE penguins AS SELECT * FROM (VALUES
+    (39.1, 18.7, 'Adelie',    2018), (39.5, 17.4, 'Adelie',    2019),
+    (44.0, 18.0, 'Gentoo',    2020), (45.2, 14.5, 'Chinstrap', 2021)
+) AS t(bill_len, bill_dep, species, year);
+```
+
+#### Scatter
+
+```sql
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point;
+```
+
+#### Scatter colored by species, with a viridis scale
+
+```sql
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color
+FROM penguins
+DRAW point
+SCALE color TO viridis;
+```
+
+#### Multi-layer (scatter + line overlay)
+
+```sql
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW line;
+```
+
+#### Faceted plot — one panel per species, vertically stacked
+
+```sql
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins
+DRAW point FACET BY species ROWS;
+```
+
+#### SQL expressions in mappings
+
+```sql
+VISUALIZE bill_len * 2 AS x, log(bill_dep) AS y FROM penguins DRAW point;
+```
+
+#### Type-annotated aesthetic (year is INTEGER but should be ordinal here)
+
+```sql
+VISUALIZE bill_len AS x, bill_dep AS y, year AS color:ordinal
+FROM penguins
+DRAW point
+SCALE color TO viridis;
+```
+
+The output of any `VISUALIZE` query is a single row with `(spec, layer_sqls)`.
+The client side (a browser app, a notebook renderer, …) is responsible for
+running each layer's SQL and feeding the rows into vega-embed via its
+`datasets` API. See [Bedevere Wise](https://github.com/caerbannogwhite/bedevere-wise)
+for a reference DuckDB-WASM consumer.
 
 ## Building
 


### PR DESCRIPTION
## Summary

Release prep only — no code changes, just docs and metadata for tagging v0.2.0.

- **CHANGELOG.md** — convert `[Unreleased]` to `[0.2.0-bring-out-your-dead] - 2026-05-03`. Captures everything since v0.1.0: ggsql (PR #2), SAS/SPSS export (PR #3), and the v1.5.1 retarget. Empty `[Unreleased]` left on top per Keep-a-Changelog convention.
- **CITATION.cff** — bump `version` and `date-released`, expand abstract to mention visualization and writers, add `grammar-of-graphics` / `ggplot2` / `vega-lite` / `data-visualization` keywords.
- **README.md** — rewrite intro and Scope to cover the four areas, add Functions sections for "Data export" (COPY TO writers, with the SAS7BDAT-not-readable-by-real-SAS caveat) and "Visualizations" (ggsql grammar surface), add Examples for scatter / multi-layer / faceted plots / SQL expressions in mappings / type overrides / COPY TO writers.

## Release steps after merge

```
git checkout main && git pull
git tag -a v0.2.0 -m "v0.2.0 (bring-out-your-dead)"
git push origin v0.2.0
```

The tag push triggers `MainDistributionPipeline` to build + deploy native binaries and the WASM artifacts.

## Test plan

- [x] `make debug` clean on the release branch.
- [x] All existing tests pass (no source changes; release prep is docs only).
- [ ] Maintainer review of CHANGELOG / README phrasing.
- [ ] Tag + release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)