### PR TITLE
Add POR export, XPT v8, and column-comment-driven variable labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build
 build/
 cmake-build-*/
+.cache/
 
 # IDE
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ that name is preserved across releases for backward compatibility.
 
 ## [Unreleased]
 
+### Added
+
+- `COPY tbl TO 'file.por'` — write SPSS Portable (POR) files via ReadStat. Same
+  type and NULL semantics as the SAV writer, but with XPT-style strict
+  column-name rules (≤ 8 chars uppercase, A-Z 0-9 _) and no compression
+  (POR is plain ASCII). Optional `LABEL` option. POR is the legacy
+  cross-platform sibling of SAV, still encountered in some government and
+  academic data archives. The reader has supported `.por` since v0.1.0.
+
 ## [0.2.0-bring-out-your-dead] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ that name is preserved across releases for backward compatibility.
   name limit to 32 chars and raises the dataset name limit to 32 chars. v8
   files round-trip through `read_stat()`, pyreadstat, haven, and R; some
   legacy SAS toolchains still expect v5, hence the conservative default.
+- `COPY tbl TO 'file.{xpt,sas7bdat,sav,por}'` now picks up DuckDB column
+  comments (set via `COMMENT ON COLUMN tbl.col IS '...'`) and writes them as
+  ReadStat variable labels — visible in SAS, SPSS, pyreadstat, haven, and R as
+  the column's descriptive label. Only applies when the COPY source is a
+  named base table; `COPY (SELECT …) TO …` has no source-table comment
+  metadata and writes empty labels. XPT v8 stores labels longer than 40 chars
+  in the LABELV8 long-label subrecord.
+- `read_stat_metadata(path, [format], [encoding])` — table function that
+  returns one row per variable with `(column_name, type, format, label)`,
+  without scanning the data. Useful for inspecting SAS / SPSS / Stata files
+  before importing, and for verifying that column comments propagated through
+  to ReadStat variable labels on export.
 
 ## [0.2.0-bring-out-your-dead] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ that name is preserved across releases for backward compatibility.
   (POR is plain ASCII). Optional `LABEL` option. POR is the legacy
   cross-platform sibling of SAV, still encountered in some government and
   academic data archives. The reader has supported `.por` since v0.1.0.
+- XPT export now accepts a `VERSION` option (5 or 8). Version 5 is the default
+  (preserves backwards compatibility with v0.2.0). Version 8 lifts the column-
+  name limit to 32 chars and raises the dataset name limit to 32 chars. v8
+  files round-trip through `read_stat()`, pyreadstat, haven, and R; some
+  legacy SAS toolchains still expect v5, hence the conservative default.
 
 ## [0.2.0-bring-out-your-dead] - 2026-05-03
 

--- a/src/read_stat_function.cpp
+++ b/src/read_stat_function.cpp
@@ -378,6 +378,159 @@ static unique_ptr<TableRef> ReadStatReplacementScan(ClientContext &context, Repl
 	return std::move(table_function);
 }
 
