### PR TITLE
Add zig_mingw_release for libc++-flavored windows_amd64_mingw builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ that name is preserved across releases for backward compatibility.
   via extension-ci-tools' standard distribution matrix — this target is
   for local verification and side-loading. See README's "Building with
   MinGW" section.
+- `make zig_mingw_release` — second `windows_amd64_mingw` build variant
+  that uses zig's bundled clang + **libc++** instead of mingw-gcc's
+  **libstdc++**. The DuckDB platform string doesn't distinguish the two
+  C++ runtimes, so a `mingw_release` artifact loaded into a libc++-linked
+  DuckDB host (e.g. zig-built `sassy` with `link_libcpp = true`) passes
+  the platform check and segfaults at function registration — std::map
+  and friends have ABI-incompatible layouts across the two STLs. Output
+  lands at `build/zig_mingw_release/...` so it's distinguishable from
+  the GCC variant. Requires zig 0.16+ on `PATH`. Drives `cmake` via the
+  shim scripts in `scripts/zig-shims/`.
 
 ## [0.2.0-bring-out-your-dead] - 2026-05-03
 

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,47 @@ mingw_release:
 	      -DCMAKE_CXX_FLAGS="$(MINGW_WIN32_API_FLAG)" \
 	      -S $(DUCKDB_SRCDIR) -B build/mingw_release
 	cmake --build build/mingw_release --config Release --parallel $(MINGW_JOBS)
+
+# ─── zig + libc++ build (Windows) ─────────────────────────────────────────────
+# Same `windows_amd64_mingw` platform stamp as `mingw_release`, but uses zig's
+# bundled clang and **libc++** (LLVM's C++ runtime) instead of mingw-gcc's
+# **libstdc++** (GNU's). The platform string doesn't distinguish the two C++
+# runtimes, so a `mingw_release` artifact loaded into a libc++-linked DuckDB
+# host (e.g. zig-built `sassy` with `link_libcpp = true`) will pass the
+# platform check and segfault at function-registration time — std::map and
+# friends have ABI-incompatible layouts across the two STLs.
+#
+# Zig as a compiler is invoked via two cmd shims (`scripts/zig-shims/`) that
+# prepend the `-target x86_64-windows-gnu` triple. CMake invokes them like
+# any other compiler binary; zig's clang frontend handles all the usual
+# flags (warnings, -E preprocessing, etc.).
+#
+# vcpkg is intentionally not consulted (its triplets don't match this
+# toolchain). zlib falls back to disabled if absent — same degradation as
+# the gcc-mingw target.
+.PHONY: zig_mingw_release
+
+# zig's clang frontend promotes a handful of warnings to errors by default
+# that DuckDB's third_party tree trips. Demote them back to warnings:
+#   -Wdate-time      pcg_random's __DATE__/__TIME__ in header (reproducibility)
+#   -Wmacro-redefined miniz / re2 / etc. redefining macros across vendored TUs
+ZIG_CFLAGS := -Wno-error=date-time -Wno-error=macro-redefined
+
+zig_mingw_release: export CC=$(PROJ_DIR)scripts/zig-shims/zig-cc.cmd
+zig_mingw_release: export CXX=$(PROJ_DIR)scripts/zig-shims/zig-cxx.cmd
+zig_mingw_release: export DUCKDB_PLATFORM=windows_amd64_mingw
+zig_mingw_release:
+	mkdir -p build/zig_mingw_release
+	cmake -G "MinGW Makefiles" \
+	      $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) \
+	      -DCMAKE_BUILD_TYPE=Release \
+	      -DDUCKDB_EXPLICIT_PLATFORM=windows_amd64_mingw \
+	      -DCMAKE_C_FLAGS="$(ZIG_CFLAGS)" \
+	      -DCMAKE_CXX_FLAGS="$(ZIG_CFLAGS)" \
+	      -S $(DUCKDB_SRCDIR) -B build/zig_mingw_release
+	# Build only the extension + the repository copy step. The default `all`
+	# target also builds duckdb's shell tool (linenoise), which calls a few
+	# POSIX-only APIs (`getpid`) that zig's mingw sysroot doesn't expose. We
+	# don't ship the shell, so skip it.
+	cmake --build build/zig_mingw_release --config Release --parallel $(MINGW_JOBS) \
+	      --target stats_duck_loadable_extension duckdb_local_extension_repo

