### PR TITLE
Fix Windows build: define ICONV_CONST=const for readstat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,14 @@ endif()
 if(Iconv_FOUND AND NOT WIN32)
     target_link_libraries(${EXTENSION_NAME} Iconv::Iconv)
 endif()
+# Align readstat's iconv inbuf typedef with win_iconv's prototype on Windows.
+# readstat's readstat_iconv_inbuf_t is `ICONV_CONST char **`, win_iconv's iconv()
+# takes `WINICONV_CONST char **` which defaults to `const char **`. Without
+# ICONV_CONST=const, the cast in readstat_convert.c mismatches by one `const`
+# and newer GCCs (≥ windows-latest runner image, May 2026) reject it.
+if(WIN32)
+    target_compile_definitions(${EXTENSION_NAME} PRIVATE ICONV_CONST=const)
+endif()
 
 set(PARAMETERS "-warnings")
 # Force i64 → (i32,i32) legalization at the WASM ABI boundary. Emscripten ≥ 4.0
@@ -130,6 +138,9 @@ if(ZLIB_FOUND)
 endif()
 if(Iconv_FOUND AND NOT WIN32)
     target_link_libraries(${LOADABLE_EXTENSION_NAME} Iconv::Iconv)
+endif()
+if(WIN32)
+    target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE ICONV_CONST=const)
 endif()
 
 install(


### PR DESCRIPTION
## Summary

Defines `ICONV_CONST=const` on Windows so `readstat`'s `iconv` inbuf typedef matches `win_iconv`'s prototype.

## Root cause

- `third_party/readstat/src/readstat_iconv.h` typedefs `readstat_iconv_inbuf_t` as `ICONV_CONST char **`, defaulting to plain `char **` when `ICONV_CONST` is undefined.
- `third_party/win_iconv/iconv.h` declares `iconv()` with `WINICONV_CONST char **inbuf`, which defaults to `const char **` when `ICONV_CONST` is undefined.
- The cast at `readstat_convert.c:18` therefore mismatches by exactly one `const`. Older GCCs emitted `-Wincompatible-pointer-types` as a warning; the GCC shipped on the `windows-latest` runner image as of 2026-05-06 rejects it as an error.

## Why this surfaced now

Same `main` SHA (`3eefd94`) that built green on 2026-05-05 fails the same way on a re-run on 2026-05-06 — runner-image bump, not a code regression.

## Test plan

- [ ] CI on this PR is green (Linux, macOS, Windows, WASM)
- [ ] After merge, rebase #10 onto main and confirm Windows build there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)