+// ─── read_stat_metadata: introspection table function ─────────────────────────
+// Returns one row per variable in the file with name / type / format / label,
+// without actually scanning the data. Useful for inspecting unfamiliar SAS /
+// SPSS / Stata files before importing, and for verifying that column comments
+// flowed through to ReadStat's variable labels on COPY ... TO 'file.{xpt,sas7bdat,sav,por}'.
+//
+// All four metadata fields come from the same readstat_metadata_handler /
+// readstat_variable_handler callbacks the reader already uses; we just collect
+// them into rows instead of populating a schema. ReadStat's row handler is
+// disabled via row_limit=0 — only header records are parsed.
+
+struct ReadStatMetadataRow {
+	string column_name;
+	string type;
+	string format;
+	string label;
+};
+
+struct ReadStatMetadataBindData : public FunctionData {
+	string path;
+	string format_name;
+	string encoding;
+	vector<ReadStatMetadataRow> rows;
+	string error_message;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto c = make_uniq<ReadStatMetadataBindData>();
+		c->path = path;
+		c->format_name = format_name;
+		c->encoding = encoding;
+		c->rows = rows;
+		return std::move(c);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<ReadStatMetadataBindData>();
+		return path == other.path && format_name == other.format_name;
+	}
+};
+
+static const char *ReadStatTypeName(readstat_type_t t) {
+	switch (t) {
+	case READSTAT_TYPE_STRING:
+		return "STRING";
+	case READSTAT_TYPE_STRING_REF:
+		return "STRING_REF";
+	case READSTAT_TYPE_INT8:
+		return "INT8";
+	case READSTAT_TYPE_INT16:
+		return "INT16";
+	case READSTAT_TYPE_INT32:
+		return "INT32";
+	case READSTAT_TYPE_FLOAT:
+		return "FLOAT";
+	case READSTAT_TYPE_DOUBLE:
+		return "DOUBLE";
+	}
+	return "UNKNOWN";
+}
+
+static int MetadataVariableHandler(int index, readstat_variable_t *variable, const char *val_labels, void *ctx) {
+	auto &bind_data = *static_cast<ReadStatMetadataBindData *>(ctx);
+	const char *name = readstat_variable_get_name(variable);
+	const char *format = readstat_variable_get_format(variable);
+	const char *label = readstat_variable_get_label(variable);
+	auto type = readstat_variable_get_type(variable);
+
+	ReadStatMetadataRow row;
+	row.column_name = name ? name : "";
+	row.type = ReadStatTypeName(type);
+	row.format = format ? format : "";
+	row.label = label ? label : "";
+	bind_data.rows.push_back(std::move(row));
+	return READSTAT_HANDLER_OK;
+}
+
+static void MetadataErrorHandler(const char *error_message, void *ctx) {
+	auto &bind_data = *static_cast<ReadStatMetadataBindData *>(ctx);
+	bind_data.error_message = error_message ? error_message : "Unknown ReadStat error";
+}
+
+static unique_ptr<FunctionData> ReadStatMetadataBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types, vector<string> &names) {
+	auto bind_data = make_uniq<ReadStatMetadataBindData>();
+	bind_data->path = input.inputs[0].GetValue<string>();
+
+	for (auto &kv : input.named_parameters) {
+		if (kv.first == "format") {
+			bind_data->format_name = StringUtil::Lower(kv.second.GetValue<string>());
+		} else if (kv.first == "encoding") {
+			bind_data->encoding = kv.second.GetValue<string>();
+		}
+	}
+
+	if (bind_data->format_name.empty()) {
+		bind_data->format_name = DetectFormat(bind_data->path);
+	}
+	if (bind_data->format_name.empty()) {
+		throw InvalidInputException(
+		    "Cannot detect file format. Specify with: read_stat_metadata('file', format := 'sas7bdat')");
+	}
+
+	readstat_parser_t *parser = readstat_parser_init();
+	readstat_set_variable_handler(parser, MetadataVariableHandler);
+	readstat_set_error_handler(parser, MetadataErrorHandler);
+	readstat_set_row_limit(parser, 0);
+
+	DuckDBIOContext io_ctx;
+	io_ctx.fs = &FileSystem::GetFileSystem(context);
+	InstallDuckDBIO(parser, io_ctx);
+
+	if (!bind_data->encoding.empty()) {
+		readstat_set_file_character_encoding(parser, bind_data->encoding.c_str());
+	}
+
+	auto error = ParseWithFormat(parser, bind_data->path, bind_data->format_name, bind_data.get());
+	readstat_set_io_ctx(parser, nullptr);
+	readstat_parser_free(parser);
+
+	if (error != READSTAT_OK) {
+		string msg = bind_data->error_message.empty() ? readstat_error_message(error) : bind_data->error_message;
+		throw IOException("Failed to read metadata from '%s': %s", bind_data->path, msg);
+	}
+
+	names = {"column_name", "type", "format", "label"};
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+	return std::move(bind_data);
+}
+
+struct ReadStatMetadataGlobalState : public GlobalTableFunctionState {
+	idx_t offset = 0;
+};
+
+static unique_ptr<GlobalTableFunctionState> ReadStatMetadataInitGlobal(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<ReadStatMetadataGlobalState>();
+}
+
+static void ReadStatMetadataExecute(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	auto &bind_data = input.bind_data->Cast<ReadStatMetadataBindData>();
+	auto &state = input.global_state->Cast<ReadStatMetadataGlobalState>();
+
+	idx_t available = bind_data.rows.size() - state.offset;
+	idx_t emit = std::min<idx_t>(available, STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < emit; i++) {
+		auto &row = bind_data.rows[state.offset + i];
+		output.SetValue(0, i, Value(row.column_name));
+		output.SetValue(1, i, Value(row.type));
+		output.SetValue(2, i, Value(row.format));
+		output.SetValue(3, i, Value(row.label));
+	}
+	output.SetCardinality(emit);
+	state.offset += emit;
+}
+
 // ─── Registration ───────────────────────────────────────────────────────────────
 
 void RegisterReadStat(ExtensionLoader &loader) {
@@ -385,6 +538,12 @@ void RegisterReadStat(ExtensionLoader &loader) {
 	func.named_parameters["format"] = LogicalType::VARCHAR;
 	func.named_parameters["encoding"] = LogicalType::VARCHAR;
 	loader.RegisterFunction(func);
+
+	TableFunction meta("read_stat_metadata", {LogicalType::VARCHAR}, ReadStatMetadataExecute, ReadStatMetadataBind,
+	                   ReadStatMetadataInitGlobal);
+	meta.named_parameters["format"] = LogicalType::VARCHAR;
+	meta.named_parameters["encoding"] = LogicalType::VARCHAR;
+	loader.RegisterFunction(meta);
 
 	auto &db = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db);

--- a/src/sas_export_function.cpp
+++ b/src/sas_export_function.cpp
@@ -14,6 +14,10 @@
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/column_list.hpp"
+#include "duckdb/parser/column_definition.hpp"
 
 extern "C" {
 #include "readstat.h"
@@ -97,6 +101,7 @@ static string ValidateColumnName(const string &name, SasFormat format, const cha
 struct ColumnSpec {
 	string original_name;
 	string mangled_name;
+	string label; // ReadStat variable label — sourced from DuckDB column comments
 	LogicalType duckdb_type;
 	readstat_type_t rs_type;
 	string rs_format;     // SAS-style "DATE9." / SPSS-style "DATE11" / "" for non-temporal
@@ -334,6 +339,32 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 		bind_data->columns.push_back(std::move(spec));
 	}
 
+	// Pull DuckDB column comments into ReadStat variable labels for `COPY tbl TO ...`.
+	// CopyInfo.table is empty for `COPY (subquery) TO ...`, in which case there's
+	// no source-table catalog entry to consult and labels stay empty. This is
+	// intentional: a SELECT has no comment metadata of its own, only its source
+	// columns do, and reaching through the projection would mislabel computed
+	// columns.
+	if (!input.info.table.empty()) {
+		auto &catalog_name = input.info.catalog;
+		auto &schema_name = input.info.schema;
+		auto entry = Catalog::GetEntry<TableCatalogEntry>(context, catalog_name, schema_name, input.info.table,
+		                                                 OnEntryNotFound::RETURN_NULL);
+		if (entry) {
+			auto &columns = entry->GetColumns();
+			for (auto &spec : bind_data->columns) {
+				if (!columns.ColumnExists(spec.original_name)) {
+					continue;
+				}
+				const auto &col = columns.GetColumn(spec.original_name);
+				const Value &comment = col.Comment();
+				if (!comment.IsNull()) {
+					spec.label = comment.ToString();
+				}
+			}
+		}
+	}
+
 	return std::move(bind_data);
 }
 
@@ -556,6 +587,9 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 		vars[i] = readstat_add_variable(writer, col.mangled_name.c_str(), col.rs_type, storage_width);
 		if (!col.rs_format.empty()) {
 			readstat_variable_set_format(vars[i], col.rs_format.c_str());
+		}
+		if (!col.label.empty()) {
+			readstat_variable_set_label(vars[i], col.label.c_str());
 		}
 	}
 

--- a/src/sas_export_function.cpp
+++ b/src/sas_export_function.cpp
@@ -21,21 +21,31 @@ extern "C" {
 
 namespace duckdb {
 
-enum class SasFormat { XPT, SAS7BDAT, SAV };
+enum class SasFormat { XPT, SAS7BDAT, SAV, POR };
+
+// SAV and POR share SPSS-side semantics: SPSS epoch (1582-10-14), SPSS format
+// strings (DATE11/DATETIME20/TIME8), spss_format_for_variable() handling.
+static inline bool IsSpssFamily(SasFormat f) {
+	return f == SasFormat::SAV || f == SasFormat::POR;
+}
 
 // ─── Per-format column-name validation ─────────────────────────────────────────
-// XPT v5: ≤ 8 chars, uppercased, ASCII alphanumeric or underscore, must start
-// with a letter or underscore. Names are uppercased before validation —
-// silent truncation would create silent collisions on round-trip.
+// XPT v5 / POR: ≤ 8 chars, uppercased, ASCII alphanumeric or underscore, must
+// start with a letter or underscore. Names are uppercased before validation —
+// silent truncation would create silent collisions on round-trip. (POR allows
+// '.', '@', '#', '$' too, but we keep the stricter A-Z 0-9 _ subset for
+// consistency with XPT.)
 // SAS7BDAT / SAV: ≤ 32 chars, otherwise the same character rules. Case is
 // preserved (real SAS is case-insensitive but stores the user's casing; SPSS
 // is case-sensitive in modern versions).
 
 static string ValidateColumnName(const string &name, SasFormat format, const char *role) {
-	const size_t max_len = (format == SasFormat::XPT) ? 8 : 32;
-	const char *format_label = format == SasFormat::XPT     ? "XPT v5"
+	const bool short_name_format = format == SasFormat::XPT || format == SasFormat::POR;
+	const size_t max_len = short_name_format ? 8 : 32;
+	const char *format_label = format == SasFormat::XPT        ? "XPT v5"
 	                           : format == SasFormat::SAS7BDAT ? "SAS7BDAT"
-	                                                          : "SAV";
+	                           : format == SasFormat::SAV      ? "SAV"
+	                                                          : "POR";
 
 	if (name.empty()) {
 		throw BinderException("Empty %s not allowed in %s export", role, format_label);
@@ -44,7 +54,7 @@ static string ValidateColumnName(const string &name, SasFormat format, const cha
 		throw BinderException("%s '%s' is too long for %s (max %llu chars). Rename in your SELECT.", role, name,
 		                      format_label, static_cast<uint64_t>(max_len));
 	}
-	string out = (format == SasFormat::XPT) ? StringUtil::Upper(name) : name;
+	string out = short_name_format ? StringUtil::Upper(name) : name;
 	for (char c : out) {
 		bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
 		if (!ok) {
@@ -70,7 +80,7 @@ struct ColumnSpec {
 };
 
 static void MapDuckDBType(const LogicalType &dt, SasFormat fmt, ColumnSpec &spec) {
-	const bool is_spss = fmt == SasFormat::SAV;
+	const bool is_spss = IsSpssFamily(fmt);
 
 	switch (dt.id()) {
 	case LogicalTypeId::BOOLEAN:
@@ -178,7 +188,10 @@ static SasFormat FormatFromInfo(const CopyInfo &info) {
 	if (fmt == "sav") {
 		return SasFormat::SAV;
 	}
-	throw BinderException("Unknown stats_duck export format '%s' (expected 'xpt', 'sas7bdat', or 'sav')",
+	if (fmt == "por") {
+		return SasFormat::POR;
+	}
+	throw BinderException("Unknown stats_duck export format '%s' (expected 'xpt', 'sas7bdat', 'sav', or 'por')",
 	                      info.format);
 }
 
@@ -190,6 +203,8 @@ static const char *FormatLabel(SasFormat f) {
 		return "SAS7BDAT";
 	case SasFormat::SAV:
 		return "SAV";
+	case SasFormat::POR:
+		return "POR";
 	}
 	return "?";
 }
@@ -236,6 +251,8 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 			table_name_user_provided = true;
 		} else if (loption == "compression") {
 			if (fmt != SasFormat::SAS7BDAT && fmt != SasFormat::SAV) {
+				// POR is text-based; SPSS's spec defines no compression for it.
+				// XPT also has no compression in either v5 or v8.
 				throw BinderException("COMPRESSION option is only meaningful for SAS7BDAT and SAV export, not %s",
 				                      fmt_label);
 			}
@@ -361,7 +378,7 @@ static ssize_t SasExportDataWriter(const void *bytes, size_t len, void *ctx) {
 
 static void InsertValue(readstat_writer_t *writer, const readstat_variable_t *var, const ColumnSpec &spec,
                         SasFormat sas_format, const Vector &vec_p, idx_t row, UnifiedVectorFormat &fmt) {
-	const int32_t epoch_offset = sas_format == SasFormat::SAV ? SPSS_EPOCH_OFFSET : SAS_EPOCH_OFFSET;
+	const int32_t epoch_offset = IsSpssFamily(sas_format) ? SPSS_EPOCH_OFFSET : SAS_EPOCH_OFFSET;
 	auto idx = fmt.sel->get_index(row);
 	if (!fmt.validity.RowIsValid(idx)) {
 		readstat_insert_missing_value(writer, var);
@@ -436,7 +453,7 @@ static void InsertValue(readstat_writer_t *writer, const readstat_variable_t *va
 		// then × 86400 to convert days→seconds).
 		auto days = UnifiedVectorFormat::GetData<date_t>(fmt)[idx].days;
 		double offset_days = static_cast<double>(days - epoch_offset);
-		double v = sas_format == SasFormat::SAV ? offset_days * 86400.0 : offset_days;
+		double v = IsSpssFamily(sas_format) ? offset_days * 86400.0 : offset_days;
 		readstat_insert_double_value(writer, var, v);
 		break;
 	}
@@ -508,6 +525,9 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 		break;
 	case SasFormat::SAV:
 		err = readstat_begin_writing_sav(writer, gstate.file_handle.get(), row_count);
+		break;
+	case SasFormat::POR:
+		err = readstat_begin_writing_por(writer, gstate.file_handle.get(), row_count);
 		break;
 	}
 	if (err != READSTAT_OK) {
@@ -598,6 +618,15 @@ void RegisterSasExport(ExtensionLoader &loader) {
 	WireCopyFunction(sav);
 	sav.extension = "sav";
 	loader.RegisterFunction(sav);
+
+	// SPSS .por — Portable file format. ASCII-encoded sibling of SAV designed
+	// for cross-platform interchange in pre-Unicode SPSS workflows. Strict
+	// XPT-style 8-char uppercase column names and no compression. Variable
+	// labels are written via the same readstat_variable_set_label path.
+	CopyFunction por("por");
+	WireCopyFunction(por);
+	por.extension = "por";
+	loader.RegisterFunction(por);
 }
 
 } // namespace duckdb

--- a/src/sas_export_function.cpp
+++ b/src/sas_export_function.cpp
@@ -35,17 +35,41 @@ static inline bool IsSpssFamily(SasFormat f) {
 // silent truncation would create silent collisions on round-trip. (POR allows
 // '.', '@', '#', '$' too, but we keep the stricter A-Z 0-9 _ subset for
 // consistency with XPT.)
-// SAS7BDAT / SAV: ≤ 32 chars, otherwise the same character rules. Case is
-// preserved (real SAS is case-insensitive but stores the user's casing; SPSS
-// is case-sensitive in modern versions).
+// XPT v8 / SAS7BDAT / SAV: ≤ 32 chars, otherwise the same character rules. XPT
+// v8 still uppercases (XPT-family files are uppercase by convention); SAS7BDAT
+// and SAV preserve the user's casing.
 
-static string ValidateColumnName(const string &name, SasFormat format, const char *role) {
-	const bool short_name_format = format == SasFormat::XPT || format == SasFormat::POR;
-	const size_t max_len = short_name_format ? 8 : 32;
-	const char *format_label = format == SasFormat::XPT        ? "XPT v5"
-	                           : format == SasFormat::SAS7BDAT ? "SAS7BDAT"
-	                           : format == SasFormat::SAV      ? "SAV"
-	                                                          : "POR";
+static size_t MaxNameLen(SasFormat format, uint8_t xpt_version) {
+	switch (format) {
+	case SasFormat::XPT:
+		return xpt_version == 8 ? 32 : 8;
+	case SasFormat::POR:
+		return 8;
+	case SasFormat::SAS7BDAT:
+	case SasFormat::SAV:
+		return 32;
+	}
+	return 8;
+}
+
+static const char *FormatLabelWithVersion(SasFormat format, uint8_t xpt_version) {
+	switch (format) {
+	case SasFormat::XPT:
+		return xpt_version == 8 ? "XPT v8" : "XPT v5";
+	case SasFormat::SAS7BDAT:
+		return "SAS7BDAT";
+	case SasFormat::SAV:
+		return "SAV";
+	case SasFormat::POR:
+		return "POR";
+	}
+	return "?";
+}
+
+static string ValidateColumnName(const string &name, SasFormat format, const char *role, uint8_t xpt_version = 5) {
+	const bool uppercase = format == SasFormat::XPT || format == SasFormat::POR;
+	const size_t max_len = MaxNameLen(format, xpt_version);
+	const char *format_label = FormatLabelWithVersion(format, xpt_version);
 
 	if (name.empty()) {
 		throw BinderException("Empty %s not allowed in %s export", role, format_label);
@@ -54,7 +78,7 @@ static string ValidateColumnName(const string &name, SasFormat format, const cha
 		throw BinderException("%s '%s' is too long for %s (max %llu chars). Rename in your SELECT.", role, name,
 		                      format_label, static_cast<uint64_t>(max_len));
 	}
-	string out = short_name_format ? StringUtil::Upper(name) : name;
+	string out = uppercase ? StringUtil::Upper(name) : name;
 	for (char c : out) {
 		bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
 		if (!ok) {
@@ -136,14 +160,16 @@ static void MapDuckDBType(const LogicalType &dt, SasFormat fmt, ColumnSpec &spec
 
 struct SasExportBindData : public FunctionData {
 	SasFormat format = SasFormat::XPT;
+	uint8_t xpt_version = 5;                                    // XPT only — 5 (default) or 8
 	string label;
 	string table_name;                                          // XPT only
-	readstat_compress_t compression = READSTAT_COMPRESS_NONE;   // SAS7BDAT only
+	readstat_compress_t compression = READSTAT_COMPRESS_NONE;   // SAS7BDAT and SAV only
 	vector<ColumnSpec> columns;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto c = make_uniq<SasExportBindData>();
 		c->format = format;
+		c->xpt_version = xpt_version;
 		c->label = label;
 		c->table_name = table_name;
 		c->compression = compression;
@@ -161,8 +187,8 @@ struct SasExportBindData : public FunctionData {
 				return false;
 			}
 		}
-		return format == other.format && label == other.label && table_name == other.table_name &&
-		       compression == other.compression;
+		return format == other.format && xpt_version == other.xpt_version && label == other.label &&
+		       table_name == other.table_name && compression == other.compression;
 	}
 };
 
@@ -218,6 +244,8 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 
 	// XPT-only: derive a default internal dataset name from the path basename.
 	// SAS7BDAT ignores readstat_writer_set_table_name, so we only build it for XPT.
+	// Truncation length follows xpt_version (set below from the VERSION option,
+	// defaulting to 5).
 	string xpt_base;
 	if (fmt == SasFormat::XPT) {
 		auto path = input.info.file_path;
@@ -230,9 +258,6 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 		if (xpt_base.empty()) {
 			xpt_base = "DATASET";
 		}
-		if (xpt_base.size() > 8) {
-			xpt_base = xpt_base.substr(0, 8);
-		}
 	}
 
 	bool table_name_user_provided = false;
@@ -243,6 +268,15 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 		}
 		if (loption == "label") {
 			bind_data->label = option.second[0].ToString();
+		} else if (loption == "version") {
+			if (fmt != SasFormat::XPT) {
+				throw BinderException("VERSION option is only meaningful for XPT export, not %s", fmt_label);
+			}
+			auto v = option.second[0].GetValue<int64_t>();
+			if (v != 5 && v != 8) {
+				throw BinderException("XPT VERSION must be 5 or 8, got %lld", static_cast<long long>(v));
+			}
+			bind_data->xpt_version = static_cast<uint8_t>(v);
 		} else if (loption == "table_name") {
 			if (fmt != SasFormat::XPT) {
 				throw BinderException("TABLE_NAME option is only meaningful for XPT export, not %s", fmt_label);
@@ -270,13 +304,22 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 	}
 
 	if (fmt == SasFormat::XPT) {
+		// Truncate auto-derived path basenames to the version-appropriate width
+		// before validation. User-supplied TABLE_NAME is left intact and must
+		// validate as-is.
+		if (!table_name_user_provided) {
+			auto cap = MaxNameLen(SasFormat::XPT, bind_data->xpt_version);
+			if (xpt_base.size() > cap) {
+				xpt_base = xpt_base.substr(0, cap);
+			}
+		}
 		try {
-			bind_data->table_name = ValidateColumnName(xpt_base, fmt, "TABLE_NAME");
+			bind_data->table_name = ValidateColumnName(xpt_base, fmt, "TABLE_NAME", bind_data->xpt_version);
 		} catch (const BinderException &) {
 			if (table_name_user_provided) {
 				throw;
 			}
-			// Auto-derived name from path didn't fit XPT v5; fall back to "DATASET".
+			// Auto-derived name from path didn't validate; fall back to "DATASET".
 			bind_data->table_name = "DATASET";
 		}
 	}
@@ -287,7 +330,7 @@ static unique_ptr<FunctionData> SasExportBind(ClientContext &context, CopyFuncti
 		spec.original_name = names[i];
 		spec.duckdb_type = sql_types[i];
 		MapDuckDBType(sql_types[i], fmt, spec);
-		spec.mangled_name = ValidateColumnName(names[i], fmt, "column name");
+		spec.mangled_name = ValidateColumnName(names[i], fmt, "column name", bind_data->xpt_version);
 		bind_data->columns.push_back(std::move(spec));
 	}
 
@@ -483,9 +526,11 @@ static void SasExportFinalize(ClientContext &, FunctionData &bind_data_p, Global
 	readstat_set_data_writer(writer, SasExportDataWriter);
 
 	if (bind_data.format == SasFormat::XPT) {
-		// XPT v5 — most universally readable XPT version. v8 (longer names, wider
-		// strings) is a future phase.
-		readstat_writer_set_file_format_version(writer, 5);
+		// XPT v5 (default) — most universally readable. v8 lifts the column-name
+		// width to 32 chars and is read transparently by ReadStat-family readers
+		// (this extension's read_stat(), pyreadstat, haven, R), but some legacy
+		// SAS toolchains still expect v5.
+		readstat_writer_set_file_format_version(writer, bind_data.xpt_version);
 		if (!bind_data.table_name.empty()) {
 			readstat_writer_set_table_name(writer, bind_data.table_name.c_str());
 		}

--- a/test/sql/sas_export_labels.test
+++ b/test/sql/sas_export_labels.test
@@ -1,0 +1,148 @@
+# name: test/sql/sas_export_labels.test
+# description: Variable labels from DuckDB column comments — for COPY tbl TO ...
+#              of any of XPT/SAS7BDAT/SAV/POR. Verified via read_stat_metadata().
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── read_stat_metadata smoke test on a fixture file ──────────────────────────
+
+query TT
+SELECT column_name, type FROM read_stat_metadata('./test/data/sample.sas7bdat') ORDER BY column_name
+----
+dtime	DOUBLE
+mychar	STRING
+mydate	DOUBLE
+mylabl	DOUBLE
+mynum	DOUBLE
+myord	DOUBLE
+mytime	DOUBLE
+
+# Replacement scan does not apply to read_stat_metadata — explicit form only.
+statement error
+SELECT * FROM read_stat_metadata('./test/data/missing_file.sas7bdat')
+----
+Failed to read metadata
+
+# ─── Column comments → SAV variable labels ────────────────────────────────────
+
+statement ok
+CREATE TABLE penguins(species VARCHAR, bill_len_mm DOUBLE, body_mass_g INTEGER);
+
+statement ok
+COMMENT ON COLUMN penguins.species IS 'Penguin species (Adelie, Gentoo, Chinstrap)'
+
+statement ok
+COMMENT ON COLUMN penguins.bill_len_mm IS 'Bill length in millimeters'
+
+statement ok
+COMMENT ON COLUMN penguins.body_mass_g IS 'Body mass in grams'
+
+statement ok
+INSERT INTO penguins VALUES ('Adelie', 39.1, 3750), ('Gentoo', 50.0, 5000);
+
+statement ok
+COPY penguins TO '__TEST_DIR__/penguins.sav';
+
+query TT
+SELECT column_name, label FROM read_stat_metadata('__TEST_DIR__/penguins.sav') ORDER BY column_name
+----
+bill_len_mm	Bill length in millimeters
+body_mass_g	Body mass in grams
+species	Penguin species (Adelie, Gentoo, Chinstrap)
+
+# ─── Same comments survive SAS7BDAT round-trip ────────────────────────────────
+
+statement ok
+COPY penguins TO '__TEST_DIR__/penguins.sas7bdat';
+
+query TT
+SELECT column_name, label FROM read_stat_metadata('__TEST_DIR__/penguins.sas7bdat') ORDER BY column_name
+----
+bill_len_mm	Bill length in millimeters
+body_mass_g	Body mass in grams
+species	Penguin species (Adelie, Gentoo, Chinstrap)
+
+# ─── XPT v5 — uppercase 8-char names, labels still ride along (≤ 40 chars) ───
+
+statement ok
+CREATE TABLE shorty(s VARCHAR, x DOUBLE);
+
+statement ok
+COMMENT ON COLUMN shorty.s IS 'Species code'
+
+statement ok
+COMMENT ON COLUMN shorty.x IS 'Bill length'
+
+statement ok
+COPY shorty TO '__TEST_DIR__/shorty.xpt';
+
+query TT
+SELECT column_name, label FROM read_stat_metadata('__TEST_DIR__/shorty.xpt') ORDER BY column_name
+----
+S	Species code
+X	Bill length
+
+# ─── XPT v8 — long labels (> 40 chars) ride a long-label subrecord ────────────
+
+statement ok
+CREATE TABLE longlab(measurement DOUBLE);
+
+statement ok
+COMMENT ON COLUMN longlab.measurement IS 'A label that exceeds forty characters in length, exercising the LABELV8 subrecord path'
+
+statement ok
+COPY longlab TO '__TEST_DIR__/longlab.xpt' (VERSION 8);
+
+query TT
+SELECT column_name, label FROM read_stat_metadata('__TEST_DIR__/longlab.xpt')
+----
+MEASUREMENT	A label that exceeds forty characters in length, exercising the LABELV8 subrecord path
+
+# ─── POR labels survive too ──────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE porlab(s VARCHAR, n INTEGER);
+
+statement ok
+COMMENT ON COLUMN porlab.s IS 'Subject code'
+
+statement ok
+COMMENT ON COLUMN porlab.n IS 'Visit number'
+
+statement ok
+COPY porlab TO '__TEST_DIR__/porlab.por';
+
+query TT
+SELECT column_name, label FROM read_stat_metadata('__TEST_DIR__/porlab.por') ORDER BY column_name
+----
+N	Visit number
+S	Subject code
+
+# ─── COPY (subquery) form has no source-table comments → empty labels ─────────
+
+statement ok
+COPY (SELECT 1 AS x, 2 AS y) TO '__TEST_DIR__/no_comments.sav';
+
+query TT
+SELECT column_name, label FROM read_stat_metadata('__TEST_DIR__/no_comments.sav') ORDER BY column_name
+----
+x	(empty)
+y	(empty)
+
+# ─── Partial comment coverage — uncommented columns get empty labels ─────────
+
+statement ok
+CREATE TABLE partial(a INTEGER, b INTEGER);
+
+statement ok
+COMMENT ON COLUMN partial.a IS 'Annotated';
+
+statement ok
+COPY partial TO '__TEST_DIR__/partial.sav';
+
+query TT
+SELECT column_name, label FROM read_stat_metadata('__TEST_DIR__/partial.sav') ORDER BY column_name
+----
+a	Annotated
+b	(empty)

--- a/test/sql/sas_export_por.test
+++ b/test/sql/sas_export_por.test
@@ -1,0 +1,117 @@
+# name: test/sql/sas_export_por.test
+# description: COPY ... TO '*.por' — SPSS Portable round-trip via ReadStat
+#              POR is the ASCII sibling of SAV. Strict XPT-style 8-char
+#              uppercase column-name rules. SPSS epoch and format strings.
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Numeric round-trip ────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE nums AS SELECT * FROM (VALUES (1, 1.5), (2, 2.5), (3, 3.5)) AS t(I, X);
+
+statement ok
+COPY nums TO '__TEST_DIR__/nums.por';
+
+query II
+SELECT CAST(I AS INTEGER), CAST(X * 10 AS INTEGER) FROM read_stat('__TEST_DIR__/nums.por') ORDER BY I
+----
+1	15
+2	25
+3	35
+
+# ─── Strings ───────────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE strs AS SELECT * FROM (VALUES ('alice', 1), ('bob', 2)) AS t(NAME, ID);
+
+statement ok
+COPY strs TO '__TEST_DIR__/strs.por';
+
+query TI
+SELECT NAME, CAST(ID AS INTEGER) FROM read_stat('__TEST_DIR__/strs.por') ORDER BY ID
+----
+alice	1
+bob	2
+
+# ─── NULLs ─────────────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE nulls AS SELECT * FROM (VALUES (1, 'a'), (NULL, 'b')) AS t(N, S);
+
+statement ok
+COPY nulls TO '__TEST_DIR__/nulls.por';
+
+query IT
+SELECT CAST(N AS INTEGER), S FROM read_stat('__TEST_DIR__/nulls.por') ORDER BY N NULLS LAST
+----
+1	a
+NULL	b
+
+# ─── Temporal types — POR uses SPSS-native epoch (seconds since 1582-10-14) ──
+
+statement ok
+CREATE TABLE temporals AS SELECT * FROM (VALUES
+    (DATE '2024-01-15', TIMESTAMP '2024-01-15 10:30:45'),
+    (DATE '1960-01-01', TIMESTAMP '1960-01-01 00:00:00')
+) AS t(D, TS);
+
+statement ok
+COPY temporals TO '__TEST_DIR__/temporals.por';
+
+query TT
+SELECT D, TS FROM read_stat('__TEST_DIR__/temporals.por') ORDER BY D
+----
+1960-01-01	1960-01-01 00:00:00
+2024-01-15	2024-01-15 10:30:45
+
+# ─── COPY (subquery) form ─────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT 42 AS THE_ANSW, 'hello' AS GREETING) TO '__TEST_DIR__/inline.por';
+
+query IT
+SELECT CAST(THE_ANSW AS INTEGER), GREETING FROM read_stat('__TEST_DIR__/inline.por')
+----
+42	hello
+
+# ─── FORMAT override ──────────────────────────────────────────────────────────
+
+statement ok
+COPY (SELECT 7 AS X) TO '__TEST_DIR__/explicit.dat' (FORMAT 'por');
+
+query I
+SELECT CAST(X AS INTEGER) FROM read_stat('__TEST_DIR__/explicit.dat', format := 'por')
+----
+7
+
+# ─── 8-char uppercase column names enforced (XPT-style strictness) ────────────
+
+statement ok
+COPY (SELECT 1 AS abc) TO '__TEST_DIR__/lower.por';
+
+query I
+SELECT CAST(ABC AS INTEGER) FROM read_stat('__TEST_DIR__/lower.por')
+----
+1
+
+# ─── Negative cases ────────────────────────────────────────────────────────────
+
+# > 8-char column name rejected.
+statement error
+COPY (SELECT 1 AS this_name_too_long) TO '__TEST_DIR__/bad.por'
+----
+too long for POR
+
+# TABLE_NAME is XPT-only.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.por' (TABLE_NAME 'NAME')
+----
+TABLE_NAME option is only meaningful for XPT export
+
+# COMPRESSION is rejected on POR (POR is ASCII, no compression in the spec).
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.por' (COMPRESSION 'rows')
+----
+COMPRESSION option is only meaningful for SAS7BDAT and SAV

--- a/test/sql/sas_export_xpt.test
+++ b/test/sql/sas_export_xpt.test
@@ -175,3 +175,49 @@ statement error
 COPY (SELECT 1 AS X) TO '__TEST_DIR__/bad.xpt' (TABLE_NAME 'this_is_too_long')
 ----
 too long for XPT v5
+
+# ─── XPT v8 (32-char names) ────────────────────────────────────────────────────
+# Reader auto-detects v5 vs v8 from the file header (longname[32] subrecord),
+# so writing as v8 round-trips through this extension's read_stat() seamlessly.
+
+# Long column name accepted with VERSION 8.
+statement ok
+COPY (SELECT 1 AS this_is_a_long_column_name_v8x) TO '__TEST_DIR__/v8.xpt' (VERSION 8)
+
+query I
+SELECT CAST(THIS_IS_A_LONG_COLUMN_NAME_V8X AS INTEGER) FROM read_stat('__TEST_DIR__/v8.xpt')
+----
+1
+
+# Long TABLE_NAME accepted under VERSION 8.
+statement ok
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/v8name.xpt' (VERSION 8, TABLE_NAME 'A_LONGER_DATASET_NAME')
+
+query I
+SELECT CAST(X AS INTEGER) FROM read_stat('__TEST_DIR__/v8name.xpt')
+----
+1
+
+# v5 (default) still rejects long names.
+statement error
+COPY (SELECT 1 AS this_is_a_long_column_name_v8x) TO '__TEST_DIR__/v5fail.xpt'
+----
+too long for XPT v5
+
+# > 32 chars rejected even under v8.
+statement error
+COPY (SELECT 1 AS a_thirty_three_character_xpt_v8name) TO '__TEST_DIR__/v8fail.xpt' (VERSION 8)
+----
+too long for XPT v8
+
+# Bogus VERSION rejected.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/badver.xpt' (VERSION 9)
+----
+XPT VERSION must be 5 or 8
+
+# VERSION on non-XPT format rejected.
+statement error
+COPY (SELECT 1 AS X) TO '__TEST_DIR__/badfmt.sav' (VERSION 8)
+----
+VERSION option is only meaningful for XPT


### PR DESCRIPTION
## Summary

Three independently shippable additions to the SAS / SPSS export surface, all built on the existing scaffolding from PR #3:

- **POR export** — `COPY tbl TO 'file.por'` writes SPSS Portable files via ReadStat. Reader-side POR has worked since v0.1.0; this completes the round-trip. Shares SPSS-family epoch and format strings with the SAV writer; column names follow strict XPT-style 8-char uppercase rules. No COMPRESSION (POR is plain ASCII).
- **XPT v8** — `COPY tbl TO 'file.xpt' (VERSION 8)` lifts column names and dataset names to 32 chars (vs. v5's 8). Default stays v5 to preserve backwards compatibility — some legacy SAS toolchains still expect it. ReadStat already implements the v8 writer; this just exposes the version knob and version-aware validation.
- **Variable labels from column comments** — DuckDB's `COMMENT ON COLUMN tbl.col IS '...'` now flows through to ReadStat's variable label slot on every `COPY tbl TO 'file.{xpt,sas7bdat,sav,por}'`. Visible in SAS, SPSS, pyreadstat, haven, and R. Only kicks in when the COPY source is a named base table. Adds a companion `read_stat_metadata(path)` table function for inspecting `(column_name, type, format, label)` without scanning data.

## Test plan

- [x] `make debug` clean
- [x] `make wasm_eh` clean (514 KB, up from 487 KB at v0.2.0)
- [x] `test/sql/sas_export_xpt.test` (74 assertions, includes new VERSION cases)
- [x] `test/sql/sas_export_sas7bdat.test` (45 assertions)
- [x] `test/sql/sas_export_sav.test` (38 assertions)
- [x] `test/sql/sas_export_por.test` (36 assertions, new fixture)
- [x] `test/sql/sas_export_labels.test` (67 assertions, new fixture — covers all 4 formats including XPT v8 long-label subrecord)
- [x] `test/sql/read_stat.test` (188 assertions — reader untouched, covers regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)