--- a/README.md
+++ b/README.md
@@ -406,6 +406,44 @@ external dep, used for SPSS `.zsav` read/write) becomes optional and
 gracefully degrades if absent (see `CMakeLists.txt:97`); install zlib via
 your mingw package manager if you need `.zsav` support.
 
+### Building with zig as the C++ toolchain (matches sassy)
+
+DuckDB's platform string `windows_amd64_mingw` does not distinguish which C++
+runtime the binary is linked against. Two `windows_amd64_mingw` extensions can
+both pass the platform check on load and then segfault during function
+registration if their `std::map` / `std::shared_ptr` / etc. layouts differ —
+which they do across **libstdc++** (GNU's STL, what mingw-w64 GCC uses) and
+**libc++** (LLVM's STL, what zig's bundled clang uses with `link_libcpp`).
+
+The downstream [sassy](https://github.com/caerbannogwhite/sassy) SAS
+interpreter builds DuckDB with zig + `link_libcpp = true`, so its DuckDB
+links against libc++. The `make mingw_release` target above produces a
+libstdc++-linked binary and is *not* compatible — it'll segfault inside
+sassy. Use the zig variant instead:
+
+```bash
+make zig_mingw_release
+```
+
+This drives the same CMake configuration as `mingw_release` but routes
+`CC` / `CXX` through `scripts/zig-shims/zig-cc.cmd` / `zig-cxx.cmd`, which
+forward to `zig cc -target x86_64-windows-gnu` and
+`zig c++ -target x86_64-windows-gnu`. Output:
+
+```
+build/zig_mingw_release/extension/stats_duck/stats_duck.duckdb_extension
+build/zig_mingw_release/repository/<duckdb_version>/windows_amd64_mingw/stats_duck.duckdb_extension
+```
+
+Same platform stamp (`windows_amd64_mingw`), different C++ runtime. On a
+correctly-built artifact, `objdump -p stats_duck.duckdb_extension | grep DLL`
+shows only Windows system DLLs (`KERNEL32.dll`, `api-ms-win-crt-*`) — no
+`libstdc++-6.dll` or `libgcc_s_seh-1.dll`. If any GNU runtime DLL appears,
+the build slipped back to GCC.
+
+**Requirements.** zig 0.16+ on `PATH`. Tested with the `zig.zig`
+WinGet-installed copy.
+
 ## Testing
 
 ```bash

--- a/scripts/zig-shims/zig-cc.cmd
+++ b/scripts/zig-shims/zig-cc.cmd
@@ -1,0 +1,5 @@
+@echo off
+REM CMake-compatible C compiler shim. Forwards all args to `zig cc`
+REM with -target x86_64-windows-gnu so the build links against zig's
+REM bundled mingw-w64 sysroot (matching sassy's link_libcpp=true).
+zig cc -target x86_64-windows-gnu %*

--- a/scripts/zig-shims/zig-cxx.cmd
+++ b/scripts/zig-shims/zig-cxx.cmd
@@ -1,0 +1,7 @@
+@echo off
+REM CMake-compatible C++ compiler shim that delegates arg filtering to a
+REM Python helper before forwarding to `zig c++`. The Python shim strips
+REM GNU-only linker flags (-Wl,--exclude-libs,ALL etc.) that DuckDB's
+REM extension build pipeline emits when CMAKE_CXX_COMPILER_ID is "Clang"
+REM but that lld-for-PE/COFF doesn't accept. See zig-cxx.py.
+python "%~dp0zig-cxx.py" %*

--- a/scripts/zig-shims/zig-cxx.py
+++ b/scripts/zig-shims/zig-cxx.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""CMake-compatible C++ compiler shim that forwards to `zig c++`.
+
+The plain `zig-cxx.cmd` shim works for compilation but trips at link time:
+DuckDB's `extension_build_tools.cmake` adds `-Wl,--exclude-libs,ALL` for any
+Clang or GCC compiler on a non-Apple, non-z/OS host (line 141, 152). The
+Windows-with-Clang case falls through to the GNU-on-Linux branch because
+there's no escape hatch for a clang-but-on-Windows scenario.
+
+`lld` for PE/COFF — what zig invokes on the `*-windows-gnu` target — does
+not implement `--exclude-libs`, so the link fails. Fortunately the flag is
+purely a symbol-hiding optimization on ELF; on Windows, symbol export is
+controlled by `__declspec(dllexport)` / `dllimport` and the absence of
+`--exclude-libs` is a no-op. Strip it.
+
+This shim also strips a couple of other GNU-only linker flags that DuckDB
+adds in the same code path (`--gc-sections`) — also redundant on PE/COFF
+where the linker discards unreferenced code by default.
+
+CMake on Windows passes long argument lists via response files (`@file.rsp`).
+The flags we care about are inside those files, not on the command line, so
+the shim expands `@file` references inline before filtering.
+"""
+import shlex
+import subprocess
+import sys
+
+# GNU/ELF-only linker flags that lld for PE/COFF rejects but that have no
+# functional impact on the Windows build. Any -Wl,arg matching these prefixes
+# is dropped before the args reach `zig c++`.
+DROP_LINKER_PREFIXES = (
+    "-Wl,--exclude-libs",
+    "-Wl,--gc-sections",
+)
+
+
+def expand_response_files(args):
+    out = []
+    for a in args:
+        if a.startswith("@"):
+            with open(a[1:], "r", encoding="utf-8") as f:
+                # Response files use shell-style quoting. shlex.split handles
+                # the simple cases CMake emits (paths with spaces, double-quoted
+                # tokens, no environment variable expansion).
+                out.extend(shlex.split(f.read(), posix=False))
+        else:
+            out.append(a)
+    return out
+
+
+def main() -> int:
+    args = expand_response_files(sys.argv[1:])
+    args = [a for a in args if not a.startswith(DROP_LINKER_PREFIXES)]
+    cmd = ["zig", "c++", "-target", "x86_64-windows-gnu", *args]
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a third `windows_amd64_mingw` build variant that uses zig's bundled clang + **libc++** (LLVM's C++ runtime) instead of mingw-gcc + **libstdc++** (GNU's). Output lands at `build/zig_mingw_release/...` so it's distinguishable from the gcc variant.

The DuckDB platform string doesn't distinguish the two C++ runtimes, so a `mingw_release` artifact loaded into a libc++-linked DuckDB host (e.g. zig-built sassy with `link_libcpp = true`) passes both the platform check and the version check and then segfaults at function registration — std::map / std::shared_ptr / etc. have ABI-incompatible layouts across libstdc++ and libc++.

Builds on top of #6 (the gcc-mingw target).

Two warts worth flagging in the diff:

1. The C++ shim is `zig-cxx.cmd` → `zig-cxx.py`, not a bare cmd forwarder. DuckDB's `extension_build_tools.cmake:152` adds `-Wl,--exclude-libs,ALL` for any Clang or GCC compiler outside Apple and z/OS — including Clang on Windows, where lld for PE/COFF doesn't accept that flag. The Python shim expands `@response_files` and strips that argument (plus `--gc-sections`, both ELF-only) before forwarding to zig. Without the strip, link fails with `error: unsupported linker arg: --exclude-libs`.

2. The cmake `--build` invocation targets `stats_duck_loadable_extension duckdb_local_extension_repo` explicitly rather than letting `all` run. The default `all` target also builds DuckDB's shell, whose `linenoise.cpp` calls POSIX `getpid()` — not in zig's mingw sysroot. We don't ship the shell, so skip it.

## Test plan

- [x] `make zig_mingw_release` builds clean (~13 min from scratch with parallel 8)
- [x] Output paths:
  - `build/zig_mingw_release/extension/stats_duck/stats_duck.duckdb_extension` (26.7 MB)
  - `build/zig_mingw_release/repository/v1.5.1/windows_amd64_mingw/stats_duck.duckdb_extension`
- [x] Footer stamps `windows_amd64_mingw`
- [x] DLL deps: KERNEL32, WS2_32, RstrtMgr, api-ms-win-crt-* (Universal CRT) — **no libstdc++-6.dll, no libgcc_s_seh-1.dll**
- [x] Sassy smoketest (`proc sql; select dnorm(0.0); quit;`) returns `0.3989422804014327`
- [x] MSVC `make release` and `make mingw_release` paths untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)