### PR TITLE
Release v0.5.0-dead-person

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **Gamma / Beta / Exponential distribution functions.** d/p/q triples in the
+  same R-style API as the existing `d/p/qnorm` / `d/p/qt` / `d/p/qchisq` /
+  `d/p/qf` families. `dgamma(x, shape, [rate])` / `pgamma` / `qgamma` (rate
+  defaults to 1, matching R); `dbeta(x, alpha, beta)` / `pbeta` / `qbeta` on
+  the [0, 1] support; `dexp(x, [rate])` / `pexp` / `qexp` (rate defaults to 1;
+  `qexp` is closed-form `-log(1-p)/rate`). All implemented on top of the
+  existing regularized incomplete gamma / beta infrastructure in
+  `distributions.hpp`. Cross-verified against R to 6+ decimal places.
+
 - **Kolmogorov-Smirnov tests.** Two new aggregates:
 
   - `ks_test_1samp(x)` — one-sample KS against the fitted normal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The extension installs and loads in DuckDB under the technical name `stats_duck` —
 that name is preserved across releases for backward compatibility.
 
-## [Unreleased]
+## [0.5.0-dead-person] - 2026-05-31
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **ggsql: `WITH … VISUALIZE`** — a leading CTE clause is now accepted in
+  front of a `VISUALIZE` statement. The captured `WITH [RECURSIVE] <cte> AS
+  (...) [, <cte> AS (...)]*` block is prepended to each layer's projected
+  SQL, so the `FROM` clause and aesthetic expressions can reference
+  CTE-bound names. Composes with every existing modifier (`FACET BY`,
+  `SCALE`, `TITLE`, multi-layer `DRAW`) — wrapping marks like `line` and
+  `bar` keep the CTE scoped to the inner subquery via standard SQL CTE
+  scoping rules. Leading SQL comments (`--`, `/* … */`) before the `WITH`
+  are skipped during keyword detection. Statements that start with `WITH`
+  but contain no top-level `VISUALIZE` keyword fall through to DuckDB's
+  regular SQL parser unchanged, so existing CTE-using queries are
+  unaffected.
+
 - **`bin_edges` / `bin_label` — auto-binning helpers.**
   `bin_edges(x [, method]) → LIST<DOUBLE>` is a buffer-based aggregate that
   returns the edge vector for the chosen rule: `'sturges'` (default,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- `table_one`: new `p_value` output column carrying the between-group test
+  result. NULL when no `by` is set or there's only one stratum. Numeric
+  variables use one-way ANOVA via `anova_oneway(value, group)`; categorical
+  variables use chi-square independence via `chisq_independence(var, group)`.
+  Multi-column `by` folds into a single grouping by concatenating columns
+  with `' / '` (the same separator used for stratum labels). The same
+  p_value is stamped on every row of a given variable so a PIVOT can grab
+  it via `FIRST(p_value)`. Test failures (zero variance, too few samples
+  for a 2×2, etc.) → NULL rather than throwing — keeps the whole table
+  rendering even when one variable's test can't run.
 - `table_one`: `force_categorical := [...]` and `force_numerical := [...]`
   named parameters to override the per-variable auto-classification. Useful
   for integer columns that are really categorical (e.g. `stage ∈ {1,2,3,4}`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **`bin_edges` / `bin_label` — auto-binning helpers.**
+  `bin_edges(x [, method]) → LIST<DOUBLE>` is a buffer-based aggregate that
+  returns the edge vector for the chosen rule: `'sturges'` (default,
+  `k = ⌈log₂(n)+1⌉`, R's `hist()` default), `'fd'` (Freedman-Diaconis), `'scott'`
+  (normal-reference), `'sqrt'`, `'rice'`, or `'auto'` (numpy's `max(sturges, fd)`).
+  Methods that depend on robust scale (FD, Scott) silently fall back to
+  Sturges when IQR/sd is zero. `bin_label(x, edges) → VARCHAR` formats the
+  bin containing `x` as `'[lo, hi)'` (or `'[lo, hi]'` for the rightmost bin so
+  the maximum is never dropped). Pairs naturally with `table_one` — bin a
+  numeric column up front, then summarise the binned column categorically.
+
+- **Local DuckDB submodule patch (`duckdb/third_party/fmt/include/fmt/format.h`).**
+  Upstream fmt checks `#ifdef _SECURE_SCL` to decide whether to use
+  `stdext::checked_array_iterator`, but Microsoft's CRT auto-defines
+  `_SECURE_SCL=0` in Release builds — and the v145 MSVC toolset (VS2026)
+  removed `stdext::checked_array_iterator` entirely, so the `#ifdef` branch
+  now fails to compile. Patched to `#if defined(_SECURE_SCL) && _SECURE_SCL > 0`,
+  which correctly takes the plain-pointer branch in Release. The patch is
+  localized and a candidate for upstream contribution; re-apply if the
+  DuckDB submodule moves.
+
 - `poibin_cdf(probs LIST<DOUBLE>, k BIGINT) → DOUBLE` — Poisson Binomial CDF.
   Returns `P(X ≤ k)` where `X = Σᵢ Bᵢ`, each `Bᵢ ∼ Bernoulli(pᵢ)` independent
   with its own success probability. Computed by Hong (2013)'s direct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **Kolmogorov-Smirnov tests.** Two new aggregates:
+
+  - `ks_test_1samp(x)` — one-sample KS against the fitted normal
+    `N(mean(x), sd(x))`. Returns `STRUCT(test_type, d_statistic, p_value, n)`.
+    Buffer-based aggregate; valid for `n >= 3`. P-value via the asymptotic
+    Kolmogorov distribution with Stephens (1970) small-sample correction.
+    Because mu/sigma are estimated from the sample the p-value is
+    **conservative** — pair with `shapiro_wilk` / `anderson_darling` when
+    normality is the primary question.
+  - `ks_test_2samp(x, y)` — two-sample KS on whether `x` and `y` come from
+    the same underlying distribution. Returns
+    `STRUCT(test_type, d_statistic, p_value, n_x, n_y)`. Asymptotic p-value
+    evaluated at the effective sample size `n_x*n_y/(n_x+n_y)`. Per-column
+    NULL handling (NULL in `x` doesn't drop the value from `y` on the same
+    row), matching `ttest_2samp` semantics.
+
 - `table_one`: new `p_value` output column carrying the between-group test
   result. NULL when no `by` is set or there's only one stratum. Numeric
   variables use one-way ANOVA via `anova_oneway(value, group)`; categorical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ that name is preserved across releases for backward compatibility.
 
 ## [Unreleased]
 
+### Added
+
+- ggsql: `TITLE '<text>' [SUBTITLE '<text>']` clause appended after any
+  `SCALE` clauses. Emitted as a Vega-Lite `TitleParams` object (always object
+  form, even without subtitle) so consumers don't need to handle both string
+  and object shapes. `SUBTITLE` without a preceding `TITLE` is a parse error.
+- ggsql: `SCALE <channel> LABEL '<text>'` operator injects an `axis.title`
+  block alongside the channel's existing `scale` block. Composes with
+  `TO` / `ZERO` / `DOMAIN` on the same channel and with `FACET BY` and
+  multi-layer specs. LABEL on an unmapped channel is a silent no-op, matching
+  the existing `SCALE` semantics.
+
 ## [0.4.0-nine-pence] - 2026-05-19
 
 Two themes for v0.4: rounding out the normality-test family that v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- `poibin_cdf(probs LIST<DOUBLE>, k BIGINT) → DOUBLE` — Poisson Binomial CDF.
+  Returns `P(X ≤ k)` where `X = Σᵢ Bᵢ`, each `Bᵢ ∼ Bernoulli(pᵢ)` independent
+  with its own success probability. Computed by Hong (2013)'s direct
+  convolution: O(n²) time, O(n) memory, numerically stable for the n that
+  show up in biostat-scale queries. Reduces exactly to `pbinom(k, n, p)` when
+  all probabilities are equal. NULL handling: NULL in either argument or
+  inside the list → NULL; any `pᵢ` outside `[0, 1]` → NULL.
+
 - **Gamma / Beta / Exponential distribution functions.** d/p/q triples in the
   same R-style API as the existing `d/p/qnorm` / `d/p/qt` / `d/p/qchisq` /
   `d/p/qf` families. `dgamma(x, shape, [rate])` / `pgamma` / `qgamma` (rate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **`corr_matrix(data, variables [, method])` table function** — long-format
+  pairwise correlation matrix as `(row_var, col_var, coef, p_value, n)` rows.
+  `method` is `'pearson'` (default), `'spearman'`, or `'kendall'`; the `coef`
+  column carries the method-appropriate coefficient (r / rho / tau) under one
+  uniform name so downstream pipelines compose without method-specific casing.
+  All n² rows emitted (full symmetric matrix including diagonal and mirror
+  pairs) so the result drops straight into a `DRAW heatmap` without a
+  CROSS JOIN. Upper triangle is computed once in C++ and mirrored — for k
+  variables that's k·(k+1)/2 aggregate runs instead of k². Pairwise-complete
+  NULL handling per the underlying `pearson_test` / `spearman_test` /
+  `kendall_test` aggregates. Non-numeric columns are rejected at bind time.
+
 - **ggsql: `WITH … VISUALIZE`** — a leading CTE clause is now accepted in
   front of a `VISUALIZE` statement. The captured `WITH [RECURSIVE] <cte> AS
   (...) [, <cte> AS (...)]*` block is prepended to each layer's projected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- ggsql: three new marks — `heatmap`, `density`, `regression`. `heatmap` is a
+  `rect` mark with ordinal x/y and quantitative color (correlation matrices,
+  contingency tables). `density` is a KDE via Vega-Lite's `density` transform
+  on the `x` aesthetic; groups by `color` if mapped (one curve per level).
+  `regression` is a `line` mark via Vega-Lite's `regression` transform fitting
+  `y ~ x`; groups by `color` if mapped. Pairs naturally with `DRAW point
+  DRAW regression` for scatter-with-fit overlays.
 - ggsql: `TITLE '<text>' [SUBTITLE '<text>']` clause appended after any
   `SCALE` clauses. Emitted as a Vega-Lite `TitleParams` object (always object
   form, even without subtitle) so consumers don't need to handle both string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ that name is preserved across releases for backward compatibility.
 
 ## [Unreleased]
 
+### Added
+
+- `table_one`: `force_categorical := [...]` and `force_numerical := [...]`
+  named parameters to override the per-variable auto-classification. Useful
+  for integer columns that are really categorical (e.g. `stage ∈ {1,2,3,4}`,
+  treatment codes) and VARCHAR columns holding numeric strings. Each entry
+  must appear in `variables` (typos surface as bind errors); the two lists
+  must not overlap.
+
 ### Changed
 
 - `table_one`: `by` named parameter is now `LIST<VARCHAR>` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ that name is preserved across releases for backward compatibility.
 
 ## [Unreleased]
 
+### Changed
+
+- `table_one`: `by` named parameter is now `LIST<VARCHAR>` instead of
+  `VARCHAR`. Single-column callers need to wrap the column name in a list:
+  `by := ['arm']` instead of `by := 'arm'`. Multi-column stratification
+  (Cartesian product of distinct value tuples across the listed columns,
+  e.g. `by := ['species', 'sex']`) is the motivation — the v0.4 single-
+  column form had no place to grow. Stratum labels join values with
+  `' / '` in declared order (e.g. `'Adelie / female'`); rows where any
+  by-column is NULL are excluded from the breakdown.
+
 ### Added
 
 - ggsql: three new marks — `heatmap`, `density`, `regression`. `heatmap` is a

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: Massimo
 repository-code: "https://github.com/caerbannogwhite/the-stats-duck"
 url: "https://github.com/caerbannogwhite/the-stats-duck"
-version: 0.4.0-nine-pence
-date-released: "2026-05-19"
+version: 0.5.0-dead-person
+date-released: "2026-05-31"
 license: Apache-2.0
 keywords:
   - duckdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(EXTENSION_SOURCES
     src/rank_correlation_function.cpp
     src/sign_test_function.cpp
     src/adjust_p_function.cpp
+    src/poibin_function.cpp
     src/table_one_function.cpp
     src/normality_function.cpp
     src/ks_test_function.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXTENSION_SOURCES
     src/sign_test_function.cpp
     src/adjust_p_function.cpp
     src/poibin_function.cpp
+    src/auto_bin_function.cpp
     src/table_one_function.cpp
     src/normality_function.cpp
     src/ks_test_function.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(EXTENSION_SOURCES
     src/adjust_p_function.cpp
     src/table_one_function.cpp
     src/normality_function.cpp
+    src/ks_test_function.cpp
     src/anova_function.cpp
     src/chisq_function.cpp
     src/read_stat_function.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(EXTENSION_SOURCES
     src/adjust_p_function.cpp
     src/poibin_function.cpp
     src/auto_bin_function.cpp
+    src/corr_matrix_function.cpp
     src/table_one_function.cpp
     src/normality_function.cpp
     src/ks_test_function.cpp

--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `df(x, df1, df2)`        | F distribution PDF      |
 | `pf(x, df1, df2)`        | F distribution CDF      |
 | `qf(p, df1, df2)`        | F distribution quantile |
+| `dgamma(x, shape, [rate])` | Gamma PDF (rate=1 default) |
+| `pgamma(x, shape, [rate])` | Gamma CDF             |
+| `qgamma(p, shape, [rate])` | Gamma quantile        |
+| `dbeta(x, alpha, beta)`  | Beta PDF on [0, 1]      |
+| `pbeta(x, alpha, beta)`  | Beta CDF                |
+| `qbeta(p, alpha, beta)`  | Beta quantile           |
+| `dexp(x, [rate])`        | Exponential PDF (rate=1 default) |
+| `pexp(x, [rate])`        | Exponential CDF         |
+| `qexp(p, [rate])`        | Exponential quantile (closed form) |
 
 ### Table 1 summary (table function)
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ SELECT * FROM table_one(
 ```
 
 Output columns (long format, fixed schema):
-`variable`, `level`, `statistic`, `stratum`, `display`
+`variable`, `level`, `statistic`, `stratum`, `display`, `p_value`
 
 - Each numeric variable yields rows for `n`, `missing`, `mean (sd)`,
   `median [q1, q3]`, `min, max` — `level` is NULL.
@@ -169,6 +169,12 @@ Output columns (long format, fixed schema):
   by joining values with `' / '` in declared order (e.g. `'Adelie / female'`
   for `by := ['species', 'sex']`). Rows where any by-column is NULL are
   excluded from the stratum breakdown.
+- `p_value` is the between-group test result, repeated on every row of the
+  same variable so a PIVOT can grab it with `FIRST(p_value)`. NULL when
+  `by` is unset or has only one stratum. Numeric variables use one-way
+  ANOVA (`anova_oneway`); categorical variables use chi-square independence
+  (`chisq_independence`). NULL when the underlying test is infeasible (zero
+  variance, too few samples).
 - Variable types are auto-classified from the catalog: integer / floating-
   point types are numeric, everything else (VARCHAR, BOOLEAN, ENUM,
   date/time) is categorical. Override per-variable with

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ columns — `spec` (a complete Vega-Lite v5 JSON spec) and `layer_sqls` (a
 runs each layer's SQL and feeds the rows to vega-embed via the `datasets` API.
 
 ```
+[WITH [RECURSIVE] <cte> AS (...) [, <cte> AS (...)]*]
 VISUALIZE <expr> AS <aesthetic> [: <type>] (, <expr> AS <aesthetic> ...)
 FROM <table>
 DRAW <mark> (DRAW <mark>)*
@@ -263,6 +264,12 @@ DRAW <mark> (DRAW <mark>)*
 [SCALE <channel> {TO <scheme> | ZERO true|false | DOMAIN <lo> <hi> | LABEL '<text>'}]*
 [TITLE '<text>' [SUBTITLE '<text>']]
 ```
+
+A leading `WITH` clause is supported; CTEs are scoped to each layer's
+projected SQL so they compose with wrapping marks (`line`, `bar`, `area`,
+`errorband`, `regression`) without extra work. `WITH … SELECT …` statements
+without a top-level `VISUALIZE` keyword fall through to DuckDB's normal SQL
+parser unchanged.
 
 **Marks:** `point`, `line`, `bar`, `histogram`, `text`, `area`, `rule`, `tick`,
 `errorbar`, `errorband`, `boxplot`, `heatmap`, `density`, `regression`. Custom

--- a/README.md
+++ b/README.md
@@ -171,7 +171,11 @@ Output columns (long format, fixed schema):
   excluded from the stratum breakdown.
 - Variable types are auto-classified from the catalog: integer / floating-
   point types are numeric, everything else (VARCHAR, BOOLEAN, ENUM,
-  date/time) is categorical.
+  date/time) is categorical. Override per-variable with
+  `force_categorical := ['stage']` (integer column that's really a
+  category) or `force_numerical := ['height']` (VARCHAR column holding
+  numeric strings). Entries must appear in `variables`, and the two lists
+  must not overlap.
 
 Pivot to wide for display:
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 SELECT * FROM table_one(
     'patients',
     variables := ['age', 'sex', 'bmi'],
-    by := 'arm'           -- optional
+    by := ['arm']         -- optional; pass multiple columns for cross-stratification
 );
 ```
 
@@ -160,10 +160,15 @@ Output columns (long format, fixed schema):
 
 - Each numeric variable yields rows for `n`, `missing`, `mean (sd)`,
   `median [q1, q3]`, `min, max` — `level` is NULL.
-- Each categorical variable yields one row per level with `n (%)` and an
-  optional trailing `missing` row.
-- `stratum` is `'Overall'` when `by` is unset, and `'Overall'` plus one
-  value per distinct `by` value otherwise.
+- Each categorical variable yields one row per level with `n (%)` plus a
+  trailing `Missing` level row that is always emitted (filter with
+  `WHERE level <> 'Missing'` if you don't want it). All level percentages
+  share the stratum-total denominator so they sum to 100%.
+- `stratum` is `'Overall'` when `by` is unset / empty; otherwise the Cartesian
+  product of distinct value tuples across the listed by-columns, labelled
+  by joining values with `' / '` in declared order (e.g. `'Adelie / female'`
+  for `by := ['species', 'sex']`). Rows where any by-column is NULL are
+  excluded from the stratum breakdown.
 - Variable types are auto-classified from the catalog: integer / floating-
   point types are numeric, everything else (VARCHAR, BOOLEAN, ENUM,
   date/time) is categorical.
@@ -171,7 +176,7 @@ Output columns (long format, fixed schema):
 Pivot to wide for display:
 
 ```sql
-PIVOT table_one('patients', variables := ['age', 'sex'], by := 'arm')
+PIVOT table_one('patients', variables := ['age', 'sex'], by := ['arm'])
     ON stratum USING first(display)
     GROUP BY variable, level, statistic;
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ diagnostics, multiple-testing corrections, and more distribution families.
 | `jarque_bera(column)`                                                 | Jarque-Bera normality test                   |
 | `shapiro_wilk(column)`                                                | Shapiro-Wilk normality test (Royston AS R94) |
 | `anderson_darling(column)`                                            | Anderson-Darling normality test              |
+| `ks_test_1samp(column)`                                               | Kolmogorov-Smirnov one-sample (vs fitted normal) |
+| `ks_test_2samp(column1, column2)`                                     | Kolmogorov-Smirnov two-sample                |
 | `sign_test_1samp(column, [mu], [alternative])`                        | Sign test on the median                      |
 | `sign_test_paired(column1, column2, [alternative])`                   | Paired sign test                             |
 
@@ -94,6 +96,10 @@ p-value, and relevant effect sizes / confidence intervals.
 **Anderson-Darling:** `test_type`, `a_squared`, `a_squared_adjusted`, `p_value`, `n`
 
 **Shapiro-Wilk:** `test_type`, `w_statistic`, `p_value`, `n`
+
+**KS one-sample:** `test_type`, `d_statistic`, `p_value`, `n`
+
+**KS two-sample:** `test_type`, `d_statistic`, `p_value`, `n_x`, `n_y`
 
 **Sign test:** `test_type`, `m_statistic`, `n_pos`, `n_neg`, `n_zero`, `p_value`, `alternative`, `n`
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | Function                                          | Description                                                |
 | ------------------------------------------------- | ---------------------------------------------------------- |
 | `table_one(data, variables [, by])`               | Long-format descriptives table for mixed variable types    |
+| `corr_matrix(data, variables [, method])`         | Long-format pairwise correlation matrix (`pearson` / `spearman` / `kendall`) |
 
 ```sql
 SELECT * FROM table_one(

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `pexp(x, [rate])`        | Exponential CDF         |
 | `qexp(p, [rate])`        | Exponential quantile (closed form) |
 | `poibin_cdf(probs LIST<DOUBLE>, k BIGINT)` | Poisson Binomial CDF — `P(X ≤ k)` for `X = Σᵢ Bᵢ`, `Bᵢ ∼ Bernoulli(pᵢ)` |
+| `bin_edges(x [, method])` *(aggregate)* | Auto bin-edge vector for `x` — `sturges` (default), `fd`, `scott`, `sqrt`, `rice`, `auto` |
+| `bin_label(x, edges)` | Label for the bin containing `x` given an edge vector (typically from `bin_edges`) |
 
 ### Table 1 summary (table function)
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ VISUALIZE <expr> AS <aesthetic> [: <type>] (, <expr> AS <aesthetic> ...)
 FROM <table>
 DRAW <mark> (DRAW <mark>)*
 [FACET BY <expr> [ROWS | COLS]]
-[SCALE <channel> {TO <scheme> | ZERO true|false | DOMAIN <lo> <hi>}]*
+[SCALE <channel> {TO <scheme> | ZERO true|false | DOMAIN <lo> <hi> | LABEL '<text>'}]*
+[TITLE '<text>' [SUBTITLE '<text>']]
 ```
 
 **Marks:** `point`, `line`, `bar`, `histogram`, `text`, `area`, `rule`, `tick`,
@@ -241,6 +242,13 @@ ship their own marks without modifying stats_duck.
 **Type overrides:** append `:quantitative`, `:ordinal`, `:nominal`, or
 `:temporal` to an aesthetic to force its Vega-Lite type
 (e.g. `year AS color:ordinal`).
+
+**Axis labels:** `SCALE x LABEL 'Bill length (mm)'` injects an `axis.title` into
+the channel; pairs with `TO` / `ZERO` / `DOMAIN` on the same channel.
+
+**Titles:** `TITLE 'Plot title' [SUBTITLE 'Plot subtitle']` appears once per
+spec, after `SCALE` clauses. Always emitted as a Vega-Lite `TitleParams` object
+so a subtitle can be added without reshaping consumer code.
 
 ## SAS compatibility
 

--- a/README.md
+++ b/README.md
@@ -232,9 +232,17 @@ DRAW <mark> (DRAW <mark>)*
 ```
 
 **Marks:** `point`, `line`, `bar`, `histogram`, `text`, `area`, `rule`, `tick`,
-`errorbar`, `errorband`, `boxplot`. Custom marks register as `ggsql_mark_v1_<name>`
-scalar functions and are discovered via DuckDB's catalog, so other extensions can
-ship their own marks without modifying stats_duck.
+`errorbar`, `errorband`, `boxplot`, `heatmap`, `density`, `regression`. Custom
+marks register as `ggsql_mark_v1_<name>` scalar functions and are discovered
+via DuckDB's catalog, so other extensions can ship their own marks without
+modifying stats_duck.
+
+`heatmap` is a `rect` mark with ordinal x/y and quantitative color (correlation
+matrices, contingency tables). `density` runs Vega-Lite's KDE on the `x`
+aesthetic, grouped by `color` if mapped (one curve per category). `regression`
+fits a linear `y ~ x` model server-side via Vega-Lite's regression transform,
+also grouped by `color`. Use `DRAW point DRAW regression` for a scatter-with-
+fit overlay.
 
 **Aesthetic channels:** `x`, `y`, `color`, `fill`, `stroke`, `shape`, `size`,
 `opacity`, `tooltip`, `text`, `x2`, `y2`. Unknown channels are silently dropped.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `dexp(x, [rate])`        | Exponential PDF (rate=1 default) |
 | `pexp(x, [rate])`        | Exponential CDF         |
 | `qexp(p, [rate])`        | Exponential quantile (closed form) |
+| `poibin_cdf(probs LIST<DOUBLE>, k BIGINT)` | Poisson Binomial CDF — `P(X ≤ k)` for `X = Σᵢ Bᵢ`, `Bᵢ ∼ Bernoulli(pᵢ)` |
 
 ### Table 1 summary (table function)
 

--- a/patches/0001-fmt-secure-scl-msvc-v145.patch
+++ b/patches/0001-fmt-secure-scl-msvc-v145.patch
@@ -1,0 +1,19 @@
+diff --git a/third_party/fmt/include/fmt/format.h b/third_party/fmt/include/fmt/format.h
+index 4c51630104..d431ca18fb 100644
+--- a/third_party/fmt/include/fmt/format.h
++++ b/third_party/fmt/include/fmt/format.h
+@@ -321,7 +321,13 @@ inline typename Container::value_type* get_data(Container& c) {
+   return c.data();
+ }
+ 
+-#ifdef _SECURE_SCL
++// Local patch: MSVC v145 toolset (VS2026) removed `stdext::checked_array_iterator`.
++// Upstream fmt checks `#ifdef _SECURE_SCL`, but Microsoft's CRT auto-defines
++// `_SECURE_SCL` to 0 in Release builds (defined-but-zero), so the original
++// `#ifdef` branch hit the removed symbol. Check the value instead — Release
++// builds (_SECURE_SCL=0) now correctly take the plain-pointer branch. DuckDB
++// submodule modification: re-apply if the submodule moves; upstream candidate.
++#if defined(_SECURE_SCL) && _SECURE_SCL > 0
+ // Make a checked iterator to avoid MSVC warnings.
+ template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+ template <typename T> checked_ptr<T> make_checked(T* p, std::size_t size) {

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,47 @@
+# Local DuckDB submodule patches
+
+This directory holds small patches that need to be applied to the pinned
+`duckdb/` submodule before it will compile in some environments. They are
+candidates for upstream contribution; the parent repository keeps them here
+so the submodule pointer stays clean.
+
+## How to apply
+
+From the repository root:
+
+```sh
+cd duckdb && git apply ../patches/<patch-file>.patch
+```
+
+The submodule will appear as "modified content" in `git status` from the
+parent repo — that's expected and means the patch is in place.
+
+To revert (e.g. before updating the submodule):
+
+```sh
+cd duckdb && git checkout -- third_party/fmt/include/fmt/format.h
+```
+
+## Inventory
+
+### `0001-fmt-secure-scl-msvc-v145.patch`
+
+**Affects:** MSVC v145 toolset (VS2026) builds only. POSIX / older MSVC builds
+compile fine without it.
+
+**Symptom (without the patch):**
+```
+duckdb\third_party\fmt\include\fmt\format.h(326): error C2653:
+  'stdext': is not a class or namespace name
+```
+
+**Cause:** upstream fmt at this version checks `#ifdef _SECURE_SCL` to decide
+whether to wrap pointers in `stdext::checked_array_iterator`. Microsoft's CRT
+auto-defines `_SECURE_SCL` to `0` in Release builds (so `#ifdef` is true even
+when the value is `0`). The v145 toolset then removed
+`stdext::checked_array_iterator` entirely, so the wrapped-pointer branch
+fails to compile in Release.
+
+**Fix:** check the value, not just defined-ness — `#if defined(_SECURE_SCL) &&
+_SECURE_SCL > 0`. Release builds (`_SECURE_SCL=0`) correctly take the
+plain-pointer `else` branch.

--- a/src/auto_bin_function.cpp
+++ b/src/auto_bin_function.cpp
@@ -1,0 +1,442 @@
+#include "auto_bin_function.hpp"
+
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+namespace {
+
+//===--------------------------------------------------------------------===//
+// Methods
+//===--------------------------------------------------------------------===//
+
+enum class BinMethod {
+	STURGES,
+	FREEDMAN_DIACONIS,
+	SCOTT,
+	SQRT,
+	RICE,
+	AUTO,
+};
+
+static BinMethod ParseMethod(const std::string &name) {
+	if (name == "sturges") return BinMethod::STURGES;
+	if (name == "fd") return BinMethod::FREEDMAN_DIACONIS;
+	if (name == "scott") return BinMethod::SCOTT;
+	if (name == "sqrt") return BinMethod::SQRT;
+	if (name == "rice") return BinMethod::RICE;
+	if (name == "auto") return BinMethod::AUTO;
+	throw BinderException(
+	    "bin_edges: unknown method '%s' — supported: 'sturges', 'fd', "
+	    "'scott', 'sqrt', 'rice', 'auto'",
+	    name);
+}
+
+//===--------------------------------------------------------------------===//
+// Bind data (carries the constant method through to Finalize)
+//===--------------------------------------------------------------------===//
+
+struct BinEdgesBindData : public FunctionData {
+	BinMethod method = BinMethod::STURGES;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto copy = make_uniq<BinEdgesBindData>();
+		copy->method = method;
+		return std::move(copy);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<BinEdgesBindData>();
+		return method == other.method;
+	}
+};
+
+static unique_ptr<FunctionData>
+BinEdgesBindNoArg(ClientContext &, AggregateFunction &,
+                  vector<unique_ptr<Expression>> &) {
+	return make_uniq<BinEdgesBindData>();
+}
+
+static unique_ptr<FunctionData>
+BinEdgesBindMethod(ClientContext &context, AggregateFunction &function,
+                   vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("bin_edges: 'method' must be a constant string");
+	}
+	Value method_val = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
+	if (method_val.IsNull()) {
+		throw BinderException("bin_edges: 'method' must not be NULL");
+	}
+	auto bd = make_uniq<BinEdgesBindData>();
+	std::string method_str = StringUtil::Lower(method_val.GetValue<string>());
+	bd->method = ParseMethod(method_str);
+	Function::EraseArgument(function, arguments, 1);
+	return std::move(bd);
+}
+
+//===--------------------------------------------------------------------===//
+// State (buffer-based, lazy alloc — same shape as anderson_darling)
+//===--------------------------------------------------------------------===//
+
+struct BinEdgesState {
+	std::vector<double> *values;
+};
+
+static void BinEdgesInit(const AggregateFunction &, data_ptr_t state_p) {
+	auto &state = *reinterpret_cast<BinEdgesState *>(state_p);
+	state.values = nullptr;
+}
+
+static void BinEdgesUpdate(Vector inputs[], AggregateInputData &, idx_t,
+                            Vector &state_vector, idx_t count) {
+	UnifiedVectorFormat idata;
+	inputs[0].ToUnifiedFormat(count, idata);
+	auto states = FlatVector::GetData<BinEdgesState *>(state_vector);
+	auto values = UnifiedVectorFormat::GetData<double>(idata);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = idata.sel->get_index(i);
+		if (!idata.validity.RowIsValid(idx)) {
+			continue;
+		}
+		double v = values[idx];
+		if (std::isnan(v)) {
+			continue;
+		}
+		auto &state = *states[i];
+		if (!state.values) {
+			state.values = new std::vector<double>();
+		}
+		state.values->push_back(v);
+	}
+}
+
+static void BinEdgesCombine(Vector &source, Vector &target, AggregateInputData &, idx_t count) {
+	auto src = FlatVector::GetData<BinEdgesState *>(source);
+	auto tgt = FlatVector::GetData<BinEdgesState *>(target);
+	for (idx_t i = 0; i < count; i++) {
+		auto &s = *src[i];
+		auto &t = *tgt[i];
+		if (!s.values || s.values->empty()) {
+			continue;
+		}
+		if (!t.values) {
+			t.values = new std::vector<double>();
+		}
+		t.values->insert(t.values->end(), s.values->begin(), s.values->end());
+	}
+}
+
+static void BinEdgesDestroy(Vector &state_vector, AggregateInputData &, idx_t count) {
+	auto states = FlatVector::GetData<BinEdgesState *>(state_vector);
+	for (idx_t i = 0; i < count; i++) {
+		delete states[i]->values;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Bin-count rules
+//===--------------------------------------------------------------------===//
+
+//! Type-7 (R/Excel-INC) quantile from an already-sorted vector. Linear
+//! interpolation between adjacent order statistics; same formula used in
+//! summary_stats. Assumes n >= 1.
+static double Quantile7(const std::vector<double> &sorted, double p) {
+	idx_t n = sorted.size();
+	if (n == 1) {
+		return sorted[0];
+	}
+	double pos = p * (static_cast<double>(n) - 1.0);
+	idx_t lo = static_cast<idx_t>(std::floor(pos));
+	idx_t hi = static_cast<idx_t>(std::ceil(pos));
+	double frac = pos - static_cast<double>(lo);
+	return sorted[lo] + frac * (sorted[hi] - sorted[lo]);
+}
+
+//! Compute the bin count k for a sorted, non-degenerate sample (n >= 2,
+//! range > 0). FD and Scott silently fall back to Sturges when their
+//! width estimate is non-positive — same convention as numpy / R.
+static int ComputeBinCount(BinMethod method, const std::vector<double> &sorted) {
+	idx_t n = sorted.size();
+	double n_d = static_cast<double>(n);
+	double range = sorted.back() - sorted.front();
+
+	auto sturges = [&]() -> int {
+		return std::max(1, static_cast<int>(std::ceil(std::log2(n_d) + 1.0)));
+	};
+	auto fd = [&]() -> int {
+		double iqr = Quantile7(sorted, 0.75) - Quantile7(sorted, 0.25);
+		if (iqr <= 0.0) {
+			return sturges();
+		}
+		double width = 2.0 * iqr * std::pow(n_d, -1.0 / 3.0);
+		if (width <= 0.0) {
+			return sturges();
+		}
+		return std::max(1, static_cast<int>(std::ceil(range / width)));
+	};
+	auto scott = [&]() -> int {
+		double mean = std::accumulate(sorted.begin(), sorted.end(), 0.0) / n_d;
+		double sq = 0.0;
+		for (double v : sorted) {
+			double d = v - mean;
+			sq += d * d;
+		}
+		if (n < 2) {
+			return sturges();
+		}
+		double sd = std::sqrt(sq / (n_d - 1.0));
+		if (sd <= 0.0) {
+			return sturges();
+		}
+		double width = 3.5 * sd * std::pow(n_d, -1.0 / 3.0);
+		if (width <= 0.0) {
+			return sturges();
+		}
+		return std::max(1, static_cast<int>(std::ceil(range / width)));
+	};
+	auto sqrt_rule = [&]() -> int {
+		return std::max(1, static_cast<int>(std::ceil(std::sqrt(n_d))));
+	};
+	auto rice = [&]() -> int {
+		return std::max(1, static_cast<int>(std::ceil(2.0 * std::pow(n_d, 1.0 / 3.0))));
+	};
+
+	switch (method) {
+	case BinMethod::STURGES:
+		return sturges();
+	case BinMethod::FREEDMAN_DIACONIS:
+		return fd();
+	case BinMethod::SCOTT:
+		return scott();
+	case BinMethod::SQRT:
+		return sqrt_rule();
+	case BinMethod::RICE:
+		return rice();
+	case BinMethod::AUTO:
+		return std::max(sturges(), fd());
+	}
+	return sturges(); // unreachable, keep MSVC happy
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize — emit LIST<DOUBLE> per state
+//===--------------------------------------------------------------------===//
+
+static void BinEdgesFinalize(Vector &state_vector, AggregateInputData &input_data, Vector &result,
+                              idx_t count, idx_t offset) {
+	auto &bd = input_data.bind_data->Cast<BinEdgesBindData>();
+	auto states = FlatVector::GetData<BinEdgesState *>(state_vector);
+	auto list_entries = FlatVector::GetData<list_entry_t>(result);
+
+	// First pass: compute edges per row + total child elements.
+	std::vector<std::vector<double>> per_row(count);
+	std::vector<bool> per_row_null(count, false);
+	idx_t total_new_elements = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[i];
+		if (!state.values || state.values->size() < 2) {
+			// n=0 → null; n=1 → null (can't form a meaningful range)
+			per_row_null[i] = true;
+			continue;
+		}
+		auto &vals = *state.values;
+		std::sort(vals.begin(), vals.end());
+		double lo = vals.front();
+		double hi = vals.back();
+		if (hi <= lo) {
+			// All values equal — degenerate range, emit a single-point
+			// degenerate edge list so bin_label still has something to chew on.
+			per_row[i] = {lo, lo};
+			total_new_elements += 2;
+			continue;
+		}
+		int k = ComputeBinCount(bd.method, vals);
+		if (k < 1) {
+			k = 1;
+		}
+		per_row[i].reserve(static_cast<idx_t>(k) + 1);
+		for (int j = 0; j <= k; j++) {
+			per_row[i].push_back(lo + static_cast<double>(j) * (hi - lo) / static_cast<double>(k));
+		}
+		total_new_elements += per_row[i].size();
+	}
+
+	// Second pass: append child elements and stamp list_entry_t. Anchor the
+	// new child entries past whatever the result vector already holds (so
+	// repeated Finalize calls into the same chunk compose safely).
+	idx_t child_anchor = ListVector::GetListSize(result);
+	ListVector::Reserve(result, child_anchor + total_new_elements);
+	auto &child = ListVector::GetEntry(result);
+	auto child_data = FlatVector::GetData<double>(child);
+	idx_t out_offset = child_anchor;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = i + offset;
+		if (per_row_null[i]) {
+			FlatVector::SetNull(result, idx, true);
+			list_entries[idx] = list_entry_t(out_offset, 0);
+			continue;
+		}
+		auto &edges = per_row[i];
+		list_entries[idx] = list_entry_t(out_offset, edges.size());
+		for (idx_t j = 0; j < edges.size(); j++) {
+			child_data[out_offset + j] = edges[j];
+		}
+		out_offset += edges.size();
+	}
+	ListVector::SetListSize(result, out_offset);
+}
+
+//===--------------------------------------------------------------------===//
+// bin_label scalar
+//===--------------------------------------------------------------------===//
+
+//! Format a double for use in a bin label: %g chops trailing zeros and uses
+//! scientific notation only for very large / very small values. 6 sig figs
+//! is enough for typical clinical / scientific ranges.
+static std::string FormatEdge(double v) {
+	char buf[64];
+	std::snprintf(buf, sizeof(buf), "%g", v);
+	return buf;
+}
+
+static void BinLabelExec(DataChunk &args, ExpressionState &, Vector &result) {
+	idx_t row_count = args.size();
+	auto &x_input = args.data[0];
+	auto &edges_input = args.data[1];
+
+	UnifiedVectorFormat x_fmt, edges_fmt;
+	x_input.ToUnifiedFormat(row_count, x_fmt);
+	edges_input.ToUnifiedFormat(row_count, edges_fmt);
+	auto x_data = UnifiedVectorFormat::GetData<double>(x_fmt);
+	auto edges_entries = UnifiedVectorFormat::GetData<list_entry_t>(edges_fmt);
+
+	auto &edges_child = ListVector::GetEntry(edges_input);
+	UnifiedVectorFormat child_fmt;
+	edges_child.ToUnifiedFormat(ListVector::GetListSize(edges_input), child_fmt);
+	auto child_data = UnifiedVectorFormat::GetData<double>(child_fmt);
+
+	auto result_data = FlatVector::GetData<string_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < row_count; i++) {
+		auto x_idx = x_fmt.sel->get_index(i);
+		auto edges_idx = edges_fmt.sel->get_index(i);
+
+		if (!x_fmt.validity.RowIsValid(x_idx) || !edges_fmt.validity.RowIsValid(edges_idx)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		double x = x_data[x_idx];
+		if (std::isnan(x)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		auto entry = edges_entries[edges_idx];
+		// Need at least one full bin (two edges).
+		if (entry.length < 2) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		// Pull edges into a small local — typical k is <50 so the copy is cheap.
+		std::vector<double> edges(entry.length);
+		bool has_null_edge = false;
+		for (idx_t j = 0; j < entry.length; j++) {
+			auto child_idx = child_fmt.sel->get_index(entry.offset + j);
+			if (!child_fmt.validity.RowIsValid(child_idx)) {
+				has_null_edge = true;
+				break;
+			}
+			edges[j] = child_data[child_idx];
+		}
+		if (has_null_edge) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		double lo = edges.front();
+		double hi = edges.back();
+		// Out-of-range → NULL. The user can COALESCE if they want a sentinel.
+		if (x < lo || x > hi) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		// Locate the bin. The right edge is closed for the LAST bin only,
+		// so values equal to the maximum land in the final bin rather than
+		// triggering "no bin found".
+		idx_t n_bins = entry.length - 1;
+		idx_t bin = 0;
+		bool found = false;
+		for (idx_t j = 0; j < n_bins; j++) {
+			bool last = (j == n_bins - 1);
+			bool in_bin = last ? (x >= edges[j] && x <= edges[j + 1])
+			                   : (x >= edges[j] && x < edges[j + 1]);
+			if (in_bin) {
+				bin = j;
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		bool last = (bin == n_bins - 1);
+		std::string lo_s = FormatEdge(edges[bin]);
+		std::string hi_s = FormatEdge(edges[bin + 1]);
+		std::string label;
+		label.reserve(lo_s.size() + hi_s.size() + 4);
+		label.push_back('[');
+		label += lo_s;
+		label += ", ";
+		label += hi_s;
+		label.push_back(last ? ']' : ')');
+		result_data[i] = StringVector::AddString(result, label);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Factory helper
+//===--------------------------------------------------------------------===//
+
+static AggregateFunction MakeBinEdges(vector<LogicalType> args, bind_aggregate_function_t bind_fn) {
+	return AggregateFunction(
+	    "bin_edges", std::move(args), LogicalType::LIST(LogicalType::DOUBLE),
+	    AggregateFunction::StateSize<BinEdgesState>, BinEdgesInit, BinEdgesUpdate, BinEdgesCombine,
+	    BinEdgesFinalize, FunctionNullHandling::DEFAULT_NULL_HANDLING, nullptr, bind_fn,
+	    BinEdgesDestroy);
+}
+
+} // namespace
+
+void RegisterBinEdges(ExtensionLoader &loader) {
+	AggregateFunctionSet set("bin_edges");
+	set.AddFunction(MakeBinEdges({LogicalType::DOUBLE}, BinEdgesBindNoArg));
+	set.AddFunction(MakeBinEdges({LogicalType::DOUBLE, LogicalType::VARCHAR}, BinEdgesBindMethod));
+	loader.RegisterFunction(set);
+}
+
+void RegisterBinLabel(ExtensionLoader &loader) {
+	ScalarFunction fn("bin_label",
+	                  {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)},
+	                  LogicalType::VARCHAR, BinLabelExec);
+	loader.RegisterFunction(fn);
+}
+
+} // namespace duckdb

--- a/src/corr_matrix_function.cpp
+++ b/src/corr_matrix_function.cpp
@@ -1,0 +1,313 @@
+#include "corr_matrix_function.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include <cmath>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+namespace {
+
+//===--------------------------------------------------------------------===//
+// Method
+//===--------------------------------------------------------------------===//
+
+enum class CorrMethod {
+	PEARSON,
+	SPEARMAN,
+	KENDALL,
+};
+
+static CorrMethod ParseMethod(const std::string &name) {
+	if (name == "pearson") return CorrMethod::PEARSON;
+	if (name == "spearman") return CorrMethod::SPEARMAN;
+	if (name == "kendall") return CorrMethod::KENDALL;
+	throw BinderException(
+	    "corr_matrix: unknown method '%s' — supported: 'pearson', 'spearman', 'kendall'",
+	    name);
+}
+
+//! Aggregate function name + the struct field that holds the correlation
+//! coefficient for the chosen method. Pearson exposes it as `.r`, Spearman
+//! as `.rho`, Kendall as `.tau` — we paper over the difference by aliasing
+//! into a common `coef` output column.
+struct MethodSql {
+	const char *func;
+	const char *coef_field;
+};
+
+static MethodSql MethodSqlOf(CorrMethod m) {
+	switch (m) {
+	case CorrMethod::PEARSON:
+		return {"pearson_test", "r"};
+	case CorrMethod::SPEARMAN:
+		return {"spearman_test", "rho"};
+	case CorrMethod::KENDALL:
+		return {"kendall_test", "tau"};
+	}
+	return {"pearson_test", "r"}; // unreachable
+}
+
+//===--------------------------------------------------------------------===//
+// State + bind data
+//===--------------------------------------------------------------------===//
+
+struct CorrMatrixRow {
+	std::string row_var;
+	std::string col_var;
+	double coef;     // NaN → emitted as NULL
+	double p_value;  // NaN → emitted as NULL
+	int64_t n;       // negative → NULL (use -1 sentinel)
+
+	CorrMatrixRow(std::string row_var, std::string col_var, double coef, double p_value, int64_t n)
+	    : row_var(std::move(row_var)), col_var(std::move(col_var)), coef(coef), p_value(p_value),
+	      n(n) {
+	}
+};
+
+struct CorrMatrixBindData : public TableFunctionData {
+	std::string data_table;
+	std::vector<std::string> variables;
+	CorrMethod method = CorrMethod::PEARSON;
+};
+
+struct CorrMatrixGlobalState : public GlobalTableFunctionState {
+	std::vector<CorrMatrixRow> rows;
+	idx_t cursor = 0;
+};
+
+//===--------------------------------------------------------------------===//
+// Helpers
+//===--------------------------------------------------------------------===//
+
+static std::string QuoteIdent(const std::string &raw) {
+	std::string out;
+	out.reserve(raw.size() + 2);
+	out.push_back('"');
+	for (char c : raw) {
+		if (c == '"') {
+			out.push_back('"');
+		}
+		out.push_back(c);
+	}
+	out.push_back('"');
+	return out;
+}
+
+//! Classification mirrors table_one's IsNumericKind. Anything we can cast to
+//! DOUBLE safely is fair game for a correlation; everything else is rejected
+//! at bind time so the user sees a clear error rather than a runtime cast.
+static bool IsNumericKind(LogicalTypeId tid) {
+	switch (tid) {
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::UHUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return true;
+	default:
+		return false;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Bind
+//===--------------------------------------------------------------------===//
+
+static unique_ptr<FunctionData> CorrMatrixBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types,
+                                                vector<string> &names) {
+	auto bd = make_uniq<CorrMatrixBindData>();
+
+	if (input.inputs.empty() || input.inputs[0].IsNull()) {
+		throw BinderException("corr_matrix: 'data' (source table name) is required");
+	}
+	bd->data_table = input.inputs[0].GetValue<string>();
+
+	auto it_vars = input.named_parameters.find("variables");
+	if (it_vars == input.named_parameters.end() || it_vars->second.IsNull()) {
+		throw BinderException("corr_matrix: 'variables' list is required");
+	}
+	auto &vars_children = ListValue::GetChildren(it_vars->second);
+	for (auto &v : vars_children) {
+		if (v.IsNull()) {
+			throw BinderException("corr_matrix: 'variables' list entries must not be NULL");
+		}
+		bd->variables.push_back(v.GetValue<string>());
+	}
+	if (bd->variables.size() < 2) {
+		throw BinderException("corr_matrix: 'variables' must contain at least 2 columns");
+	}
+
+	auto it_method = input.named_parameters.find("method");
+	if (it_method != input.named_parameters.end() && !it_method->second.IsNull()) {
+		std::string method_str = StringUtil::Lower(it_method->second.GetValue<string>());
+		bd->method = ParseMethod(method_str);
+	}
+
+	// Catalog lookup — confirm each variable exists and is numeric.
+	auto &catalog = Catalog::GetCatalog(context, INVALID_CATALOG);
+	auto &schema = DEFAULT_SCHEMA;
+	auto entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, schema, bd->data_table,
+	                              OnEntryNotFound::THROW_EXCEPTION);
+	auto &tbl = entry->Cast<TableCatalogEntry>();
+	auto &cols = tbl.GetColumns();
+	for (auto &v : bd->variables) {
+		if (!cols.ColumnExists(v)) {
+			throw BinderException("corr_matrix: column '%s' not found in table '%s'", v,
+			                      bd->data_table);
+		}
+		auto &col = cols.GetColumn(v);
+		if (!IsNumericKind(col.GetType().id())) {
+			throw BinderException(
+			    "corr_matrix: column '%s' is not numeric (type %s); "
+			    "correlation requires numeric columns",
+			    v, col.GetType().ToString());
+		}
+	}
+
+	names = {"row_var", "col_var", "coef", "p_value", "n"};
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE,
+	                LogicalType::DOUBLE, LogicalType::BIGINT};
+	return std::move(bd);
+}
+
+//===--------------------------------------------------------------------===//
+// InitGlobal — compute upper triangle once, mirror to fill the matrix
+//===--------------------------------------------------------------------===//
+
+static unique_ptr<GlobalTableFunctionState>
+CorrMatrixInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	auto &bd = input.bind_data->Cast<CorrMatrixBindData>();
+	auto state = make_uniq<CorrMatrixGlobalState>();
+
+	Connection conn(*context.db);
+	MethodSql msql = MethodSqlOf(bd.method);
+
+	idx_t k = bd.variables.size();
+
+	// Provisional storage: index by [row_idx][col_idx]. Filled on the upper
+	// triangle and mirrored to the lower so emission order is deterministic.
+	struct Cell {
+		double coef;
+		double p_value;
+		int64_t n;
+		bool set;
+	};
+	std::vector<std::vector<Cell>> grid(k, std::vector<Cell>(k, {std::nan(""), std::nan(""), -1, false}));
+
+	auto run_pair = [&](idx_t i, idx_t j) {
+		std::stringstream sql;
+		sql << "SELECT (s)." << msql.coef_field << " AS coef, "
+		    << "(s).p_value AS p, "
+		    << "(s).n AS n "
+		    << "FROM (SELECT " << msql.func << "(" << QuoteIdent(bd.variables[i])
+		    << "::DOUBLE, " << QuoteIdent(bd.variables[j]) << "::DOUBLE) AS s "
+		    << "FROM " << QuoteIdent(bd.data_table) << ")";
+		auto result = conn.Query(sql.str());
+		Cell cell{std::nan(""), std::nan(""), -1, true};
+		if (!result->HasError()) {
+			auto chunk = result->Fetch();
+			if (chunk && chunk->size() > 0) {
+				auto v_coef = chunk->GetValue(0, 0);
+				auto v_p = chunk->GetValue(1, 0);
+				auto v_n = chunk->GetValue(2, 0);
+				if (!v_coef.IsNull()) {
+					cell.coef = v_coef.GetValue<double>();
+				}
+				if (!v_p.IsNull()) {
+					cell.p_value = v_p.GetValue<double>();
+				}
+				if (!v_n.IsNull()) {
+					cell.n = v_n.GetValue<int64_t>();
+				}
+			}
+		}
+		grid[i][j] = cell;
+		if (i != j) {
+			// Correlations are symmetric for all three supported methods —
+			// no need to recompute.
+			grid[j][i] = cell;
+		}
+	};
+
+	for (idx_t i = 0; i < k; i++) {
+		for (idx_t j = i; j < k; j++) {
+			run_pair(i, j);
+		}
+	}
+
+	// Emit in declaration order so a PIVOT lands the rows / cols in the
+	// user's chosen sequence.
+	state->rows.reserve(k * k);
+	for (idx_t i = 0; i < k; i++) {
+		for (idx_t j = 0; j < k; j++) {
+			auto &c = grid[i][j];
+			state->rows.emplace_back(bd.variables[i], bd.variables[j], c.coef, c.p_value, c.n);
+		}
+	}
+
+	return std::move(state);
+}
+
+//===--------------------------------------------------------------------===//
+// Execute
+//===--------------------------------------------------------------------===//
+
+static void CorrMatrixExecute(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	auto &state = input.global_state->Cast<CorrMatrixGlobalState>();
+	idx_t emitted = 0;
+	while (state.cursor < state.rows.size() && emitted < STANDARD_VECTOR_SIZE) {
+		auto &row = state.rows[state.cursor++];
+		output.SetValue(0, emitted, Value(row.row_var));
+		output.SetValue(1, emitted, Value(row.col_var));
+		if (std::isnan(row.coef)) {
+			FlatVector::SetNull(output.data[2], emitted, true);
+		} else {
+			output.SetValue(2, emitted, Value::DOUBLE(row.coef));
+		}
+		if (std::isnan(row.p_value)) {
+			FlatVector::SetNull(output.data[3], emitted, true);
+		} else {
+			output.SetValue(3, emitted, Value::DOUBLE(row.p_value));
+		}
+		if (row.n < 0) {
+			FlatVector::SetNull(output.data[4], emitted, true);
+		} else {
+			output.SetValue(4, emitted, Value::BIGINT(row.n));
+		}
+		emitted++;
+	}
+	output.SetCardinality(emitted);
+}
+
+} // namespace
+
+void RegisterCorrMatrix(ExtensionLoader &loader) {
+	TableFunction fn("corr_matrix", {LogicalType::VARCHAR}, CorrMatrixExecute, CorrMatrixBind,
+	                  CorrMatrixInitGlobal);
+	fn.named_parameters["variables"] = LogicalType::LIST(LogicalType::VARCHAR);
+	fn.named_parameters["method"] = LogicalType::VARCHAR;
+	loader.RegisterFunction(fn);
+}
+
+} // namespace duckdb

--- a/src/distribution_functions.cpp
+++ b/src/distribution_functions.cpp
@@ -188,6 +188,132 @@ static void QFExec(DataChunk &args, ExpressionState &, Vector &result) {
 	    });
 }
 
+// ── Gamma ───────────────────────────────────────────────────────────────────
+
+static void DGamma2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double shape, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::GammaPDF(x, shape); }, mask, idx);
+	    });
+}
+
+static void DGamma3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double shape, double rate, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::GammaPDF(x, shape, rate); }, mask, idx);
+	    });
+}
+
+static void PGamma2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double shape, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::GammaCDF(x, shape); }, mask, idx);
+	    });
+}
+
+static void PGamma3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double shape, double rate, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::GammaCDF(x, shape, rate); }, mask, idx);
+	    });
+}
+
+static void QGamma2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double p, double shape, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::GammaQuantile(p, shape); }, mask, idx);
+	    });
+}
+
+static void QGamma3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double p, double shape, double rate, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::GammaQuantile(p, shape, rate); }, mask, idx);
+	    });
+}
+
+// ── Beta ────────────────────────────────────────────────────────────────────
+
+static void DBetaExec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double alpha, double beta, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::BetaPDF(x, alpha, beta); }, mask, idx);
+	    });
+}
+
+static void PBetaExec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double alpha, double beta, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::BetaCDF(x, alpha, beta); }, mask, idx);
+	    });
+}
+
+static void QBetaExec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double p, double alpha, double beta, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::BetaQuantile(p, alpha, beta); }, mask, idx);
+	    });
+}
+
+// ── Exponential ─────────────────────────────────────────────────────────────
+
+static void DExpStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	UnaryExecutor::ExecuteWithNulls<double, double>(
+	    args.data[0], result, args.size(),
+	    [](double x, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::ExponentialPDF(x); }, mask, idx);
+	    });
+}
+
+static void DExp2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double rate, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::ExponentialPDF(x, rate); }, mask, idx);
+	    });
+}
+
+static void PExpStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	UnaryExecutor::ExecuteWithNulls<double, double>(
+	    args.data[0], result, args.size(),
+	    [](double x, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::ExponentialCDF(x); }, mask, idx);
+	    });
+}
+
+static void PExp2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double rate, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::ExponentialCDF(x, rate); }, mask, idx);
+	    });
+}
+
+static void QExpStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	UnaryExecutor::ExecuteWithNulls<double, double>(
+	    args.data[0], result, args.size(),
+	    [](double p, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::ExponentialQuantile(p); }, mask, idx);
+	    });
+}
+
+static void QExp2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double p, double rate, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::ExponentialQuantile(p, rate); }, mask, idx);
+	    });
+}
+
 } // namespace
 
 void RegisterDistributionFunctions(ExtensionLoader &loader) {
@@ -230,6 +356,54 @@ void RegisterDistributionFunctions(ExtensionLoader &loader) {
 	loader.RegisterFunction(ScalarFunction("df", {DBL, DBL, DBL}, DBL, DFExec));
 	loader.RegisterFunction(ScalarFunction("pf", {DBL, DBL, DBL}, DBL, PFExec));
 	loader.RegisterFunction(ScalarFunction("qf", {DBL, DBL, DBL}, DBL, QFExec));
+
+	// ── Gamma ───────────────────────────────────────────────────────────────
+	// dgamma(x, shape) defaults rate = 1; dgamma(x, shape, rate) for the
+	// explicit form. Matches R's `dgamma(x, shape, rate = 1)`.
+	{
+		ScalarFunctionSet dgamma("dgamma");
+		dgamma.AddFunction(ScalarFunction({DBL, DBL}, DBL, DGamma2Exec));
+		dgamma.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, DGamma3Exec));
+		loader.RegisterFunction(dgamma);
+	}
+	{
+		ScalarFunctionSet pgamma("pgamma");
+		pgamma.AddFunction(ScalarFunction({DBL, DBL}, DBL, PGamma2Exec));
+		pgamma.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, PGamma3Exec));
+		loader.RegisterFunction(pgamma);
+	}
+	{
+		ScalarFunctionSet qgamma("qgamma");
+		qgamma.AddFunction(ScalarFunction({DBL, DBL}, DBL, QGamma2Exec));
+		qgamma.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, QGamma3Exec));
+		loader.RegisterFunction(qgamma);
+	}
+
+	// ── Beta ────────────────────────────────────────────────────────────────
+	loader.RegisterFunction(ScalarFunction("dbeta", {DBL, DBL, DBL}, DBL, DBetaExec));
+	loader.RegisterFunction(ScalarFunction("pbeta", {DBL, DBL, DBL}, DBL, PBetaExec));
+	loader.RegisterFunction(ScalarFunction("qbeta", {DBL, DBL, DBL}, DBL, QBetaExec));
+
+	// ── Exponential ─────────────────────────────────────────────────────────
+	// One-arg form defaults rate = 1 (matches R's `dexp(x, rate = 1)`).
+	{
+		ScalarFunctionSet dexp("dexp");
+		dexp.AddFunction(ScalarFunction({DBL}, DBL, DExpStdExec));
+		dexp.AddFunction(ScalarFunction({DBL, DBL}, DBL, DExp2Exec));
+		loader.RegisterFunction(dexp);
+	}
+	{
+		ScalarFunctionSet pexp("pexp");
+		pexp.AddFunction(ScalarFunction({DBL}, DBL, PExpStdExec));
+		pexp.AddFunction(ScalarFunction({DBL, DBL}, DBL, PExp2Exec));
+		loader.RegisterFunction(pexp);
+	}
+	{
+		ScalarFunctionSet qexp("qexp");
+		qexp.AddFunction(ScalarFunction({DBL}, DBL, QExpStdExec));
+		qexp.AddFunction(ScalarFunction({DBL, DBL}, DBL, QExp2Exec));
+		loader.RegisterFunction(qexp);
+	}
 }
 
 } // namespace duckdb

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -22,7 +22,16 @@ namespace ggsql {
 namespace {
 
 string BuildProjectedSql(const VisualizeStatement &stmt) {
-	string sql = "SELECT ";
+	string sql;
+	// Prepend any leading WITH clause so the FROM and aesthetic expressions
+	// can resolve CTE-bound names. CTEs are scoped to the inner query when a
+	// mark wraps the projection (e.g. `SELECT * FROM (<projected>) ORDER BY x`),
+	// so passing the WITH through verbatim composes cleanly with line / bar /
+	// area / errorband / regression wraps without any extra plumbing.
+	if (!stmt.with_clause.empty()) {
+		sql += stmt.with_clause + " ";
+	}
+	sql += "SELECT ";
 	for (size_t i = 0; i < stmt.aesthetics.size(); i++) {
 		if (i > 0) {
 			sql += ", ";
@@ -333,11 +342,120 @@ bool StartsWithIdentifier(const string &lower, const string &keyword) {
 	return next == ' ' || next == '\t' || next == '\n' || next == '\r' || next == ';';
 }
 
+// Strip leading whitespace and SQL comments (`-- to end of line`, `/* ... */`)
+// from the front of `s`. DuckDB hands the parser extension the raw statement
+// text including any comments, so we need to skip past them before deciding
+// whether the statement is ours.
+static void SkipLeadingCommentsAndWhitespace(string &s) {
+	size_t i = 0;
+	while (i < s.size()) {
+		char c = s[i];
+		if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+			i++;
+			continue;
+		}
+		if (c == '-' && i + 1 < s.size() && s[i + 1] == '-') {
+			i += 2;
+			while (i < s.size() && s[i] != '\n') {
+				i++;
+			}
+			continue;
+		}
+		if (c == '/' && i + 1 < s.size() && s[i + 1] == '*') {
+			i += 2;
+			while (i + 1 < s.size() && !(s[i] == '*' && s[i + 1] == '/')) {
+				i++;
+			}
+			if (i + 1 < s.size()) {
+				i += 2; // past `*/`
+			}
+			continue;
+		}
+		break;
+	}
+	if (i > 0) {
+		s.erase(0, i);
+	}
+}
+
 ParserExtensionParseResult GgsqlParse(ParserExtensionInfo *, const string &query) {
 	string trimmed = query;
-	StringUtil::Trim(trimmed);
+	SkipLeadingCommentsAndWhitespace(trimmed);
+	StringUtil::Trim(trimmed); // trailing whitespace too
 	auto lower = StringUtil::Lower(trimmed);
-	if (!StartsWithIdentifier(lower, "visualize")) {
+	if (StartsWithIdentifier(lower, "visualize")) {
+		// Direct path — bare VISUALIZE statement.
+	} else if (StartsWithIdentifier(lower, "with")) {
+		// Could be ours (WITH … VISUALIZE …) or DuckDB's (WITH … SELECT …).
+		// Only claim it if a top-level VISUALIZE keyword exists in the
+		// input — case-insensitive, whole-word match, ignoring strings /
+		// quoted identifiers / parenthesised expressions. The cheap
+		// approach is a manual scan rather than a full tokenize: keep
+		// track of paren depth and skip over string/quoted-ident content,
+		// then look for `visualize` as a standalone token at depth 0.
+		bool has_visualize = false;
+		int depth = 0;
+		char quote = 0;
+		auto is_ident_part = [](char c) {
+			return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			       (c >= '0' && c <= '9') || c == '_';
+		};
+		for (size_t i = 0; i < trimmed.size(); i++) {
+			char c = trimmed[i];
+			if (quote != 0) {
+				if (c == quote) {
+					if (i + 1 < trimmed.size() && trimmed[i + 1] == quote) {
+						i++; // SQL '' / "" escape
+					} else {
+						quote = 0;
+					}
+				}
+				continue;
+			}
+			if (c == '\'' || c == '"') {
+				quote = c;
+				continue;
+			}
+			if (c == '(') {
+				depth++;
+				continue;
+			}
+			if (c == ')') {
+				depth--;
+				continue;
+			}
+			if (depth > 0) {
+				continue;
+			}
+			// At depth 0: try to match the whole-word "visualize" case-insensitively.
+			if ((c == 'v' || c == 'V') && i + 9 <= trimmed.size()) {
+				static const char kKeyword[] = "visualize";
+				bool match = true;
+				for (size_t k = 0; k < 9; k++) {
+					char a = trimmed[i + k];
+					char b = kKeyword[k];
+					char a_lower = (a >= 'A' && a <= 'Z') ? (a - 'A' + 'a') : a;
+					if (a_lower != b) {
+						match = false;
+						break;
+					}
+				}
+				if (match) {
+					// Must be a standalone token — surrounded by non-identifier chars.
+					bool left_ok = (i == 0) || !is_ident_part(trimmed[i - 1]);
+					bool right_ok = (i + 9 == trimmed.size()) ||
+					                !is_ident_part(trimmed[i + 9]);
+					if (left_ok && right_ok) {
+						has_visualize = true;
+						break;
+					}
+				}
+			}
+		}
+		if (!has_visualize) {
+			return ParserExtensionParseResult(); // hand off to DuckDB
+		}
+	} else {
 		return ParserExtensionParseResult();
 	}
 	auto parsed = ParseGgsql(trimmed);

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -14,6 +14,8 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parser/parser_extension.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
 namespace ggsql {
 
@@ -66,25 +68,34 @@ bool HasFacet(const VisualizeStatement &stmt) {
 	return false;
 }
 
-// Inject `,"scale":{<merged-properties>}` into each encoding channel that has
-// at least one matching ScaleSpec. Relies on the current encoding format using
-// only primitive sub-properties (no nested objects), so the first '}' after the
-// channel's opening '{' is the closing brace. Multiple SCALE clauses on the
-// same channel merge into one scale object.
+// Inject channel sub-objects (e.g. `,"scale":{...}` for TO/ZERO/DOMAIN,
+// `,"axis":{...}` for LABEL) into each encoding channel that has at least one
+// matching ScaleSpec. Relies on the current encoding format using only
+// primitive sub-properties at this point (no nested objects), so the first '}'
+// after the channel's opening '{' is its closing brace. Multiple ScaleSpec
+// entries on the same (channel, sub_object) merge into one block; multiple
+// sub_objects on the same channel each produce their own block.
 string ApplyScales(string layer_body, const vector<ScaleSpec> &scales) {
-	// Preserve user-specified order while grouping by channel.
-	std::map<string, string> merged; // channel → comma-separated "key":value list
-	std::vector<string> order;
+	// channel → sub_object → "k1":v1,"k2":v2  (within-block insertion order preserved)
+	std::map<string, std::map<string, string>> by_channel;
+	std::vector<string> channel_order;
+	std::map<string, std::vector<string>> sub_obj_order; // per-channel sub_object insertion order
 	for (const auto &scale : scales) {
-		auto it = merged.find(scale.aesthetic);
-		if (it == merged.end()) {
-			merged[scale.aesthetic] = "\"" + scale.property + "\":" + scale.value_json;
-			order.push_back(scale.aesthetic);
-		} else {
-			it->second += ",\"" + scale.property + "\":" + scale.value_json;
+		auto &props = by_channel[scale.aesthetic][scale.sub_object];
+		if (!props.empty()) {
+			props += ",";
+		}
+		props += "\"" + scale.property + "\":" + scale.value_json;
+		auto &ch_subs = sub_obj_order[scale.aesthetic];
+		if (std::find(ch_subs.begin(), ch_subs.end(), scale.sub_object) == ch_subs.end()) {
+			ch_subs.push_back(scale.sub_object);
+		}
+		if (std::find(channel_order.begin(), channel_order.end(), scale.aesthetic) ==
+		    channel_order.end()) {
+			channel_order.push_back(scale.aesthetic);
 		}
 	}
-	for (const auto &channel : order) {
+	for (const auto &channel : channel_order) {
 		string needle = "\"" + channel + "\":{";
 		size_t pos = layer_body.find(needle);
 		if (pos == string::npos) {
@@ -95,10 +106,28 @@ string ApplyScales(string layer_body, const vector<ScaleSpec> &scales) {
 		if (close_brace == string::npos) {
 			continue;
 		}
-		string injection = ",\"scale\":{" + merged[channel] + "}";
+		string injection;
+		for (const auto &sub_obj : sub_obj_order[channel]) {
+			injection += ",\"" + sub_obj + "\":{" + by_channel[channel][sub_obj] + "}";
+		}
 		layer_body.insert(close_brace, injection);
 	}
 	return layer_body;
+}
+
+// Build the Vega-Lite title block. Returns "" if no title is set. The block is
+// always emitted as a TitleParams object (not a bare string) so that subtitle
+// can be added without changing the shape; this keeps fixture output stable.
+string BuildTitleBlock(const VisualizeStatement &stmt) {
+	if (stmt.title.empty()) {
+		return "";
+	}
+	string out = ",\"title\":{\"text\":\"" + JsonEscape(stmt.title) + "\"";
+	if (!stmt.subtitle.empty()) {
+		out += ",\"subtitle\":\"" + JsonEscape(stmt.subtitle) + "\"";
+	}
+	out += "}";
+	return out;
 }
 
 // Replace the rendered "type":"..." inside the targeted channel with the user's
@@ -150,6 +179,8 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	}
 	CompiledResult out;
 
+	string title_block = BuildTitleBlock(stmt);
+
 	if (stmt.layers.size() == 1) {
 		// Single layer: emit canonical Vega-Lite single-view shape (top-level
 		// data + mark + encoding). When faceted, wrap mark/encoding inside a
@@ -171,6 +202,7 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 		} else {
 			spec += rendered.layer_body;
 		}
+		spec += title_block;
 		spec += "}";
 
 		out.spec_json = std::move(spec);
@@ -207,6 +239,7 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	} else {
 		spec += layer_array;
 	}
+	spec += title_block;
 	spec += "}";
 	out.spec_json = std::move(spec);
 	return out;

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -177,6 +177,27 @@ ParseResult ParseGgsql(const string &query) {
 		return true;
 	};
 
+	// Optional leading `WITH … VISUALIZE`. Capture every top-level token from
+	// the WITH up to (but not including) VISUALIZE — the tokenizer already
+	// flattens parenthesised CTE bodies into single tokens, so we don't need
+	// to track depth here. Reconstruct the SQL by joining with single spaces;
+	// SQL is whitespace-tolerant, so `WITH t AS (…) , u AS (…)` parses the
+	// same as `WITH t AS (…), u AS (…)`.
+	if (!at_end() && IEqual(peek(), "WITH")) {
+		string with_text;
+		while (!at_end() && !IEqual(peek(), "VISUALIZE")) {
+			if (!with_text.empty()) {
+				with_text += " ";
+			}
+			with_text += tokens[i++];
+		}
+		if (at_end()) {
+			result.error = "WITH clause is not followed by VISUALIZE";
+			return result;
+		}
+		result.stmt.with_clause = std::move(with_text);
+	}
+
 	if (!consume("VISUALIZE")) {
 		return result;
 	}

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -95,6 +95,63 @@ bool IEqual(const string &tok, const char *kw) {
 
 } // namespace
 
+string UnquoteSqlString(const string &raw) {
+	if (raw.size() < 2 || raw.front() != '\'' || raw.back() != '\'') {
+		return raw;
+	}
+	string out;
+	out.reserve(raw.size() - 2);
+	for (size_t i = 1; i + 1 < raw.size(); i++) {
+		// Collapse SQL '' escape to a single quote.
+		if (raw[i] == '\'' && i + 2 < raw.size() && raw[i + 1] == '\'') {
+			out += '\'';
+			i++;
+		} else {
+			out += raw[i];
+		}
+	}
+	return out;
+}
+
+string JsonEscape(const string &s) {
+	string out;
+	out.reserve(s.size());
+	for (unsigned char c : s) {
+		switch (c) {
+		case '"':
+			out += "\\\"";
+			break;
+		case '\\':
+			out += "\\\\";
+			break;
+		case '\b':
+			out += "\\b";
+			break;
+		case '\f':
+			out += "\\f";
+			break;
+		case '\n':
+			out += "\\n";
+			break;
+		case '\r':
+			out += "\\r";
+			break;
+		case '\t':
+			out += "\\t";
+			break;
+		default:
+			if (c < 0x20) {
+				char buf[8];
+				snprintf(buf, sizeof(buf), "\\u%04x", c);
+				out += buf;
+			} else {
+				out += static_cast<char>(c);
+			}
+		}
+	}
+	return out;
+}
+
 ParseResult ParseGgsql(const string &query) {
 	ParseResult result;
 	auto tokenized = Tokenize(query);
@@ -233,7 +290,8 @@ ParseResult ParseGgsql(const string &query) {
 	}
 	result.stmt.from_table = tokens[i++];
 
-	while (!at_end() && !IEqual(peek(), "FACET") && !IEqual(peek(), "SCALE")) {
+	while (!at_end() && !IEqual(peek(), "FACET") && !IEqual(peek(), "SCALE") &&
+	       !IEqual(peek(), "TITLE") && !IEqual(peek(), "SUBTITLE")) {
 		if (!consume("DRAW")) {
 			return result;
 		}
@@ -260,13 +318,14 @@ ParseResult ParseGgsql(const string &query) {
 			return result;
 		}
 		if (at_end() || IEqual(peek(), "SCALE") || IEqual(peek(), "ROWS") ||
-		    IEqual(peek(), "COLS")) {
+		    IEqual(peek(), "COLS") || IEqual(peek(), "TITLE") || IEqual(peek(), "SUBTITLE")) {
 			result.error = "Expected expression after 'FACET BY'";
 			return result;
 		}
 		string expr;
 		while (!at_end() && !IEqual(peek(), "SCALE") && !IEqual(peek(), "ROWS") &&
-		       !IEqual(peek(), "COLS")) {
+		       !IEqual(peek(), "COLS") && !IEqual(peek(), "TITLE") &&
+		       !IEqual(peek(), "SUBTITLE")) {
 			if (!expr.empty()) {
 				expr += " ";
 			}
@@ -339,12 +398,43 @@ ParseResult ParseGgsql(const string &query) {
 			string hi = tokens[i++];
 			scale.property = "domain";
 			scale.value_json = "[" + lo + "," + hi + "]";
+		} else if (IEqual(op, "LABEL")) {
+			if (at_end()) {
+				result.error = "Expected axis label after 'SCALE <aesthetic> LABEL'";
+				return result;
+			}
+			scale.sub_object = "axis";
+			scale.property = "title";
+			scale.value_json = "\"" + JsonEscape(UnquoteSqlString(tokens[i++])) + "\"";
 		} else {
 			result.error = "Unknown SCALE operator '" + op +
-			               "' (expected TO / ZERO / DOMAIN)";
+			               "' (expected TO / ZERO / DOMAIN / LABEL)";
 			return result;
 		}
 		result.stmt.scales.push_back(std::move(scale));
+	}
+
+	// Optional `TITLE '<text>' [SUBTITLE '<text>']`. SUBTITLE without TITLE is
+	// rejected — keeps the surface area honest (Vega-Lite ignores a subtitle
+	// without a title anyway, so silently accepting it would mask typos).
+	if (!at_end() && IEqual(peek(), "TITLE")) {
+		i++;
+		if (at_end()) {
+			result.error = "Expected title text after 'TITLE'";
+			return result;
+		}
+		result.stmt.title = UnquoteSqlString(tokens[i++]);
+		if (!at_end() && IEqual(peek(), "SUBTITLE")) {
+			i++;
+			if (at_end()) {
+				result.error = "Expected subtitle text after 'SUBTITLE'";
+				return result;
+			}
+			result.stmt.subtitle = UnquoteSqlString(tokens[i++]);
+		}
+	} else if (!at_end() && IEqual(peek(), "SUBTITLE")) {
+		result.error = "SUBTITLE requires a preceding TITLE clause";
+		return result;
 	}
 
 	if (!at_end()) {

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -194,6 +194,79 @@ MarkResult RenderBoxplot(const MarkContext &ctx) {
 	return r;
 }
 
+MarkResult RenderHeatmap(const MarkContext &ctx) {
+	// Rect mark with categorical-by-default x/y and quantitative color. Both
+	// axes override to ordinal because the typical heatmap (correlation matrix,
+	// contingency table, factor-by-factor counts) uses discrete bins; users
+	// who want a continuous-binned heatmap can type-override the channel back.
+	MarkResult r;
+	r.layer_body = "\"mark\":\"rect\",\"encoding\":" +
+	               BuildEncoding(ctx, kStandardChannels,
+	                             {{"x", "ordinal"}, {"y", "ordinal"}, {"color", "quantitative"}});
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
+// Build a "groupby":["color"] fragment iff the user mapped the color aesthetic.
+// Used by density / regression transforms so multi-curve overlays work without
+// an extra clause.
+string BuildGroupbyExtra(const MarkContext &ctx) {
+	if (HasAesthetic(ctx, "color")) {
+		return ",\"groupby\":[\"color\"]";
+	}
+	return "";
+}
+
+// Build optional-channel fragments (color, opacity, ...) for marks that splice
+// their own x/y encoding (histogram / density / regression). Returns "" if no
+// optional channels are mapped; otherwise the leading "," is included so the
+// caller can concatenate directly.
+string BuildOptionalChannels(const MarkContext &ctx) {
+	string out;
+	for (const auto &ch : kStandardChannels) {
+		string name = ch.name;
+		if (name == "x" || name == "y") {
+			continue;
+		}
+		string fragment = BuildChannel(ctx, name, ch.vega_type, "");
+		if (!fragment.empty()) {
+			out += "," + fragment;
+		}
+	}
+	return out;
+}
+
+MarkResult RenderDensity(const MarkContext &ctx) {
+	// Vega-Lite density transform consumes the underlying field `x` and emits
+	// fields `value` (x-axis) and `density` (y-axis). When the user mapped a
+	// color aesthetic, group by it to produce one density curve per level.
+	string transform = "\"transform\":[{\"density\":\"x\"" + BuildGroupbyExtra(ctx) + "}]";
+	string encoding = "{\"x\":{\"field\":\"value\",\"type\":\"quantitative\"},"
+	                  "\"y\":{\"field\":\"density\",\"type\":\"quantitative\"}";
+	encoding += BuildOptionalChannels(ctx);
+	encoding += "}";
+	MarkResult r;
+	r.layer_body = transform + ",\"mark\":\"area\",\"encoding\":" + encoding;
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
+MarkResult RenderRegression(const MarkContext &ctx) {
+	// Vega-Lite regression transform fits y ~ x and emits the same field names
+	// back as the smoothed line. Grouped by color when mapped so each category
+	// gets its own fit line.
+	string transform =
+	    "\"transform\":[{\"regression\":\"y\",\"on\":\"x\"" + BuildGroupbyExtra(ctx) + "}]";
+	string encoding = "{\"x\":{\"field\":\"x\",\"type\":\"quantitative\"},"
+	                  "\"y\":{\"field\":\"y\",\"type\":\"quantitative\"}";
+	encoding += BuildOptionalChannels(ctx);
+	encoding += "}";
+	MarkResult r;
+	r.layer_body = transform + ",\"mark\":\"line\",\"encoding\":" + encoding;
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
 MarkResult RenderHistogram(const MarkContext &ctx) {
 	// Histogram's x is binned and y is computed (aggregate:count, no field).
 	// Optional channels (color, opacity, ...) come from kStandardChannels but x
@@ -275,6 +348,13 @@ void RegisterBuiltinMarks(ExtensionLoader &loader) {
 	RegisterMark(loader, "errorbar", {"x", "y"}, RenderErrorbar);
 	RegisterMark(loader, "errorband", {"x", "y"}, RenderErrorband);
 	RegisterMark(loader, "boxplot", {"x", "y"}, RenderBoxplot);
+	// Heatmap (categorical-axis rect), density (KDE area), and regression
+	// (linear-fit line). Density and regression rely on Vega-Lite transforms,
+	// so they ignore the underlying row order — safe to emit projected_sql
+	// directly. Color is the grouping aesthetic for both transforms.
+	RegisterMark(loader, "heatmap", {"x", "y", "color"}, RenderHeatmap);
+	RegisterMark(loader, "density", {"x"}, RenderDensity);
+	RegisterMark(loader, "regression", {"x", "y"}, RenderRegression);
 }
 
 } // namespace ggsql

--- a/src/include/auto_bin_function.hpp
+++ b/src/include/auto_bin_function.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// bin_edges(x [, method]) → LIST<DOUBLE>
+//   Buffer-based aggregate that computes the bin-edge vector for a numeric
+//   column under one of six classical rules. Returns the edges as a sorted
+//   LIST<DOUBLE> of length k+1 (so the caller can inspect / plot the
+//   boundaries directly). Methods (case-insensitive, default 'sturges'):
+//     'sturges'   — k = ceil(log2(n) + 1)        (R's hist() default)
+//     'fd'        — Freedman-Diaconis: bin_width = 2·IQR·n^(-1/3)
+//     'scott'     — bin_width = 3.5·sd·n^(-1/3)  (normal-reference rule)
+//     'sqrt'      — k = ceil(sqrt(n))            (Excel default)
+//     'rice'      — k = ceil(2·n^(1/3))
+//     'auto'      — max(sturges, fd)             (numpy's default)
+//
+//   Degenerate inputs (n < 2, or all values equal, or IQR/sd = 0 in FD/Scott)
+//   silently fall back to Sturges. Empty / all-NULL group → NULL output.
+void RegisterBinEdges(ExtensionLoader &loader);
+
+// bin_label(x, edges) → VARCHAR
+//   Maps a value to the formatted label `[lo, hi)` for the bin containing x,
+//   where the bin is defined by adjacent entries of the `edges` vector
+//   (typically produced by bin_edges). The right-most bin is closed on the
+//   right (`[lo, hi]`) so the maximum value is never dropped. Returns NULL
+//   for x outside the [edges[0], edges[last]] range or for any NULL input.
+void RegisterBinLabel(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/corr_matrix_function.hpp
+++ b/src/include/corr_matrix_function.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// corr_matrix(tbl, variables := [...] [, method := 'pearson']) → TABLE
+//
+// Long-format pairwise correlation matrix as a DuckDB table function.
+// Emits one row per ordered pair (row_var, col_var) — including self-pairs on
+// the diagonal and both (a, b) / (b, a) mirrors — so the result feeds the
+// ggsql `heatmap` mark directly without a CROSS JOIN.
+//
+// Schema:  row_var VARCHAR, col_var VARCHAR, coef DOUBLE, p_value DOUBLE, n BIGINT
+//
+// `coef` is the chosen method's correlation coefficient: Pearson r, Spearman
+// rho, or Kendall tau — the column name stays method-agnostic so a single
+// downstream pipeline works across all three. NULLs in the source columns
+// are excluded pairwise.
+void RegisterCorrMatrix(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/distributions.hpp
+++ b/src/include/distributions.hpp
@@ -426,4 +426,184 @@ inline double FQuantile(double p, double df1, double df2) {
 	return 0.5 * (lo + hi);
 }
 
+// ── Gamma distribution ──────────────────────────────────────────────────────
+// Parametrization: shape α > 0, rate β > 0 (matching R's default rate form;
+// scale = 1/rate). PDF = β^α / Γ(α) · x^(α-1) · e^(-βx) on x ≥ 0.
+
+inline double GammaPDF(double x, double shape, double rate = 1.0) {
+	if (shape <= 0.0 || rate <= 0.0) {
+		throw std::invalid_argument("shape and rate must be > 0");
+	}
+	if (x < 0.0) {
+		return 0.0;
+	}
+	if (x == 0.0) {
+		if (shape < 1.0) {
+			return std::numeric_limits<double>::infinity();
+		}
+		if (shape == 1.0) {
+			return rate;
+		}
+		return 0.0;
+	}
+	double log_pdf = shape * std::log(rate) + (shape - 1.0) * std::log(x) - rate * x -
+	                 std::lgamma(shape);
+	return std::exp(log_pdf);
+}
+
+inline double GammaCDF(double x, double shape, double rate = 1.0) {
+	if (shape <= 0.0 || rate <= 0.0) {
+		throw std::invalid_argument("shape and rate must be > 0");
+	}
+	if (x <= 0.0) {
+		return 0.0;
+	}
+	return GammaP(shape, rate * x);
+}
+
+inline double GammaQuantile(double p, double shape, double rate = 1.0) {
+	if (shape <= 0.0 || rate <= 0.0) {
+		throw std::invalid_argument("shape and rate must be > 0");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	if (p == 0.0) {
+		return 0.0;
+	}
+	if (p == 1.0) {
+		return std::numeric_limits<double>::infinity();
+	}
+
+	// Bracket via the mean (shape/rate); expand until CDF(hi) ≥ p.
+	double lo = 0.0;
+	double hi = std::max(shape / rate * 2.0, 1.0 / rate);
+	while (GammaCDF(hi, shape, rate) < p) {
+		hi *= 2.0;
+	}
+	for (int i = 0; i < 100; i++) {
+		double mid = 0.5 * (lo + hi);
+		if (GammaCDF(mid, shape, rate) < p) {
+			lo = mid;
+		} else {
+			hi = mid;
+		}
+	}
+	return 0.5 * (lo + hi);
+}
+
+// ── Beta distribution ───────────────────────────────────────────────────────
+// Shape parameters α, β > 0, support [0, 1]. PDF = x^(α-1)(1-x)^(β-1) / B(α, β).
+
+inline double BetaPDF(double x, double alpha, double beta) {
+	if (alpha <= 0.0 || beta <= 0.0) {
+		throw std::invalid_argument("alpha and beta must be > 0");
+	}
+	if (x < 0.0 || x > 1.0) {
+		return 0.0;
+	}
+	if (x == 0.0) {
+		if (alpha < 1.0) {
+			return std::numeric_limits<double>::infinity();
+		}
+		if (alpha == 1.0) {
+			return beta;
+		}
+		return 0.0;
+	}
+	if (x == 1.0) {
+		if (beta < 1.0) {
+			return std::numeric_limits<double>::infinity();
+		}
+		if (beta == 1.0) {
+			return alpha;
+		}
+		return 0.0;
+	}
+	double log_pdf =
+	    (alpha - 1.0) * std::log(x) + (beta - 1.0) * std::log(1.0 - x) - LogBeta(alpha, beta);
+	return std::exp(log_pdf);
+}
+
+inline double BetaCDF(double x, double alpha, double beta) {
+	if (alpha <= 0.0 || beta <= 0.0) {
+		throw std::invalid_argument("alpha and beta must be > 0");
+	}
+	if (x <= 0.0) {
+		return 0.0;
+	}
+	if (x >= 1.0) {
+		return 1.0;
+	}
+	return BetaIncomplete(alpha, beta, x);
+}
+
+inline double BetaQuantile(double p, double alpha, double beta) {
+	if (alpha <= 0.0 || beta <= 0.0) {
+		throw std::invalid_argument("alpha and beta must be > 0");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	if (p == 0.0) {
+		return 0.0;
+	}
+	if (p == 1.0) {
+		return 1.0;
+	}
+
+	// Bisect on [0, 1] — support is bounded, no need to expand.
+	double lo = 0.0;
+	double hi = 1.0;
+	for (int i = 0; i < 100; i++) {
+		double mid = 0.5 * (lo + hi);
+		if (BetaCDF(mid, alpha, beta) < p) {
+			lo = mid;
+		} else {
+			hi = mid;
+		}
+	}
+	return 0.5 * (lo + hi);
+}
+
+// ── Exponential distribution ────────────────────────────────────────────────
+// Rate λ > 0. PDF = λ · e^(-λx) on x ≥ 0. Special case of Gamma(1, λ) but
+// worth a closed-form path because the quantile is analytic.
+
+inline double ExponentialPDF(double x, double rate = 1.0) {
+	if (rate <= 0.0) {
+		throw std::invalid_argument("rate must be > 0");
+	}
+	if (x < 0.0) {
+		return 0.0;
+	}
+	return rate * std::exp(-rate * x);
+}
+
+inline double ExponentialCDF(double x, double rate = 1.0) {
+	if (rate <= 0.0) {
+		throw std::invalid_argument("rate must be > 0");
+	}
+	if (x <= 0.0) {
+		return 0.0;
+	}
+	return 1.0 - std::exp(-rate * x);
+}
+
+inline double ExponentialQuantile(double p, double rate = 1.0) {
+	if (rate <= 0.0) {
+		throw std::invalid_argument("rate must be > 0");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	if (p == 0.0) {
+		return 0.0;
+	}
+	if (p == 1.0) {
+		return std::numeric_limits<double>::infinity();
+	}
+	return -std::log(1.0 - p) / rate;
+}
+
 } // namespace stats_duck

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -33,6 +33,11 @@ struct VisualizeStatement {
 	string facet_layout; // "" (grid), "rows", or "cols" — only meaningful when a facet aesthetic is present
 	string title;        // "" if not set; raw text (caller JSON-escapes for output)
 	string subtitle;     // "" if not set; SUBTITLE alone (no TITLE) is rejected at parse time
+	// Optional leading `WITH [RECURSIVE] <cte> AS (...) [, ...]` block. Captured
+	// verbatim as a single SQL string and prepended to each layer's projected
+	// SQL so the FROM clause and aesthetic expressions can reference CTEs.
+	// Empty string when no WITH clause was provided.
+	string with_clause;
 };
 
 // Strip surrounding single quotes from a SQL string literal and collapse '' → '.

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -13,9 +13,10 @@ struct DrawLayer {
 };
 
 struct ScaleSpec {
-	string aesthetic;  // channel to scale (x, y, color, ...)
-	string property;   // Vega-Lite scale property: "scheme", "domain", "zero", ...
-	string value_json; // value formatted as JSON ('"viridis"', '[0,100]', 'false', ...)
+	string aesthetic;             // channel to scale (x, y, color, ...)
+	string sub_object = "scale";  // channel sub-object: "scale" (TO/ZERO/DOMAIN) or "axis" (LABEL)
+	string property;              // sub-object property: "scheme", "domain", "zero", "title", ...
+	string value_json;            // value formatted as JSON ('"viridis"', '[0,100]', 'false', '"My label"', ...)
 };
 
 struct TypeOverride {
@@ -30,7 +31,17 @@ struct VisualizeStatement {
 	vector<ScaleSpec> scales;
 	vector<TypeOverride> type_overrides;
 	string facet_layout; // "" (grid), "rows", or "cols" — only meaningful when a facet aesthetic is present
+	string title;        // "" if not set; raw text (caller JSON-escapes for output)
+	string subtitle;     // "" if not set; SUBTITLE alone (no TITLE) is rejected at parse time
 };
+
+// Strip surrounding single quotes from a SQL string literal and collapse '' → '.
+// Tokens without surrounding single quotes are returned unchanged (so bare
+// identifiers like `viridis` remain usable for operators that accept either).
+string UnquoteSqlString(const string &raw);
+
+// Escape a raw string for embedding inside a JSON string literal.
+string JsonEscape(const string &s);
 
 struct ParseResult {
 	bool success = false;

--- a/src/include/ks_test_function.hpp
+++ b/src/include/ks_test_function.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// Register `ks_test_1samp(x)` — one-sample Kolmogorov-Smirnov test against the
+// fitted normal N(mean(x), sd(x)). Returns
+// STRUCT(test_type, d_statistic, p_value, n). P-value via the asymptotic
+// Kolmogorov distribution with Stephens (1970) small-sample correction;
+// because the parameters are estimated from the sample, the p-value is
+// conservative — pair with shapiro_wilk / anderson_darling when normality
+// is the primary question.
+void RegisterKsTest1Samp(ExtensionLoader &loader);
+
+// Register `ks_test_2samp(x, y)` — two-sample Kolmogorov-Smirnov test on
+// whether x and y come from the same underlying distribution. Returns
+// STRUCT(test_type, d_statistic, p_value, n_x, n_y). P-value via the
+// asymptotic Kolmogorov distribution evaluated at the effective sample
+// size n_x*n_y/(n_x+n_y).
+void RegisterKsTest2Samp(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/poibin_function.hpp
+++ b/src/include/poibin_function.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// Register `poibin_cdf(probs LIST<DOUBLE>, k BIGINT) → DOUBLE` — CDF of the
+// Poisson Binomial distribution: the sum X = Σᵢ Bᵢ where each Bᵢ is an
+// independent Bernoulli(pᵢ) with its own success probability.
+//
+// Returns P(X ≤ k). Computed by Hong (2013)'s direct convolution method —
+// O(n²) time, O(n) memory, numerically stable for the n that show up in
+// biostat-scale queries (typically n ≤ a few hundred).
+//
+// NULL handling: NULL in either argument → NULL output. NULL inside the
+// `probs` list → NULL output (one bad probability invalidates the whole
+// sum). Any pᵢ outside [0, 1] → NULL.
+void RegisterPoibinCdf(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/ks_test_function.cpp
+++ b/src/ks_test_function.cpp
@@ -1,0 +1,372 @@
+#include "ks_test_function.hpp"
+
+#include "distributions.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace duckdb {
+
+namespace {
+
+//===--------------------------------------------------------------------===//
+// Shared: asymptotic Kolmogorov distribution p-value
+//===--------------------------------------------------------------------===//
+
+// Kolmogorov distribution survival function:
+//   Q(λ) = 2 · Σ_{k≥1} (-1)^(k-1) · exp(-2 · k² · λ²)
+// Returns the two-sided KS p-value. Converges rapidly; we cap at 100 terms
+// and bail when an additional term contributes less than 1e-12 of the running
+// sum (terms alternate signs and decay super-exponentially).
+double KolmogorovQ(double lambda) {
+	if (lambda <= 0.0) {
+		return 1.0;
+	}
+	double sum = 0.0;
+	double last_term = 0.0;
+	int sign = 1;
+	for (int k = 1; k < 101; k++) {
+		double term = std::exp(-2.0 * k * k * lambda * lambda);
+		sum += sign * term;
+		if (k > 1 && std::fabs(term) < 1e-12 * std::fabs(sum) && term < last_term) {
+			break;
+		}
+		last_term = term;
+		sign = -sign;
+	}
+	double p = 2.0 * sum;
+	if (p < 0.0) {
+		p = 0.0;
+	} else if (p > 1.0) {
+		p = 1.0;
+	}
+	return p;
+}
+
+// Stephens (1970) small-sample correction to the asymptotic λ. Same form used
+// by Numerical Recipes' kstest / kstwo: λ_eff = (√en + 0.12 + 0.11/√en) · D.
+// `en` is the effective sample size (n for 1-sample, n1*n2/(n1+n2) for 2-sample).
+double KsPValue(double d_statistic, double en) {
+	double sqrt_en = std::sqrt(en);
+	double lambda = (sqrt_en + 0.12 + 0.11 / sqrt_en) * d_statistic;
+	return KolmogorovQ(lambda);
+}
+
+//===--------------------------------------------------------------------===//
+// Result struct schemas
+//===--------------------------------------------------------------------===//
+
+LogicalType KsTest1SampResultType() {
+	child_list_t<LogicalType> children;
+	children.push_back({"test_type", LogicalType::VARCHAR});
+	children.push_back({"d_statistic", LogicalType::DOUBLE});
+	children.push_back({"p_value", LogicalType::DOUBLE});
+	children.push_back({"n", LogicalType::BIGINT});
+	return LogicalType::STRUCT(std::move(children));
+}
+
+LogicalType KsTest2SampResultType() {
+	child_list_t<LogicalType> children;
+	children.push_back({"test_type", LogicalType::VARCHAR});
+	children.push_back({"d_statistic", LogicalType::DOUBLE});
+	children.push_back({"p_value", LogicalType::DOUBLE});
+	children.push_back({"n_x", LogicalType::BIGINT});
+	children.push_back({"n_y", LogicalType::BIGINT});
+	return LogicalType::STRUCT(std::move(children));
+}
+
+//===--------------------------------------------------------------------===//
+// One-sample KS — vs fitted N(mean, sd)
+//===--------------------------------------------------------------------===//
+
+struct Ks1SampState {
+	std::vector<double> *values;
+};
+
+static void Ks1Init(const AggregateFunction &, data_ptr_t state_p) {
+	auto &state = *reinterpret_cast<Ks1SampState *>(state_p);
+	state.values = nullptr;
+}
+
+static void Ks1Update(Vector inputs[], AggregateInputData &, idx_t, Vector &state_vector, idx_t count) {
+	UnifiedVectorFormat idata;
+	inputs[0].ToUnifiedFormat(count, idata);
+	auto states = FlatVector::GetData<Ks1SampState *>(state_vector);
+	auto values = UnifiedVectorFormat::GetData<double>(idata);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = idata.sel->get_index(i);
+		if (!idata.validity.RowIsValid(idx)) {
+			continue;
+		}
+		double v = values[idx];
+		if (std::isnan(v)) {
+			continue;
+		}
+		auto &state = *states[i];
+		if (!state.values) {
+			state.values = new std::vector<double>();
+		}
+		state.values->push_back(v);
+	}
+}
+
+static void Ks1Combine(Vector &source, Vector &target, AggregateInputData &, idx_t count) {
+	auto src = FlatVector::GetData<Ks1SampState *>(source);
+	auto tgt = FlatVector::GetData<Ks1SampState *>(target);
+	for (idx_t i = 0; i < count; i++) {
+		auto &s = *src[i];
+		auto &t = *tgt[i];
+		if (!s.values || s.values->empty()) {
+			continue;
+		}
+		if (!t.values) {
+			t.values = new std::vector<double>();
+		}
+		t.values->insert(t.values->end(), s.values->begin(), s.values->end());
+	}
+}
+
+static void Ks1Destroy(Vector &state_vector, AggregateInputData &, idx_t count) {
+	auto states = FlatVector::GetData<Ks1SampState *>(state_vector);
+	for (idx_t i = 0; i < count; i++) {
+		delete states[i]->values;
+	}
+}
+
+static void Ks1Finalize(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count, idx_t offset) {
+	auto states = FlatVector::GetData<Ks1SampState *>(state_vector);
+	auto &children = StructVector::GetEntries(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[i];
+		auto idx = i + offset;
+		// Need at least 3 points to estimate mean and sd meaningfully and
+		// have anything sensible to compare.
+		if (!state.values || state.values->size() < 3) {
+			FlatVector::SetNull(result, idx, true);
+			continue;
+		}
+
+		auto &values = *state.values;
+		idx_t n = values.size();
+		double n_d = static_cast<double>(n);
+		std::sort(values.begin(), values.end());
+
+		double mean = 0.0;
+		for (double v : values) {
+			mean += v;
+		}
+		mean /= n_d;
+		double sx2 = 0.0;
+		for (double v : values) {
+			double diff = v - mean;
+			sx2 += diff * diff;
+		}
+		// Sample standard deviation (n-1 denominator); zero variance ⇒
+		// degenerate sample, can't compare to a normal.
+		if (sx2 <= 0.0) {
+			FlatVector::SetNull(result, idx, true);
+			continue;
+		}
+		double sd = std::sqrt(sx2 / (n_d - 1.0));
+
+		// KS statistic: at each sorted x_(i+1), the ECDF jumps from i/n to
+		// (i+1)/n. The KS sup-norm is the larger of the "before-jump" and
+		// "after-jump" gaps from the reference CDF.
+		double d = 0.0;
+		for (idx_t k = 0; k < n; k++) {
+			double f = stats_duck::NormalCDF(values[k], mean, sd);
+			double f_n_lower = static_cast<double>(k) / n_d;
+			double f_n_upper = static_cast<double>(k + 1) / n_d;
+			double gap_lo = std::fabs(f - f_n_lower);
+			double gap_hi = std::fabs(f_n_upper - f);
+			if (gap_lo > d) {
+				d = gap_lo;
+			}
+			if (gap_hi > d) {
+				d = gap_hi;
+			}
+		}
+
+		double p = KsPValue(d, n_d);
+
+		FlatVector::GetData<string_t>(*children[0])[idx] =
+		    StringVector::AddString(*children[0], "Kolmogorov-Smirnov (one-sample, fitted normal)");
+		FlatVector::GetData<double>(*children[1])[idx] = d;
+		FlatVector::GetData<double>(*children[2])[idx] = p;
+		FlatVector::GetData<int64_t>(*children[3])[idx] = static_cast<int64_t>(n);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Two-sample KS — compare two ECDFs
+//===--------------------------------------------------------------------===//
+
+struct Ks2SampState {
+	std::vector<double> *x;
+	std::vector<double> *y;
+};
+
+static void Ks2Init(const AggregateFunction &, data_ptr_t state_p) {
+	auto &state = *reinterpret_cast<Ks2SampState *>(state_p);
+	state.x = nullptr;
+	state.y = nullptr;
+}
+
+static void Ks2Update(Vector inputs[], AggregateInputData &, idx_t, Vector &state_vector, idx_t count) {
+	UnifiedVectorFormat x_data, y_data;
+	inputs[0].ToUnifiedFormat(count, x_data);
+	inputs[1].ToUnifiedFormat(count, y_data);
+	auto states = FlatVector::GetData<Ks2SampState *>(state_vector);
+	auto xs = UnifiedVectorFormat::GetData<double>(x_data);
+	auto ys = UnifiedVectorFormat::GetData<double>(y_data);
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[i];
+		auto xi = x_data.sel->get_index(i);
+		auto yi = y_data.sel->get_index(i);
+		// Each column contributes independently — NULL in x doesn't drop the
+		// row from y. Matches ttest_2samp's per-column NULL handling.
+		if (x_data.validity.RowIsValid(xi)) {
+			double v = xs[xi];
+			if (!std::isnan(v)) {
+				if (!state.x) {
+					state.x = new std::vector<double>();
+				}
+				state.x->push_back(v);
+			}
+		}
+		if (y_data.validity.RowIsValid(yi)) {
+			double v = ys[yi];
+			if (!std::isnan(v)) {
+				if (!state.y) {
+					state.y = new std::vector<double>();
+				}
+				state.y->push_back(v);
+			}
+		}
+	}
+}
+
+static void Ks2Combine(Vector &source, Vector &target, AggregateInputData &, idx_t count) {
+	auto src = FlatVector::GetData<Ks2SampState *>(source);
+	auto tgt = FlatVector::GetData<Ks2SampState *>(target);
+	for (idx_t i = 0; i < count; i++) {
+		auto &s = *src[i];
+		auto &t = *tgt[i];
+		if (s.x && !s.x->empty()) {
+			if (!t.x) {
+				t.x = new std::vector<double>();
+			}
+			t.x->insert(t.x->end(), s.x->begin(), s.x->end());
+		}
+		if (s.y && !s.y->empty()) {
+			if (!t.y) {
+				t.y = new std::vector<double>();
+			}
+			t.y->insert(t.y->end(), s.y->begin(), s.y->end());
+		}
+	}
+}
+
+static void Ks2Destroy(Vector &state_vector, AggregateInputData &, idx_t count) {
+	auto states = FlatVector::GetData<Ks2SampState *>(state_vector);
+	for (idx_t i = 0; i < count; i++) {
+		delete states[i]->x;
+		delete states[i]->y;
+	}
+}
+
+static void Ks2Finalize(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count, idx_t offset) {
+	auto states = FlatVector::GetData<Ks2SampState *>(state_vector);
+	auto &children = StructVector::GetEntries(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[i];
+		auto idx = i + offset;
+		idx_t nx = state.x ? state.x->size() : 0;
+		idx_t ny = state.y ? state.y->size() : 0;
+		// Need at least one observation in each sample.
+		if (nx == 0 || ny == 0) {
+			FlatVector::SetNull(result, idx, true);
+			continue;
+		}
+
+		auto &xs = *state.x;
+		auto &ys = *state.y;
+		std::sort(xs.begin(), xs.end());
+		std::sort(ys.begin(), ys.end());
+
+		// Standard two-pointer scan over the merged order. At each step we
+		// advance whichever pointer points to the smaller value (ties advance
+		// both, with one ECDF cycling through the tie group before D is
+		// re-evaluated).
+		double d = 0.0;
+		idx_t i_x = 0, i_y = 0;
+		double f_x = 0.0, f_y = 0.0;
+		double inv_nx = 1.0 / static_cast<double>(nx);
+		double inv_ny = 1.0 / static_cast<double>(ny);
+		while (i_x < nx && i_y < ny) {
+			double v_x = xs[i_x];
+			double v_y = ys[i_y];
+			if (v_x <= v_y) {
+				do {
+					i_x++;
+					f_x += inv_nx;
+				} while (i_x < nx && xs[i_x] == v_x);
+			}
+			if (v_y <= v_x) {
+				do {
+					i_y++;
+					f_y += inv_ny;
+				} while (i_y < ny && ys[i_y] == v_y);
+			}
+			double gap = std::fabs(f_x - f_y);
+			if (gap > d) {
+				d = gap;
+			}
+		}
+		// Tail: one ECDF is at 1, the other still climbing — the maximum gap
+		// can only have grown earlier, but recheck to be safe against
+		// floating-point drift.
+		// (The loop above also covers this: once one pointer hits the end,
+		// we exit, and the other ECDF being below 1 means the prior gap is
+		// already accounted for.)
+
+		double nx_d = static_cast<double>(nx);
+		double ny_d = static_cast<double>(ny);
+		double en = nx_d * ny_d / (nx_d + ny_d);
+		double p = KsPValue(d, en);
+
+		FlatVector::GetData<string_t>(*children[0])[idx] =
+		    StringVector::AddString(*children[0], "Kolmogorov-Smirnov (two-sample)");
+		FlatVector::GetData<double>(*children[1])[idx] = d;
+		FlatVector::GetData<double>(*children[2])[idx] = p;
+		FlatVector::GetData<int64_t>(*children[3])[idx] = static_cast<int64_t>(nx);
+		FlatVector::GetData<int64_t>(*children[4])[idx] = static_cast<int64_t>(ny);
+	}
+}
+
+} // namespace
+
+void RegisterKsTest1Samp(ExtensionLoader &loader) {
+	AggregateFunction fn("ks_test_1samp", {LogicalType::DOUBLE}, KsTest1SampResultType(),
+	                     AggregateFunction::StateSize<Ks1SampState>, Ks1Init, Ks1Update, Ks1Combine,
+	                     Ks1Finalize, FunctionNullHandling::DEFAULT_NULL_HANDLING, nullptr, nullptr,
+	                     Ks1Destroy);
+	loader.RegisterFunction(fn);
+}
+
+void RegisterKsTest2Samp(ExtensionLoader &loader) {
+	AggregateFunction fn("ks_test_2samp", {LogicalType::DOUBLE, LogicalType::DOUBLE},
+	                     KsTest2SampResultType(), AggregateFunction::StateSize<Ks2SampState>, Ks2Init,
+	                     Ks2Update, Ks2Combine, Ks2Finalize, FunctionNullHandling::DEFAULT_NULL_HANDLING,
+	                     nullptr, nullptr, Ks2Destroy);
+	loader.RegisterFunction(fn);
+}
+
+} // namespace duckdb

--- a/src/poibin_function.cpp
+++ b/src/poibin_function.cpp
@@ -1,0 +1,151 @@
+#include "poibin_function.hpp"
+
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include <cmath>
+#include <vector>
+
+namespace duckdb {
+
+// Poisson Binomial distribution CDF — the distribution of X = Σᵢ Bᵢ where
+// each Bᵢ ∼ Bernoulli(pᵢ) is independent but the pᵢ may differ.
+//
+// Algorithm: direct convolution (Hong 2013, "On computing the distribution
+// function for the Poisson binomial distribution"). Start with pmf = [1, 0, …]
+// (no trials → P(X=0) = 1) and fold each trial in by replacing
+//   new_pmf[j] = pmf[j-1] · pᵢ + pmf[j] · (1 - pᵢ)
+// updating top-down in place so we never read a stale slot. O(n²) time,
+// O(n) memory; stable for moderate n.
+
+namespace {
+
+//! Returns P(X ≤ k) or NaN to signal an invalid input that should surface as
+//! NULL. `probs_validity` parallels `probs`: any false entry indicates a NULL
+//! probability and short-circuits to NaN.
+static double PoibinCdf(const std::vector<double> &probs,
+                        const std::vector<bool> &probs_validity, int64_t k) {
+	idx_t n = probs.size();
+	// Validate the probabilities first — one bad entry invalidates the whole
+	// sum, since we have no principled way to "skip" a Bernoulli.
+	for (idx_t i = 0; i < n; i++) {
+		if (!probs_validity[i]) {
+			return std::nan("");
+		}
+		double p = probs[i];
+		if (std::isnan(p) || p < 0.0 || p > 1.0) {
+			return std::nan("");
+		}
+	}
+
+	if (k < 0) {
+		return 0.0;
+	}
+	if (n == 0) {
+		// Empty sum → X = 0 deterministically, so P(X ≤ k) = 1 for any k ≥ 0.
+		return 1.0;
+	}
+	if (static_cast<idx_t>(k) >= n) {
+		return 1.0;
+	}
+
+	// pmf[j] = P(X = j) after the trials processed so far. Allocate one slot
+	// per possible value (0..n).
+	std::vector<double> pmf(n + 1, 0.0);
+	pmf[0] = 1.0;
+
+	for (idx_t i = 0; i < n; i++) {
+		double p = probs[i];
+		double q = 1.0 - p;
+		// After trial i, max occupied index is i+1. Update top-down so each
+		// slot reads the pre-update value from j-1 before being overwritten.
+		idx_t max_j = i + 1;
+		pmf[max_j] = pmf[max_j - 1] * p;
+		for (idx_t j = max_j - 1; j >= 1; j--) {
+			pmf[j] = pmf[j - 1] * p + pmf[j] * q;
+		}
+		pmf[0] *= q;
+	}
+
+	double cdf = 0.0;
+	idx_t k_cap = static_cast<idx_t>(k);
+	for (idx_t j = 0; j <= k_cap; j++) {
+		cdf += pmf[j];
+	}
+	// Clamp away tiny floating-point overshoot from the convolution.
+	if (cdf > 1.0) {
+		cdf = 1.0;
+	} else if (cdf < 0.0) {
+		cdf = 0.0;
+	}
+	return cdf;
+}
+
+static void PoibinCdfExec(DataChunk &args, ExpressionState &, Vector &result) {
+	idx_t row_count = args.size();
+	auto &list_input = args.data[0];
+	auto &k_input = args.data[1];
+
+	UnifiedVectorFormat list_fmt, k_fmt;
+	list_input.ToUnifiedFormat(row_count, list_fmt);
+	k_input.ToUnifiedFormat(row_count, k_fmt);
+	auto list_entries = UnifiedVectorFormat::GetData<list_entry_t>(list_fmt);
+	auto k_data = UnifiedVectorFormat::GetData<int64_t>(k_fmt);
+
+	auto &input_child = ListVector::GetEntry(list_input);
+	UnifiedVectorFormat child_fmt;
+	input_child.ToUnifiedFormat(ListVector::GetListSize(list_input), child_fmt);
+	auto child_data = UnifiedVectorFormat::GetData<double>(child_fmt);
+
+	auto result_data = FlatVector::GetData<double>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	std::vector<double> probs_buf;
+	std::vector<bool> validity_buf;
+
+	for (idx_t i = 0; i < row_count; i++) {
+		auto list_idx = list_fmt.sel->get_index(i);
+		auto k_idx = k_fmt.sel->get_index(i);
+
+		if (!list_fmt.validity.RowIsValid(list_idx) ||
+		    !k_fmt.validity.RowIsValid(k_idx)) {
+			result_validity.SetInvalid(i);
+			result_data[i] = 0.0;
+			continue;
+		}
+
+		auto entry = list_entries[list_idx];
+		int64_t k = k_data[k_idx];
+
+		probs_buf.assign(entry.length, 0.0);
+		validity_buf.assign(entry.length, true);
+		for (idx_t j = 0; j < entry.length; j++) {
+			auto child_idx = child_fmt.sel->get_index(entry.offset + j);
+			if (!child_fmt.validity.RowIsValid(child_idx)) {
+				validity_buf[j] = false;
+			} else {
+				probs_buf[j] = child_data[child_idx];
+			}
+		}
+
+		double r = PoibinCdf(probs_buf, validity_buf, k);
+		if (std::isnan(r)) {
+			result_validity.SetInvalid(i);
+			result_data[i] = 0.0;
+		} else {
+			result_data[i] = r;
+		}
+	}
+}
+
+} // namespace
+
+void RegisterPoibinCdf(ExtensionLoader &loader) {
+	ScalarFunction fn("poibin_cdf",
+	                  {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::BIGINT},
+	                  LogicalType::DOUBLE, PoibinCdfExec);
+	loader.RegisterFunction(fn);
+}
+
+} // namespace duckdb

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -10,6 +10,7 @@
 #include "rank_correlation_function.hpp"
 #include "sign_test_function.hpp"
 #include "adjust_p_function.hpp"
+#include "poibin_function.hpp"
 #include "table_one_function.hpp"
 #include "normality_function.hpp"
 #include "ks_test_function.hpp"
@@ -51,6 +52,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Multiple-testing corrections
 	RegisterAdjustP(loader);
+
+	// Poisson Binomial CDF
+	RegisterPoibinCdf(loader);
 
 	// Table 1 helper
 	RegisterTableOne(loader);

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -11,6 +11,7 @@
 #include "sign_test_function.hpp"
 #include "adjust_p_function.hpp"
 #include "poibin_function.hpp"
+#include "auto_bin_function.hpp"
 #include "table_one_function.hpp"
 #include "normality_function.hpp"
 #include "ks_test_function.hpp"
@@ -55,6 +56,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Poisson Binomial CDF
 	RegisterPoibinCdf(loader);
+
+	// Auto-binning helpers
+	RegisterBinEdges(loader);
+	RegisterBinLabel(loader);
 
 	// Table 1 helper
 	RegisterTableOne(loader);

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -12,6 +12,7 @@
 #include "adjust_p_function.hpp"
 #include "poibin_function.hpp"
 #include "auto_bin_function.hpp"
+#include "corr_matrix_function.hpp"
 #include "table_one_function.hpp"
 #include "normality_function.hpp"
 #include "ks_test_function.hpp"
@@ -60,6 +61,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Auto-binning helpers
 	RegisterBinEdges(loader);
 	RegisterBinLabel(loader);
+
+	// Pairwise correlation matrix
+	RegisterCorrMatrix(loader);
 
 	// Table 1 helper
 	RegisterTableOne(loader);

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -12,6 +12,7 @@
 #include "adjust_p_function.hpp"
 #include "table_one_function.hpp"
 #include "normality_function.hpp"
+#include "ks_test_function.hpp"
 #include "anova_function.hpp"
 #include "chisq_function.hpp"
 #include "read_stat_function.hpp"
@@ -37,6 +38,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterJarqueBera(loader);
 	RegisterShapiroWilk(loader);
 	RegisterAndersonDarling(loader);
+	RegisterKsTest1Samp(loader);
+	RegisterKsTest2Samp(loader);
 	RegisterAnovaOneway(loader);
 	RegisterChiSquareTests(loader);
 

--- a/src/table_one_function.cpp
+++ b/src/table_one_function.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <sstream>
 #include <string>
@@ -39,6 +40,12 @@ struct TableOneRow {
 	std::string statistic;
 	std::string stratum; // "Overall" or a `by`-column value
 	std::string display;
+	// Between-group p-value: NaN means "no test applicable" → emitted as NULL.
+	// The same value is stamped on every row of the same variable so a PIVOT
+	// can pick it up with FIRST(p_value). NULL when `by` is unset / single
+	// stratum or when the underlying test fails (e.g. zero variance, too few
+	// samples).
+	double p_value = std::nan("");
 };
 
 struct TableOneBindData : public TableFunctionData {
@@ -252,9 +259,13 @@ static unique_ptr<FunctionData> TableOneBind(ClientContext &context, TableFuncti
 	}
 
 	// Output schema (static — see header comment).
-	names = {"variable", "level", "statistic", "stratum", "display"};
+	// p_value is the between-group test result for the variable; it is
+	// repeated on every row of the same variable so a PIVOT can grab it via
+	// FIRST(p_value). NULL when no `by` is set, when there's only one
+	// stratum, or when the test failed.
+	names = {"variable", "level", "statistic", "stratum", "display", "p_value"};
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
-	                LogicalType::VARCHAR, LogicalType::VARCHAR};
+	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE};
 	return std::move(bd);
 }
 
@@ -406,6 +417,74 @@ static void EmitCategoricalRows(Connection &conn, const std::string &table,
 	               FormatPercent(static_cast<double>(miss), denom)});
 }
 
+// ── Between-group p-value ──────────────────────────────────────────────────
+
+//! Compute the between-group p-value for a single variable. Returns NaN
+//! ("no result") when no test applies (no by-columns, fewer than 2 strata)
+//! or when the underlying aggregate failed (e.g. zero variance, too few
+//! samples for ANOVA / chi-square).
+//!
+//! Numeric variables → one-way ANOVA via `anova_oneway(value, group)`. Works
+//! for 2 groups (where F = t² pooled) and 3+ groups uniformly.
+//!
+//! Categorical variables → chi-square independence via
+//! `chisq_independence(row, col)` with the variable as rows and the (possibly
+//! concatenated) `by` columns as cols.
+//!
+//! Multi-column `by` is folded into a single grouping string by concatenating
+//! the columns with " / " — same separator used for stratum labels.
+static double ComputeBetweenGroupPValue(Connection &conn, const std::string &table,
+                                        const std::string &var, bool numeric,
+                                        const std::vector<std::string> &by_cols,
+                                        idx_t n_strata) {
+	if (by_cols.empty() || n_strata < 2) {
+		return std::nan("");
+	}
+
+	// Build the grouping expression: single column verbatim, multi-column
+	// concatenated with the same " / " separator used in stratum labels.
+	std::string group_expr;
+	if (by_cols.size() == 1) {
+		group_expr = QuoteIdent(by_cols[0]) + "::VARCHAR";
+	} else {
+		for (size_t i = 0; i < by_cols.size(); i++) {
+			if (i > 0) {
+				group_expr += " || ' / ' || ";
+			}
+			group_expr += QuoteIdent(by_cols[i]) + "::VARCHAR";
+		}
+	}
+
+	// Common WHERE: variable + every by-column non-NULL.
+	std::string where_clause = QuoteIdent(var) + " IS NOT NULL";
+	for (auto &b : by_cols) {
+		where_clause += " AND " + QuoteIdent(b) + " IS NOT NULL";
+	}
+
+	std::stringstream sql;
+	if (numeric) {
+		sql << "SELECT (anova_oneway(" << QuoteIdent(var) << "::DOUBLE, " << group_expr
+		    << ")).p_value FROM " << QuoteIdent(table) << " WHERE " << where_clause;
+	} else {
+		sql << "SELECT (chisq_independence(" << QuoteIdent(var) << "::VARCHAR, " << group_expr
+		    << ")).p_value FROM " << QuoteIdent(table) << " WHERE " << where_clause;
+	}
+
+	auto result = conn.Query(sql.str());
+	if (result->HasError()) {
+		return std::nan(""); // test infeasible (e.g. zero variance, sparse 2x2) → NULL
+	}
+	auto chunk = result->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		return std::nan("");
+	}
+	auto v = chunk->GetValue(0, 0);
+	if (v.IsNull()) {
+		return std::nan("");
+	}
+	return v.GetValue<double>();
+}
+
 // ── InitGlobal: pre-compute every row ──────────────────────────────────────
 
 static unique_ptr<GlobalTableFunctionState> TableOneInitGlobal(ClientContext &context,
@@ -476,6 +555,8 @@ static unique_ptr<GlobalTableFunctionState> TableOneInitGlobal(ClientContext &co
 		const std::string &var = bd.variables[var_idx];
 		bool numeric = bd.is_numeric[var_idx];
 
+		size_t first_row = state->rows.size();
+
 		// Overall
 		std::vector<std::string> empty_values;
 		if (numeric) {
@@ -494,6 +575,15 @@ static unique_ptr<GlobalTableFunctionState> TableOneInitGlobal(ClientContext &co
 				EmitCategoricalRows(conn, bd.data_table, var, bd.by_columns, tup, label,
 				                    state->rows);
 			}
+		}
+
+		// Compute the between-group p-value once per variable, then stamp it
+		// on every row we just emitted for this variable. NaN sentinel →
+		// Execute will SetNull on those cells.
+		double p_value = ComputeBetweenGroupPValue(conn, bd.data_table, var, numeric,
+		                                            bd.by_columns, by_tuples.size());
+		for (size_t i = first_row; i < state->rows.size(); i++) {
+			state->rows[i].p_value = p_value;
 		}
 	};
 
@@ -521,6 +611,11 @@ static void TableOneExecute(ClientContext &context, TableFunctionInput &input, D
 		output.SetValue(2, emitted, Value(row.statistic));
 		output.SetValue(3, emitted, Value(row.stratum));
 		output.SetValue(4, emitted, Value(row.display));
+		if (std::isnan(row.p_value)) {
+			FlatVector::SetNull(output.data[5], emitted, true);
+		} else {
+			output.SetValue(5, emitted, Value::DOUBLE(row.p_value));
+		}
 		emitted++;
 	}
 	output.SetCardinality(emitted);

--- a/src/table_one_function.cpp
+++ b/src/table_one_function.cpp
@@ -45,7 +45,21 @@ struct TableOneRow {
 	// can pick it up with FIRST(p_value). NULL when `by` is unset / single
 	// stratum or when the underlying test fails (e.g. zero variance, too few
 	// samples).
-	double p_value = std::nan("");
+	double p_value;
+
+	// Explicit constructor so 5-arg brace-init calls (the existing pattern in
+	// EmitNumericRows / EmitCategoricalRows) keep working with p_value
+	// defaulted to NaN. A C++17 NSDMI default would also work under MSVC, but
+	// emscripten's libc++ rejects brace-init of an aggregate with NSDMIs
+	// when the brace list is shorter than the field count — the constructor
+	// form is portable across both toolchains.
+	TableOneRow(std::string variable, std::string level, std::string statistic,
+	            std::string stratum, std::string display,
+	            double p_value = std::nan(""))
+	    : variable(std::move(variable)), level(std::move(level)),
+	      statistic(std::move(statistic)), stratum(std::move(stratum)),
+	      display(std::move(display)), p_value(p_value) {
+	}
 };
 
 struct TableOneBindData : public TableFunctionData {

--- a/src/table_one_function.cpp
+++ b/src/table_one_function.cpp
@@ -45,7 +45,9 @@ struct TableOneBindData : public TableFunctionData {
 	// Parsed inputs
 	std::string data_table;            // unqualified table name (catalog resolution happens here)
 	std::vector<std::string> variables;
-	std::string by_column;             // empty → no grouping; "Overall" only
+	std::vector<std::string> by_columns; // empty → no grouping; "Overall" only.
+	                                     // Multi-column = Cartesian product of distinct
+	                                     // value tuples; stratum label joins with " / ".
 	// Classified per variable (filled at bind time)
 	std::vector<bool> is_numeric;
 };
@@ -161,10 +163,19 @@ static unique_ptr<FunctionData> TableOneBind(ClientContext &context, TableFuncti
 		throw BinderException("table_one: 'variables' must not be empty");
 	}
 
-	// Named param: by VARCHAR (optional).
+	// Named param: by LIST<VARCHAR> (optional). One element → single-column
+	// stratification (the v0.4 behaviour, now spelled `by := ['arm']`). Multiple
+	// elements → Cartesian product of distinct value tuples across the columns;
+	// the stratum label joins values with " / " in the declared column order.
 	auto it_by = input.named_parameters.find("by");
 	if (it_by != input.named_parameters.end() && !it_by->second.IsNull()) {
-		bd->by_column = it_by->second.GetValue<string>();
+		auto &by_children = ListValue::GetChildren(it_by->second);
+		for (auto &c : by_children) {
+			if (c.IsNull()) {
+				throw BinderException("table_one: 'by' list entries must not be NULL");
+			}
+			bd->by_columns.push_back(c.GetValue<string>());
+		}
 	}
 
 	// Catalog lookup — get column types so we can classify each variable.
@@ -183,9 +194,11 @@ static unique_ptr<FunctionData> TableOneBind(ClientContext &context, TableFuncti
 		auto &col = cols.GetColumn(v);
 		bd->is_numeric.push_back(IsNumericKind(col.GetType().id()));
 	}
-	if (!bd->by_column.empty() && !cols.ColumnExists(bd->by_column)) {
-		throw BinderException("table_one: 'by' column '%s' not found in table '%s'",
-		                      bd->by_column, bd->data_table);
+	for (auto &b : bd->by_columns) {
+		if (!cols.ColumnExists(b)) {
+			throw BinderException("table_one: 'by' column '%s' not found in table '%s'",
+			                      b, bd->data_table);
+		}
 	}
 
 	// Output schema (static — see header comment).
@@ -197,13 +210,28 @@ static unique_ptr<FunctionData> TableOneBind(ClientContext &context, TableFuncti
 
 // ── Per-variable row generation (runs via an internal Connection) ──────────
 
-//! For a numeric variable, fetch summary stats per group and append the
-//! formatted rows. If `group_value` is empty, the group label is "Overall"
-//! and the WHERE clause is omitted; otherwise we restrict to rows where
-//! the by-column equals `group_value`.
+//! Build the per-stratum WHERE fragment (without the leading " WHERE "). Empty
+//! when `by_cols` is empty (the Overall stratum) — caller should skip emitting
+//! a WHERE clause in that case.
+static std::string BuildStratumPredicate(const std::vector<std::string> &by_cols,
+                                         const std::vector<std::string> &group_values) {
+	std::string out;
+	for (size_t i = 0; i < by_cols.size(); i++) {
+		if (i > 0) {
+			out += " AND ";
+		}
+		out += QuoteIdent(by_cols[i]) + " = " + QuoteString(group_values[i]);
+	}
+	return out;
+}
+
+//! For a numeric variable, fetch summary stats per stratum and append the
+//! formatted rows. If `group_values` is empty, the stratum label is "Overall"
+//! and the WHERE clause is omitted; otherwise we restrict to rows where each
+//! by-column equals its parallel value in `group_values`.
 static void EmitNumericRows(Connection &conn, const std::string &table,
-                            const std::string &var, const std::string &by_col,
-                            const std::string &group_value,
+                            const std::string &var, const std::vector<std::string> &by_cols,
+                            const std::vector<std::string> &group_values,
                             const std::string &stratum_label,
                             std::vector<TableOneRow> &out) {
 	std::stringstream sql;
@@ -211,8 +239,8 @@ static void EmitNumericRows(Connection &conn, const std::string &table,
 	       "(s).median, (s).q1, (s).q3, (s).min, (s).max "
 	    << "FROM (SELECT summary_stats(" << QuoteIdent(var) << "::DOUBLE) AS s "
 	    << "FROM " << QuoteIdent(table);
-	if (!group_value.empty()) {
-		sql << " WHERE " << QuoteIdent(by_col) << " = " << QuoteString(group_value);
+	if (!group_values.empty()) {
+		sql << " WHERE " << BuildStratumPredicate(by_cols, group_values);
 	}
 	sql << ")";
 
@@ -265,23 +293,26 @@ static void EmitNumericRows(Connection &conn, const std::string &table,
 //! including the missing count — so the per-stratum level percentages sum to
 //! 100%.
 static void EmitCategoricalRows(Connection &conn, const std::string &table,
-                                const std::string &var, const std::string &by_col,
-                                const std::string &group_value,
+                                const std::string &var,
+                                const std::vector<std::string> &by_cols,
+                                const std::vector<std::string> &group_values,
                                 const std::string &stratum_label,
                                 std::vector<TableOneRow> &out) {
+	std::string stratum_pred =
+	    group_values.empty() ? std::string() : BuildStratumPredicate(by_cols, group_values);
 	std::stringstream sql;
 	sql << "SELECT " << QuoteIdent(var) << "::VARCHAR AS lvl, COUNT(*) AS n "
 	    << "FROM " << QuoteIdent(table) << " WHERE " << QuoteIdent(var) << " IS NOT NULL";
-	if (!group_value.empty()) {
-		sql << " AND " << QuoteIdent(by_col) << " = " << QuoteString(group_value);
+	if (!stratum_pred.empty()) {
+		sql << " AND " << stratum_pred;
 	}
 	sql << " GROUP BY 1 ORDER BY 1";
 
 	std::stringstream missing_sql;
 	missing_sql << "SELECT COUNT(*) FROM " << QuoteIdent(table) << " WHERE "
 	            << QuoteIdent(var) << " IS NULL";
-	if (!group_value.empty()) {
-		missing_sql << " AND " << QuoteIdent(by_col) << " = " << QuoteString(group_value);
+	if (!stratum_pred.empty()) {
+		missing_sql << " AND " << stratum_pred;
 	}
 
 	auto result = conn.Query(sql.str());
@@ -334,14 +365,35 @@ static unique_ptr<GlobalTableFunctionState> TableOneInitGlobal(ClientContext &co
 
 	Connection conn(*context.db);
 
-	// If `by` is set, discover its distinct values up front so we can iterate
-	// groups in a stable order. NULLs in `by` are excluded from the breakdown.
-	std::vector<std::string> by_values;
-	if (!bd.by_column.empty()) {
+	// If `by` is set, discover the distinct tuples of by-column values up front
+	// so we can iterate strata in a stable order. Rows where any by-column is
+	// NULL are excluded from the breakdown (matching the v0.4 single-column
+	// behaviour). Each tuple becomes its own stratum, labelled by joining the
+	// values with " / " in declared order.
+	std::vector<std::vector<std::string>> by_tuples;
+	if (!bd.by_columns.empty()) {
 		std::stringstream sql;
-		sql << "SELECT DISTINCT " << QuoteIdent(bd.by_column) << "::VARCHAR AS v "
-		    << "FROM " << QuoteIdent(bd.data_table) << " WHERE "
-		    << QuoteIdent(bd.by_column) << " IS NOT NULL ORDER BY 1";
+		sql << "SELECT DISTINCT ";
+		for (size_t i = 0; i < bd.by_columns.size(); i++) {
+			if (i > 0) {
+				sql << ", ";
+			}
+			sql << QuoteIdent(bd.by_columns[i]) << "::VARCHAR";
+		}
+		sql << " FROM " << QuoteIdent(bd.data_table) << " WHERE ";
+		for (size_t i = 0; i < bd.by_columns.size(); i++) {
+			if (i > 0) {
+				sql << " AND ";
+			}
+			sql << QuoteIdent(bd.by_columns[i]) << " IS NOT NULL";
+		}
+		sql << " ORDER BY ";
+		for (size_t i = 0; i < bd.by_columns.size(); i++) {
+			if (i > 0) {
+				sql << ", ";
+			}
+			sql << (i + 1);
+		}
 		auto result = conn.Query(sql.str());
 		if (result->HasError()) {
 			throw InvalidInputException("table_one: failed to enumerate `by` values (%s)",
@@ -349,28 +401,48 @@ static unique_ptr<GlobalTableFunctionState> TableOneInitGlobal(ClientContext &co
 		}
 		while (auto chunk = result->Fetch()) {
 			for (idx_t i = 0; i < chunk->size(); i++) {
-				by_values.push_back(chunk->GetValue(0, i).ToString());
+				std::vector<std::string> tup;
+				for (idx_t c = 0; c < bd.by_columns.size(); c++) {
+					tup.push_back(chunk->GetValue(c, i).ToString());
+				}
+				by_tuples.push_back(std::move(tup));
 			}
 		}
 	}
 
-	// Group iteration order: Overall first, then each by-value alphabetically.
+	auto join_tuple = [](const std::vector<std::string> &tup) {
+		std::string out;
+		for (size_t i = 0; i < tup.size(); i++) {
+			if (i > 0) {
+				out += " / ";
+			}
+			out += tup[i];
+		}
+		return out;
+	};
+
+	// Group iteration order: Overall first, then each by-tuple in distinct order.
 	auto emit_var = [&](idx_t var_idx) {
 		const std::string &var = bd.variables[var_idx];
 		bool numeric = bd.is_numeric[var_idx];
 
 		// Overall
+		std::vector<std::string> empty_values;
 		if (numeric) {
-			EmitNumericRows(conn, bd.data_table, var, bd.by_column, "", "Overall", state->rows);
+			EmitNumericRows(conn, bd.data_table, var, bd.by_columns, empty_values, "Overall",
+			                state->rows);
 		} else {
-			EmitCategoricalRows(conn, bd.data_table, var, bd.by_column, "", "Overall", state->rows);
+			EmitCategoricalRows(conn, bd.data_table, var, bd.by_columns, empty_values, "Overall",
+			                    state->rows);
 		}
-		// Per-group breakdown.
-		for (auto &g : by_values) {
+		// Per-stratum breakdown.
+		for (auto &tup : by_tuples) {
+			std::string label = join_tuple(tup);
 			if (numeric) {
-				EmitNumericRows(conn, bd.data_table, var, bd.by_column, g, g, state->rows);
+				EmitNumericRows(conn, bd.data_table, var, bd.by_columns, tup, label, state->rows);
 			} else {
-				EmitCategoricalRows(conn, bd.data_table, var, bd.by_column, g, g, state->rows);
+				EmitCategoricalRows(conn, bd.data_table, var, bd.by_columns, tup, label,
+				                    state->rows);
 			}
 		}
 	};
@@ -410,7 +482,7 @@ void RegisterTableOne(ExtensionLoader &loader) {
 	TableFunction fn("table_one", {LogicalType::VARCHAR}, TableOneExecute, TableOneBind,
 	                  TableOneInitGlobal);
 	fn.named_parameters["variables"] = LogicalType::LIST(LogicalType::VARCHAR);
-	fn.named_parameters["by"] = LogicalType::VARCHAR;
+	fn.named_parameters["by"] = LogicalType::LIST(LogicalType::VARCHAR);
 	loader.RegisterFunction(fn);
 }
 

--- a/src/table_one_function.cpp
+++ b/src/table_one_function.cpp
@@ -178,6 +178,48 @@ static unique_ptr<FunctionData> TableOneBind(ClientContext &context, TableFuncti
 		}
 	}
 
+	// Named params: force_categorical / force_numerical — per-variable
+	// classification overrides. Integer columns that are really categorical
+	// (`stage ∈ {1,2,3,4}`, treatment codes, etc.) need force_categorical;
+	// VARCHAR columns holding numeric strings need force_numerical. Each entry
+	// must appear in `variables` so typos surface as bind errors rather than
+	// silent no-ops; the two lists must not overlap.
+	std::vector<std::string> force_categorical;
+	std::vector<std::string> force_numerical;
+	auto read_override = [&](const char *param_name, std::vector<std::string> &out) {
+		auto it = input.named_parameters.find(param_name);
+		if (it == input.named_parameters.end() || it->second.IsNull()) {
+			return;
+		}
+		auto &children = ListValue::GetChildren(it->second);
+		for (auto &c : children) {
+			if (c.IsNull()) {
+				throw BinderException("table_one: '%s' list entries must not be NULL",
+				                      param_name);
+			}
+			out.push_back(c.GetValue<string>());
+		}
+	};
+	read_override("force_categorical", force_categorical);
+	read_override("force_numerical", force_numerical);
+	for (auto &v : force_categorical) {
+		if (std::find(force_numerical.begin(), force_numerical.end(), v) !=
+		    force_numerical.end()) {
+			throw BinderException("table_one: '%s' is listed in both force_categorical "
+			                      "and force_numerical", v);
+		}
+		if (std::find(bd->variables.begin(), bd->variables.end(), v) == bd->variables.end()) {
+			throw BinderException("table_one: force_categorical entry '%s' is not in 'variables'",
+			                      v);
+		}
+	}
+	for (auto &v : force_numerical) {
+		if (std::find(bd->variables.begin(), bd->variables.end(), v) == bd->variables.end()) {
+			throw BinderException("table_one: force_numerical entry '%s' is not in 'variables'",
+			                      v);
+		}
+	}
+
 	// Catalog lookup — get column types so we can classify each variable.
 	auto &catalog = Catalog::GetCatalog(context, INVALID_CATALOG);
 	auto &schema = DEFAULT_SCHEMA;
@@ -192,7 +234,15 @@ static unique_ptr<FunctionData> TableOneBind(ClientContext &context, TableFuncti
 			                      v, bd->data_table);
 		}
 		auto &col = cols.GetColumn(v);
-		bd->is_numeric.push_back(IsNumericKind(col.GetType().id()));
+		bool numeric = IsNumericKind(col.GetType().id());
+		if (std::find(force_categorical.begin(), force_categorical.end(), v) !=
+		    force_categorical.end()) {
+			numeric = false;
+		} else if (std::find(force_numerical.begin(), force_numerical.end(), v) !=
+		           force_numerical.end()) {
+			numeric = true;
+		}
+		bd->is_numeric.push_back(numeric);
 	}
 	for (auto &b : bd->by_columns) {
 		if (!cols.ColumnExists(b)) {
@@ -483,6 +533,8 @@ void RegisterTableOne(ExtensionLoader &loader) {
 	                  TableOneInitGlobal);
 	fn.named_parameters["variables"] = LogicalType::LIST(LogicalType::VARCHAR);
 	fn.named_parameters["by"] = LogicalType::LIST(LogicalType::VARCHAR);
+	fn.named_parameters["force_categorical"] = LogicalType::LIST(LogicalType::VARCHAR);
+	fn.named_parameters["force_numerical"] = LogicalType::LIST(LogicalType::VARCHAR);
 	loader.RegisterFunction(fn);
 }
 

--- a/test/sql/auto_bin.test
+++ b/test/sql/auto_bin.test
@@ -1,0 +1,178 @@
+# name: test/sql/auto_bin.test
+# description: bin_edges aggregate (Sturges / FD / Scott / sqrt / Rice / auto) + bin_label scalar
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE seq20 AS SELECT unnest([1.0,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]) AS x;
+
+# ─── Bin-count rules ────────────────────────────────────────────────────────
+
+# Sturges: k = ceil(log2(20) + 1) = ceil(5.32) = 6 → 7 edges over [1, 20].
+query I
+SELECT len(bin_edges(x)) FROM seq20
+----
+7
+
+# Freedman-Diaconis: width = 2·IQR·n^(-1/3) ≈ 2·9.5·0.368 ≈ 7.0 → k=3, 4 edges.
+query I
+SELECT len(bin_edges(x, 'fd')) FROM seq20
+----
+4
+
+# Scott: width = 3.5·sd·n^(-1/3). sd(1..20) ≈ 5.92 → width ≈ 7.62 → k=3, 4 edges.
+query I
+SELECT len(bin_edges(x, 'scott')) FROM seq20
+----
+4
+
+# Square-root rule: k = ceil(sqrt(20)) = 5 → 6 edges.
+query I
+SELECT len(bin_edges(x, 'sqrt')) FROM seq20
+----
+6
+
+# Rice rule: k = ceil(2 · 20^(1/3)) = ceil(5.43) = 6 → 7 edges.
+query I
+SELECT len(bin_edges(x, 'rice')) FROM seq20
+----
+7
+
+# Auto = max(sturges, fd) = max(6, 3) = 6 → 7 edges.
+query I
+SELECT len(bin_edges(x, 'auto')) FROM seq20
+----
+7
+
+# Method is case-insensitive.
+query I
+SELECT len(bin_edges(x, 'STURGES')) FROM seq20
+----
+7
+
+# Edge vector spans [min(x), max(x)] exactly.
+query RR
+SELECT (bin_edges(x))[1], (bin_edges(x))[len(bin_edges(x))] FROM seq20
+----
+1	20
+
+# ─── bin_label ──────────────────────────────────────────────────────────────
+
+# Round-trip: every value lands in one of the bins; the maximum lands in the
+# last (closed) bin; bin assignments partition the data.
+query TI
+WITH e AS (SELECT bin_edges(x, 'sqrt') AS edges FROM seq20)
+SELECT bin_label(x, edges), count(*) FROM seq20, e GROUP BY 1 ORDER BY 1
+----
+[1, 4.8)	4
+[12.4, 16.2)	4
+[16.2, 20]	4
+[4.8, 8.6)	4
+[8.6, 12.4)	4
+
+# Last bin is closed on the right — the maximum value gets a label, not NULL.
+query T
+WITH e AS (SELECT bin_edges(x, 'sqrt') AS edges FROM seq20)
+SELECT bin_label(20.0, edges) FROM e
+----
+[16.2, 20]
+
+# Intermediate bin is half-open `[lo, hi)`.
+query T
+WITH e AS (SELECT bin_edges(x, 'sqrt') AS edges FROM seq20)
+SELECT bin_label(4.8, edges) FROM e
+----
+[4.8, 8.6)
+
+# Value below min → NULL.
+query T
+WITH e AS (SELECT bin_edges(x, 'sqrt') AS edges FROM seq20)
+SELECT bin_label(0.5, edges) FROM e
+----
+NULL
+
+# Value above max → NULL.
+query T
+WITH e AS (SELECT bin_edges(x, 'sqrt') AS edges FROM seq20)
+SELECT bin_label(25.0, edges) FROM e
+----
+NULL
+
+# NULL x → NULL.
+query T
+WITH e AS (SELECT bin_edges(x, 'sqrt') AS edges FROM seq20)
+SELECT bin_label(NULL::DOUBLE, edges) FROM e
+----
+NULL
+
+# NULL edges → NULL.
+query T
+SELECT bin_label(5.0, NULL::DOUBLE[])
+----
+NULL
+
+# ─── Degenerate / edge inputs ───────────────────────────────────────────────
+
+# n < 2 → NULL (can't form a meaningful range).
+query I
+SELECT bin_edges(x) IS NULL FROM (SELECT unnest([5.0]) AS x)
+----
+true
+
+# All-NULL group → NULL.
+query I
+SELECT bin_edges(x) IS NULL FROM (SELECT NULL::DOUBLE AS x)
+----
+true
+
+# All values equal → degenerate edge list with a single point. bin_label
+# still returns the trivial label so downstream code doesn't crash.
+query T
+WITH e AS (SELECT bin_edges(x) AS edges FROM (SELECT unnest([3.0, 3, 3, 3, 3]) AS x))
+SELECT bin_label(3.0, edges) FROM e
+----
+[3, 3]
+
+# Unknown method → bind error.
+statement error
+SELECT bin_edges(x, 'sturg') FROM seq20
+----
+unknown method 'sturg'
+
+# Non-constant method → bind error.
+statement error
+SELECT bin_edges(x, m) FROM (SELECT x, 'sturges' AS m FROM seq20)
+----
+'method' must be a constant string
+
+# NULL method → bind error.
+statement error
+SELECT bin_edges(x, NULL::VARCHAR) FROM seq20
+----
+'method' must not be NULL
+
+# ─── Integration with table_one ─────────────────────────────────────────────
+
+# Materialize a binned column and feed it to table_one. The bin label is a
+# VARCHAR, so table_one will treat it as categorical without needing
+# force_categorical.
+statement ok
+CREATE TABLE patients AS SELECT * FROM (VALUES
+    (25.0, 'F'), (32, 'F'), (45, 'M'), (51, 'M'), (38, 'F'),
+    (62, 'M'), (29, 'F'), (47, 'M'), (55, 'F'), (41, 'M')
+) AS t(age, sex);
+
+statement ok
+CREATE TABLE patients_binned AS
+WITH e AS (SELECT bin_edges(age, 'sqrt') AS edges FROM patients)
+SELECT *, bin_label(age, edges) AS age_bin FROM patients, e;
+
+# Sturges/sqrt on n=10 → k=ceil(sqrt(10))=4 distinct bins. Spot-check that
+# table_one sees them as categorical and the counts add up to 10.
+query I
+SELECT sum(CAST(regexp_extract(display, '^([0-9]+)') AS INT))
+FROM table_one('patients_binned', variables := ['age_bin'])
+WHERE statistic = 'n (%)'
+----
+10

--- a/test/sql/corr_matrix.test
+++ b/test/sql/corr_matrix.test
@@ -1,0 +1,186 @@
+# name: test/sql/corr_matrix.test
+# description: corr_matrix table function — long-format pairwise correlation matrix
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS SELECT * FROM (VALUES
+    (39.1, 18.7, 181.0, 3750.0),
+    (39.5, 17.4, 186,   3800),
+    (40.3, 18.0, 195,   3250),
+    (46.5, 17.9, 192,   3500),
+    (50.0, 15.9, 224,   5350),
+    (49.2, 18.2, 221,   6300)
+) AS t(bill_len, bill_dep, flipper, mass);
+
+# ─── Output schema and self-pairs ───────────────────────────────────────────
+
+# n² rows for k variables (4×4 = 16 here).
+query I
+SELECT count(*) FROM corr_matrix('penguins', variables := ['bill_len','bill_dep','flipper','mass'])
+----
+16
+
+# Diagonal entries: coef = 1 (within fp tolerance), n equals the row count.
+query TI
+SELECT row_var, n FROM corr_matrix('penguins',
+    variables := ['bill_len','bill_dep','flipper','mass'])
+WHERE row_var = col_var ORDER BY row_var
+----
+bill_dep	6
+bill_len	6
+flipper	6
+mass	6
+
+# All diagonal coefficients are 1.
+query R
+SELECT max(abs(coef - 1.0)) FROM corr_matrix('penguins',
+    variables := ['bill_len','bill_dep','flipper','mass'])
+WHERE row_var = col_var
+----
+0
+
+# ─── Symmetry (Pearson) ─────────────────────────────────────────────────────
+
+# Mirror entries match exactly (computed once, mirrored in C++).
+query R
+SELECT max(abs(a.coef - b.coef)) FROM
+    corr_matrix('penguins', variables := ['bill_len','bill_dep','flipper','mass']) a
+    JOIN corr_matrix('penguins', variables := ['bill_len','bill_dep','flipper','mass']) b
+      ON a.row_var = b.col_var AND a.col_var = b.row_var
+----
+0
+
+# Spot-check vs R: cor(bill_len, flipper) ≈ 0.887 for this 6-row fixture.
+query R
+SELECT round(coef, 3) FROM corr_matrix('penguins',
+    variables := ['bill_len','flipper'])
+WHERE row_var = 'bill_len' AND col_var = 'flipper'
+----
+0.887
+
+# Negative correlation: bill_len vs bill_dep ≈ -0.505.
+query R
+SELECT round(coef, 3) FROM corr_matrix('penguins',
+    variables := ['bill_len','bill_dep'])
+WHERE row_var = 'bill_len' AND col_var = 'bill_dep'
+----
+-0.505
+
+# ─── Methods ────────────────────────────────────────────────────────────────
+
+# Spearman rho on the same 2-column pair (different value than Pearson r).
+query R
+SELECT round(coef, 3) FROM corr_matrix('penguins',
+    variables := ['bill_len','flipper'], method := 'spearman')
+WHERE row_var = 'bill_len' AND col_var = 'flipper'
+----
+0.943
+
+# Kendall tau.
+query R
+SELECT round(coef, 3) FROM corr_matrix('penguins',
+    variables := ['bill_len','flipper'], method := 'kendall')
+WHERE row_var = 'bill_len' AND col_var = 'flipper'
+----
+0.867
+
+# Method is case-insensitive.
+query I
+SELECT count(*) FROM corr_matrix('penguins',
+    variables := ['bill_len','flipper'], method := 'PEARSON')
+----
+4
+
+# ─── Pairwise-complete handling ─────────────────────────────────────────────
+
+# NULLs in a column are excluded from that pair's n; other pairs unaffected.
+statement ok
+CREATE TABLE p_with_nulls AS SELECT * FROM (VALUES
+    (1.0,    2.0, 3.0),
+    (2,      4,   NULL),
+    (3,      NULL,7),
+    (4,      8,   9),
+    (5,     10,   11)
+) AS t(a, b, c);
+
+# (a, b): 4 non-null pairs (rows 1, 2, 4, 5).
+query I
+SELECT n FROM corr_matrix('p_with_nulls', variables := ['a','b','c'])
+WHERE row_var = 'a' AND col_var = 'b'
+----
+4
+
+# (a, c): 4 non-null pairs (rows 1, 3, 4, 5).
+query I
+SELECT n FROM corr_matrix('p_with_nulls', variables := ['a','b','c'])
+WHERE row_var = 'a' AND col_var = 'c'
+----
+4
+
+# (b, c): 3 non-null pairs (rows 1, 4, 5).
+query I
+SELECT n FROM corr_matrix('p_with_nulls', variables := ['a','b','c'])
+WHERE row_var = 'b' AND col_var = 'c'
+----
+3
+
+# ─── Composition with WITH … VISUALIZE → heatmap ────────────────────────────
+
+# The canonical correlation-heatmap pipeline: feed the corr_matrix output
+# straight into a VISUALIZE block via the v0.5 WITH support. We only verify
+# the spec compiles and the layer SQL references corr_matrix correctly.
+# Single line so the paren-preserved whitespace doesn't end up in the fixture.
+query TT
+WITH c AS (SELECT * FROM corr_matrix('penguins', variables := ['bill_len','bill_dep','flipper','mass'])) VISUALIZE row_var AS x, col_var AS y, coef AS color FROM c DRAW heatmap SCALE color TO redblue SCALE color DOMAIN -1 1
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"rect","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"ordinal"},"color":{"field":"color","type":"quantitative","scale":{"scheme":"redblue","domain":[-1,1]}}}}	{layer_0='WITH c AS (SELECT * FROM corr_matrix(\'penguins\', variables := [\'bill_len\',\'bill_dep\',\'flipper\',\'mass\'])) SELECT row_var AS x, col_var AS y, coef AS color FROM c'}
+
+# ─── Error cases ────────────────────────────────────────────────────────────
+
+# Need at least 2 variables for a "matrix".
+statement error
+SELECT * FROM corr_matrix('penguins', variables := ['bill_len'])
+----
+must contain at least 2 columns
+
+# Empty variables list.
+statement error
+SELECT * FROM corr_matrix('penguins', variables := [])
+----
+must contain at least 2 columns
+
+# NULL inside variables list.
+statement error
+SELECT * FROM corr_matrix('penguins', variables := ['bill_len', NULL])
+----
+'variables' list entries must not be NULL
+
+# Missing column.
+statement error
+SELECT * FROM corr_matrix('penguins', variables := ['bill_len', 'bogus'])
+----
+column 'bogus' not found
+
+# Non-numeric column.
+statement ok
+CREATE TABLE mixed AS SELECT * FROM (VALUES (1.0, 'a'), (2.0, 'b')) AS t(num, cat);
+
+statement error
+SELECT * FROM corr_matrix('mixed', variables := ['num', 'cat'])
+----
+not numeric
+
+# Unknown method.
+statement error
+SELECT * FROM corr_matrix('penguins', variables := ['bill_len','flipper'],
+    method := 'rankit')
+----
+unknown method 'rankit'
+
+# Missing table.
+statement error
+SELECT * FROM corr_matrix('does_not_exist', variables := ['a','b'])
+----
+Table

--- a/test/sql/distributions_gamma_beta_exp.test
+++ b/test/sql/distributions_gamma_beta_exp.test
@@ -1,0 +1,141 @@
+# name: test/sql/distributions_gamma_beta_exp.test
+# description: Gamma, Beta, and Exponential distribution functions (d/p/q triples)
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Gamma ──────────────────────────────────────────────────────────────────
+
+# dgamma(1, shape=2, rate=1) = 1 · e^(-1) = 1/e. The 2-arg form defaults rate=1.
+query R
+SELECT dgamma(1.0, 2.0)
+----
+0.367879
+
+# Explicit rate: dgamma(2, shape=3, rate=0.5) — R: 0.09196986
+query R
+SELECT dgamma(2.0, 3.0, 0.5)
+----
+0.091970
+
+# pgamma(2, shape=3, rate=1) — R: 0.3233236
+query R
+SELECT pgamma(2.0, 3.0)
+----
+0.323324
+
+# qgamma(0.5, shape=3) — R: 2.674060
+query R
+SELECT qgamma(0.5, 3.0)
+----
+2.674060
+
+# Round-trip: pgamma(qgamma(p)) ≈ p
+query I
+SELECT abs(pgamma(qgamma(0.7, 4.0, 1.5), 4.0, 1.5) - 0.7) < 1e-6
+----
+true
+
+# Invalid: shape <= 0 → NULL
+query R
+SELECT dgamma(1.0, -1.0)
+----
+NULL
+
+# Invalid: x < 0 returns 0 (PDF is zero outside support)
+query R
+SELECT dgamma(-1.0, 2.0)
+----
+0
+
+# ─── Beta ───────────────────────────────────────────────────────────────────
+
+# dbeta(0.3, 2, 5) — R: 2.1609
+query R
+SELECT dbeta(0.3, 2.0, 5.0)
+----
+2.160900
+
+# pbeta(0.3, 2, 5) — R: 0.5798249
+query R
+SELECT pbeta(0.3, 2.0, 5.0)
+----
+0.579825
+
+# qbeta(0.5, 2, 5) — R: 0.2644500
+query R
+SELECT qbeta(0.5, 2.0, 5.0)
+----
+0.264450
+
+# Uniform special case: Beta(1, 1) is U[0, 1]; PDF is constant 1.
+query RR
+SELECT dbeta(0.0, 1.0, 1.0), dbeta(1.0, 1.0, 1.0)
+----
+1	1
+
+# Outside support [0, 1] → 0
+query R
+SELECT dbeta(1.5, 2.0, 5.0)
+----
+0
+
+# Invalid: negative shape → NULL
+query R
+SELECT dbeta(0.5, -1.0, 5.0)
+----
+NULL
+
+# ─── Exponential ────────────────────────────────────────────────────────────
+
+# Default rate=1: dexp(1) = e^(-1) = 1/e
+query R
+SELECT dexp(1.0)
+----
+0.367879
+
+# pexp(1) = 1 - e^(-1)
+query R
+SELECT pexp(1.0)
+----
+0.632121
+
+# qexp(0.5) = ln(2)
+query R
+SELECT qexp(0.5)
+----
+0.693147
+
+# Custom rate λ=2: qexp(0.5, 2) = ln(2)/2
+query R
+SELECT qexp(0.5, 2.0)
+----
+0.346574
+
+# Round-trip
+query I
+SELECT abs(pexp(qexp(0.7, 1.5), 1.5) - 0.7) < 1e-9
+----
+true
+
+# x < 0 ⇒ PDF=0, CDF=0
+query RR
+SELECT dexp(-1.0), pexp(-1.0)
+----
+0	0
+
+# Invalid: rate <= 0 → NULL
+query R
+SELECT pexp(1.0, 0.0)
+----
+NULL
+
+# ─── Consistency: Exponential = Gamma(1, rate) ──────────────────────────────
+
+# dexp(x, rate) ≡ dgamma(x, 1, rate); pexp ≡ pgamma; qexp ≡ qgamma.
+query I
+SELECT abs(dexp(1.5, 2.0) - dgamma(1.5, 1.0, 2.0)) < 1e-12
+       AND abs(pexp(1.5, 2.0) - pgamma(1.5, 1.0, 2.0)) < 1e-12
+       AND abs(qexp(0.7, 2.0) - qgamma(0.7, 1.0, 2.0)) < 1e-6
+----
+true

--- a/test/sql/ggsql_mark_registry.test
+++ b/test/sql/ggsql_mark_registry.test
@@ -33,11 +33,14 @@ WHERE function_name LIKE 'ggsql_mark_v1_%'
 ggsql_mark_v1_area
 ggsql_mark_v1_bar
 ggsql_mark_v1_boxplot
+ggsql_mark_v1_density
 ggsql_mark_v1_errorband
 ggsql_mark_v1_errorbar
+ggsql_mark_v1_heatmap
 ggsql_mark_v1_histogram
 ggsql_mark_v1_line
 ggsql_mark_v1_point
+ggsql_mark_v1_regression
 ggsql_mark_v1_rule
 ggsql_mark_v1_text
 ggsql_mark_v1_tick

--- a/test/sql/ggsql_visualize_new_marks.test
+++ b/test/sql/ggsql_visualize_new_marks.test
@@ -1,0 +1,97 @@
+# name: test/sql/ggsql_visualize_new_marks.test
+# description: v0.5 — heatmap (rect), density (KDE area + transform), regression (line + fit transform)
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES
+    (39.1, 18.7, 'Adelie'), (39.5, 17.4, 'Adelie'),
+    (44.0, 18.0, 'Gentoo'), (45.2, 14.5, 'Gentoo'),
+    (50.0, 19.3, 'Chinstrap')
+) AS t(bill_len, bill_dep, species);
+
+# ─── Heatmap ─────────────────────────────────────────────────────────────────
+
+# Heatmap maps x ordinal, y ordinal, color quantitative — typical correlation
+# / contingency-table shape. mark = rect.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, bill_len AS color FROM penguins DRAW heatmap
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"rect","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"ordinal"},"color":{"field":"color","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, bill_len AS color FROM penguins'}
+
+# Heatmap composes with SCALE TO for the color scheme — typical viridis heatmap.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, bill_len AS color FROM penguins DRAW heatmap SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"rect","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"ordinal"},"color":{"field":"color","type":"quantitative","scale":{"scheme":"viridis"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, bill_len AS color FROM penguins'}
+
+# Heatmap requires color — clean missing-aesthetic error.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW heatmap
+----
+'heatmap' requires 'color' aesthetic
+
+# Per-channel type override still works on a heatmap (force x back to quantitative
+# for a binned heatmap of a continuous variable).
+query TT
+VISUALIZE bill_len AS x:quantitative, bill_dep AS y, bill_len AS color FROM penguins DRAW heatmap
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"rect","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"ordinal"},"color":{"field":"color","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, bill_len AS color FROM penguins'}
+
+# ─── Density ─────────────────────────────────────────────────────────────────
+
+# Bare density: Vega-Lite density transform produces "value"/"density" output
+# fields which get bound to x/y axes. mark = area.
+query TT
+VISUALIZE bill_len AS x FROM penguins DRAW density
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"x"}],"mark":"area","encoding":{"x":{"field":"value","type":"quantitative"},"y":{"field":"density","type":"quantitative"}}}	{layer_0=SELECT bill_len AS x FROM penguins}
+
+# Density with color → grouped density curves (one per category). The color
+# aesthetic flows into both the transform's groupby and the encoding.
+query TT
+VISUALIZE bill_len AS x, species AS color FROM penguins DRAW density
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"x","groupby":["color"]}],"mark":"area","encoding":{"x":{"field":"value","type":"quantitative"},"y":{"field":"density","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT bill_len AS x, species AS color FROM penguins'}
+
+# Density requires x — clean missing-aesthetic error.
+statement error
+VISUALIZE bill_len AS y FROM penguins DRAW density
+----
+'density' requires 'x' aesthetic
+
+# SCALE LABEL still works on density's synthetic y channel — the encoding emits
+# a "y":{...} block regardless of what field it points to.
+query TT
+VISUALIZE bill_len AS x FROM penguins DRAW density SCALE y LABEL 'Density'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"x"}],"mark":"area","encoding":{"x":{"field":"value","type":"quantitative"},"y":{"field":"density","type":"quantitative","axis":{"title":"Density"}}}}	{layer_0=SELECT bill_len AS x FROM penguins}
+
+# ─── Regression ──────────────────────────────────────────────────────────────
+
+# Bare regression: Vega-Lite regression transform fits y ~ x. mark = line.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW regression
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"regression":"y","on":"x"}],"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Regression with color → one fit per category.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW regression
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"regression":"y","on":"x","groupby":["color"]}],"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins'}
+
+# Regression requires both x and y.
+statement error
+VISUALIZE bill_len AS x FROM penguins DRAW regression
+----
+'regression' requires 'y' aesthetic
+
+# Multi-layer: scatter + regression overlay — the canonical scatter-with-fit
+# plot. Each layer has the same data but different transforms / marks.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW regression
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"transform":[{"regression":"y","on":"x"}],"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins', layer_1='SELECT bill_len AS x, bill_dep AS y FROM penguins'}

--- a/test/sql/ggsql_visualize_titles.test
+++ b/test/sql/ggsql_visualize_titles.test
@@ -1,0 +1,119 @@
+# name: test/sql/ggsql_visualize_titles.test
+# description: v0.5 — TITLE/SUBTITLE clause and SCALE <ch> LABEL '...' axis-title operator
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES (39.1, 18.7, 'Adelie'), (39.5, 17.4, 'Adelie'), (44.0, 18.0, 'Gentoo')) AS t(bill_len, bill_dep, species);
+
+# ─── TITLE ────────────────────────────────────────────────────────────────────
+
+# Bare TITLE — emitted as a TitleParams object so SUBTITLE can be added later
+# without changing the spec shape.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point TITLE 'Penguin bill dimensions'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}},"title":{"text":"Penguin bill dimensions"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# TITLE + SUBTITLE — both appear in the title block.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point TITLE 'Bill dimensions' SUBTITLE 'Source: Palmer Station LTER'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}},"title":{"text":"Bill dimensions","subtitle":"Source: Palmer Station LTER"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# TITLE composes with SCALE — title block sits after encoding, scales inside channels.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point SCALE color TO viridis TITLE 'Colored by species'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}},"title":{"text":"Colored by species"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color FROM penguins'}
+
+# TITLE composes with FACET — facet wraps the encoding, title goes at top-level.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species TITLE 'Per-species view'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"field":"facet","type":"nominal"},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},"title":{"text":"Per-species view"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet FROM penguins'}
+
+# TITLE on a multi-layer spec lands at the outer level, not per-layer.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW line TITLE 'Points and line'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}],"title":{"text":"Points and line"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y FROM penguins) ORDER BY x'}
+
+# SQL '' escape inside a title round-trips to a single quote.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point TITLE 'Bill''s mom'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}},"title":{"text":"Bill's mom"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Embedded double-quote in the title is JSON-escaped.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point TITLE 'He said "hi"'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}},"title":{"text":"He said \"hi\""}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# ─── SCALE LABEL ──────────────────────────────────────────────────────────────
+
+# Single axis label injects `"axis":{"title":...}` alongside the channel's field/type.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x LABEL 'Bill length (mm)'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative","axis":{"title":"Bill length (mm)"}},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# Two LABEL clauses target different channels — each gets its own axis block.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x LABEL 'Bill length (mm)' SCALE y LABEL 'Bill depth (mm)'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative","axis":{"title":"Bill length (mm)"}},"y":{"field":"y","type":"quantitative","axis":{"title":"Bill depth (mm)"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# LABEL coexists with SCALE TO/DOMAIN on the same channel — scale and axis are
+# both injected into the channel block.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x DOMAIN 30 50 SCALE x LABEL 'Bill length (mm)'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative","scale":{"domain":[30,50]},"axis":{"title":"Bill length (mm)"}},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# LABEL on an unmapped channel is a silent no-op (matches existing SCALE behavior).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE color LABEL 'Species'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# LABEL + TITLE together — exercises both injection paths in one spec.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x LABEL 'Bill length (mm)' SCALE y LABEL 'Bill depth (mm)' TITLE 'Penguin bill dimensions' SUBTITLE 'n=3'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative","axis":{"title":"Bill length (mm)"}},"y":{"field":"y","type":"quantitative","axis":{"title":"Bill depth (mm)"}}},"title":{"text":"Penguin bill dimensions","subtitle":"n=3"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
+
+# ─── Error cases ──────────────────────────────────────────────────────────────
+
+# SUBTITLE without preceding TITLE.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SUBTITLE 'orphan'
+----
+SUBTITLE requires a preceding TITLE clause
+
+# TITLE with no text argument.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point TITLE
+----
+Expected title text after 'TITLE'
+
+# SUBTITLE with no text argument.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point TITLE 'ok' SUBTITLE
+----
+Expected subtitle text after 'SUBTITLE'
+
+# SCALE LABEL with no label argument.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x LABEL
+----
+Expected axis label after 'SCALE <aesthetic> LABEL'
+
+# Updated SCALE-op error message lists LABEL.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point SCALE x BOGUS foo
+----
+Unknown SCALE operator 'BOGUS' (expected TO / ZERO / DOMAIN / LABEL)

--- a/test/sql/ggsql_visualize_with.test
+++ b/test/sql/ggsql_visualize_with.test
@@ -1,0 +1,99 @@
+# name: test/sql/ggsql_visualize_with.test
+# description: v0.5 — `WITH … VISUALIZE` support so CTEs can feed the FROM clause directly
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS
+SELECT * FROM (VALUES
+    (39.1, 18.7, 'Adelie'), (39.5, 17.4, 'Adelie'),
+    (44.0, 18.0, 'Gentoo'), (45.2, 14.5, 'Gentoo'),
+    (50.0, 19.3, 'Chinstrap')
+) AS t(bill_len, bill_dep, species);
+
+# ─── Single CTE ─────────────────────────────────────────────────────────────
+
+# CTE is preserved verbatim in the projected SQL.
+query TT
+WITH big AS (SELECT * FROM penguins WHERE bill_len > 40)
+VISUALIZE bill_len AS x, bill_dep AS y FROM big DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='WITH big AS (SELECT * FROM penguins WHERE bill_len > 40) SELECT bill_len AS x, bill_dep AS y FROM big'}
+
+# ─── Multi-CTE ──────────────────────────────────────────────────────────────
+
+# Comma-separated CTEs round-trip through the tokenizer with whitespace
+# normalised (`(…) , (…)`); functionally equivalent to the input.
+query TT
+WITH a AS (SELECT * FROM penguins WHERE bill_len > 40),
+     b AS (SELECT bill_len, bill_dep * 2 AS bill_dep FROM a)
+VISUALIZE bill_len AS x, bill_dep AS y FROM b DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='WITH a AS (SELECT * FROM penguins WHERE bill_len > 40) , b AS (SELECT bill_len, bill_dep * 2 AS bill_dep FROM a) SELECT bill_len AS x, bill_dep AS y FROM b'}
+
+# ─── CTE + wrapping mark (line orders the projection) ───────────────────────
+
+# `line` wraps the projected SQL in a subquery for ORDER BY. CTEs are scoped
+# to the inner query, so the wrap composes without lifting the WITH.
+query TT
+WITH d AS (SELECT * FROM penguins WHERE species != 'Chinstrap')
+VISUALIZE bill_len AS x, bill_dep AS y FROM d DRAW line
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT * FROM (WITH d AS (SELECT * FROM penguins WHERE species != \'Chinstrap\') SELECT bill_len AS x, bill_dep AS y FROM d) ORDER BY x'}
+
+# ─── CTE + FACET + SCALE + TITLE (full composition) ─────────────────────────
+
+# Every modifier still works in the presence of a WITH clause.
+query TT
+WITH d AS (SELECT * FROM penguins)
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM d
+DRAW point
+FACET BY species
+SCALE color TO viridis
+TITLE 'CTE composition test'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"field":"facet","type":"nominal"},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}},"title":{"text":"CTE composition test"}}	{layer_0='WITH d AS (SELECT * FROM penguins) SELECT bill_len AS x, bill_dep AS y, species AS color, species AS facet FROM d'}
+
+# ─── Leading comments are skipped ───────────────────────────────────────────
+
+# Block comment before WITH.
+query TT
+/* a header comment */
+WITH big AS (SELECT * FROM penguins WHERE bill_len > 40)
+VISUALIZE bill_len AS x, bill_dep AS y FROM big DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='WITH big AS (SELECT * FROM penguins WHERE bill_len > 40) SELECT bill_len AS x, bill_dep AS y FROM big'}
+
+# Line comment before WITH (the common case when annotating a query).
+query TT
+-- annotate the filter
+WITH big AS (SELECT * FROM penguins WHERE bill_len > 40)
+VISUALIZE bill_len AS x, bill_dep AS y FROM big DRAW point
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='WITH big AS (SELECT * FROM penguins WHERE bill_len > 40) SELECT bill_len AS x, bill_dep AS y FROM big'}
+
+# ─── Fall-through: plain WITH … SELECT … still works ───────────────────────
+
+# A WITH clause without a top-level VISUALIZE keyword is left for DuckDB's
+# regular SQL parser to handle.
+query I
+WITH cte AS (SELECT 42 AS n) SELECT n FROM cte
+----
+42
+
+# Quoted-identifier or string literal containing "visualize" must NOT be
+# misidentified — depth/quote tracking in the keyword scanner protects this.
+query T
+WITH cte AS (SELECT 'visualize me later' AS msg) SELECT msg FROM cte
+----
+visualize me later
+
+# ─── Error: WITH not followed by VISUALIZE inside a ggsql-claimed statement ─
+
+# Only fires when our heuristic does claim the statement; otherwise this would
+# fall through to DuckDB. Constructing the trigger requires a top-level
+# VISUALIZE keyword somewhere — e.g. as a column alias in the CTE body —
+# but those are protected by paren-depth tracking. Hence we can't easily
+# craft a deterministic error case here; the parse-time guard exists in
+# ParseGgsql for defensive purposes only.

--- a/test/sql/ks_test.test
+++ b/test/sql/ks_test.test
@@ -1,0 +1,109 @@
+# name: test/sql/ks_test.test
+# description: Kolmogorov-Smirnov one-sample (vs fitted normal) and two-sample tests
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── ks_test_1samp ──────────────────────────────────────────────────────────
+
+# Sequential integers 1..20 — symmetric, near-normal sample. D and p match
+# R: ks.test(1:20, "pnorm", mean(1:20), sd(1:20)) → D=0.076564, p=0.99963.
+statement ok
+CREATE TABLE t1 AS SELECT unnest([1.0,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]) AS x;
+
+query TRRI
+SELECT (s).test_type, (s).d_statistic, (s).p_value, (s).n FROM (
+    SELECT ks_test_1samp(x) AS s FROM t1
+)
+----
+Kolmogorov-Smirnov (one-sample, fitted normal)	0.076564	0.999635	20
+
+# Highly skewed sample (exponential-ish): D is well above zero. The vanilla
+# KS p-value here is conservative (~0.31) because mu/sigma are estimated
+# from the sample — users who need a Lilliefors-corrected p should pair
+# with `shapiro_wilk` / `anderson_darling`.
+statement ok
+CREATE TABLE t2 AS SELECT unnest([0.1, 0.2, 0.3, 1.0, 2, 4, 8, 16, 32, 64]) AS x;
+
+query I
+SELECT (ks_test_1samp(x)).d_statistic > 0.25 FROM t2
+----
+true
+
+# Tiny sample — under the n>=3 floor → NULL.
+statement ok
+CREATE TABLE t_small AS SELECT unnest([1.0, 2]) AS x;
+
+query I
+SELECT ks_test_1samp(x) IS NULL FROM t_small
+----
+true
+
+# All-equal sample — zero variance, can't fit a normal → NULL.
+statement ok
+CREATE TABLE t_constant AS SELECT unnest([5.0, 5, 5, 5, 5]) AS x;
+
+query I
+SELECT ks_test_1samp(x) IS NULL FROM t_constant
+----
+true
+
+# NULLs in the input are dropped, not propagated.
+statement ok
+CREATE TABLE t_with_nulls AS SELECT unnest([1.0, 2, 3, NULL::DOUBLE, 4, 5, 6, 7, 8, 9, 10]) AS x;
+
+query I
+SELECT (ks_test_1samp(x)).n FROM t_with_nulls
+----
+10
+
+# ─── ks_test_2samp ──────────────────────────────────────────────────────────
+
+# Two shifted-but-overlapping samples. R asymptotic:
+#   ks.test(1:10, 3:12) → D=0.2, p≈0.9748.
+statement ok
+CREATE TABLE t_pair AS SELECT a, b FROM (VALUES
+    (1.0, 3.0), (2, 4), (3, 5), (4, 6), (5, 7),
+    (6, 8), (7, 9), (8, 10), (9, 11), (10, 12)
+) AS v(a, b);
+
+query TRRII
+SELECT (s).test_type, (s).d_statistic, (s).p_value, (s).n_x, (s).n_y FROM (
+    SELECT ks_test_2samp(a, b) AS s FROM t_pair
+)
+----
+Kolmogorov-Smirnov (two-sample)	0.200000	0.974789	10	10
+
+# Two clearly different samples (1..10 vs 50..59) — D = 1, p ≈ 0.
+query I
+SELECT (s).p_value < 0.001 FROM (
+    SELECT ks_test_2samp(a, b) AS s FROM (VALUES
+        (1.0, 50.0), (2, 51), (3, 52), (4, 53), (5, 54),
+        (6, 55), (7, 56), (8, 57), (9, 58), (10, 59)
+    ) AS v(a, b)
+)
+----
+true
+
+# Two-sample handles per-column NULLs independently: NULL in a doesn't drop
+# the b value from the same row.
+statement ok
+CREATE TABLE t_pair_nulls AS SELECT a, b FROM (VALUES
+    (1.0, 10.0), (NULL::DOUBLE, 11.0), (2.0, NULL::DOUBLE), (3.0, 12.0)
+) AS v(a, b);
+
+query II
+SELECT (s).n_x, (s).n_y FROM (
+    SELECT ks_test_2samp(a, b) AS s FROM t_pair_nulls
+)
+----
+3	3
+
+# Empty x sample → NULL (no two-sample test possible).
+statement ok
+CREATE TABLE t_one_side AS SELECT NULL::DOUBLE AS a, b FROM (VALUES (1.0),(2),(3)) AS v(b);
+
+query I
+SELECT ks_test_2samp(a, b) IS NULL FROM t_one_side
+----
+true

--- a/test/sql/poibin_cdf.test
+++ b/test/sql/poibin_cdf.test
@@ -1,0 +1,126 @@
+# name: test/sql/poibin_cdf.test
+# description: Poisson Binomial CDF via Hong (2013) direct convolution
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Headline case: matches R's poibin::ppoibin ─────────────────────────────
+
+# ppoibin(2, c(0.1, 0.2, 0.3, 0.4, 0.5)) = 0.85
+query R
+SELECT poibin_cdf([0.1, 0.2, 0.3, 0.4, 0.5]::DOUBLE[], 2)
+----
+0.85
+
+# Same series, k = 0: only the all-failure outcome contributes.
+# 0.9 · 0.8 · 0.7 · 0.6 · 0.5 = 0.1512
+query R
+SELECT poibin_cdf([0.1, 0.2, 0.3, 0.4, 0.5]::DOUBLE[], 0)
+----
+0.1512
+
+# Same series, k = 5 (= n): every outcome accounted for → exactly 1.
+query R
+SELECT poibin_cdf([0.1, 0.2, 0.3, 0.4, 0.5]::DOUBLE[], 5)
+----
+1
+
+# ─── Reduces to Binomial when all probabilities are equal ──────────────────
+
+# All p = 0.5, n = 5 → Binomial(5, 0.5). P(X ≤ 2) = (C(5,0)+C(5,1)+C(5,2))/32
+# = (1 + 5 + 10) / 32 = 16/32 = 0.5.
+query R
+SELECT poibin_cdf([0.5, 0.5, 0.5, 0.5, 0.5]::DOUBLE[], 2)
+----
+0.5
+
+# All p = 0.3, n = 4 → Binomial(4, 0.3). P(X ≤ 1) = 0.7⁴ + 4·0.3·0.7³ = 0.6517.
+query R
+SELECT poibin_cdf([0.3, 0.3, 0.3, 0.3]::DOUBLE[], 1)
+----
+0.6517
+
+# ─── Edge cases ─────────────────────────────────────────────────────────────
+
+# Empty probability list → X is deterministically 0 → P(X ≤ k) = 1 for k ≥ 0.
+query R
+SELECT poibin_cdf([]::DOUBLE[], 0)
+----
+1
+
+# k < 0 → CDF below the support is always 0.
+query R
+SELECT poibin_cdf([0.5]::DOUBLE[], -1)
+----
+0
+
+# k ≥ n → CDF above the support is always 1.
+query R
+SELECT poibin_cdf([0.5, 0.5]::DOUBLE[], 100)
+----
+1
+
+# All p = 1 → X = n deterministically, so P(X ≤ k) = 0 for k < n and 1 for k ≥ n.
+query RRR
+SELECT
+    poibin_cdf([1.0, 1.0, 1.0]::DOUBLE[], 2),
+    poibin_cdf([1.0, 1.0, 1.0]::DOUBLE[], 3),
+    poibin_cdf([1.0, 1.0, 1.0]::DOUBLE[], 4)
+----
+0	1	1
+
+# All p = 0 → X = 0 deterministically → P(X ≤ k) = 1 for k ≥ 0.
+query R
+SELECT poibin_cdf([0.0, 0.0, 0.0]::DOUBLE[], 0)
+----
+1
+
+# ─── Validity / NULL handling ───────────────────────────────────────────────
+
+# Probability outside [0, 1] → NULL (one bad entry invalidates the sum).
+query R
+SELECT poibin_cdf([0.3, 1.5]::DOUBLE[], 1)
+----
+NULL
+
+query R
+SELECT poibin_cdf([-0.1, 0.5]::DOUBLE[], 1)
+----
+NULL
+
+# NULL inside the list → NULL output.
+query R
+SELECT poibin_cdf([0.3, NULL]::DOUBLE[], 1)
+----
+NULL
+
+# NULL list → NULL.
+query R
+SELECT poibin_cdf(NULL::DOUBLE[], 1)
+----
+NULL
+
+# NULL k → NULL.
+query R
+SELECT poibin_cdf([0.3, 0.4]::DOUBLE[], NULL)
+----
+NULL
+
+# ─── Per-row evaluation (scalar over a table) ───────────────────────────────
+
+statement ok
+CREATE TABLE trial_groups AS SELECT * FROM (VALUES
+    ([0.1, 0.2, 0.3]::DOUBLE[], 1),
+    ([0.5, 0.5, 0.5, 0.5]::DOUBLE[], 2),
+    ([0.9, 0.9]::DOUBLE[], 0)
+) AS t(probs, threshold);
+
+# Group 1: ppoibin(1, c(0.1, 0.2, 0.3)) = 0.902
+# Group 2: pbinom(2, 4, 0.5) = 11/16 = 0.6875
+# Group 3: 0.1 · 0.1 = 0.01 (all-failure probability)
+query R
+SELECT poibin_cdf(probs, threshold) FROM trial_groups ORDER BY threshold
+----
+0.01
+0.902
+0.6875

--- a/test/sql/table_one.test
+++ b/test/sql/table_one.test
@@ -16,16 +16,17 @@ CREATE TABLE patients AS SELECT * FROM (VALUES
     (NULL, 'M', 27.4, 'B')
 ) AS t(age, sex, bmi, arm);
 
-# ─── Output schema is fixed (variable, level, statistic, stratum, display) ────
+# ─── Output schema is fixed (variable, level, statistic, stratum, display, p_value) ────
 
-query TTTTT
+# Without `by`: p_value is NULL on every row (nothing to compare against).
+query TTTTTR
 SELECT * FROM table_one('patients', variables := ['age']) ORDER BY statistic
 ----
-age	NULL	mean (sd)	Overall	55.6 (7.2)
-age	NULL	median [q1, q3]	Overall	54.2 [51.3, 59.6]
-age	NULL	min, max	Overall	45.7, 67.1
-age	NULL	missing	Overall	1
-age	NULL	n	Overall	7
+age	NULL	mean (sd)	Overall	55.6 (7.2)	NULL
+age	NULL	median [q1, q3]	Overall	54.2 [51.3, 59.6]	NULL
+age	NULL	min, max	Overall	45.7, 67.1	NULL
+age	NULL	missing	Overall	1	NULL
+age	NULL	n	Overall	7	NULL
 
 # ─── Numeric variable rows ──────────────────────────────────────────────────
 
@@ -271,3 +272,68 @@ SELECT * FROM table_one('staged', variables := ['height'],
     force_numerical := ['hieght'])
 ----
 force_numerical entry 'hieght' is not in 'variables'
+
+# ─── Between-group p-value column ───────────────────────────────────────────
+
+# Without `by`: p_value is NULL for every row (no comparison to make).
+query R
+SELECT DISTINCT p_value FROM table_one('patients', variables := ['age'])
+----
+NULL
+
+# Numeric variable, single-column `by`: one-way ANOVA across the strata. All
+# rows of a given variable share the same p_value so PIVOTs can grab it via
+# FIRST(p_value).
+query TR
+SELECT DISTINCT variable, p_value FROM table_one('patients',
+    variables := ['age', 'bmi'], by := ['arm'])
+ORDER BY variable
+----
+age	0.774647
+bmi	0.391848
+
+# Categorical variable, single-column `by`: chi-square independence. sex is
+# 2 F / 2 M in every arm → contingency table is identical between arms,
+# so the test is exactly p = 1.0.
+query R
+SELECT DISTINCT p_value FROM table_one('patients',
+    variables := ['sex'], by := ['arm'])
+----
+1
+
+# Multi-column `by`: the strata are tuples; the test folds them into a
+# single categorical group via the same " / " concatenation used for
+# stratum labels.
+query TR
+SELECT DISTINCT variable, p_value FROM table_one('patients',
+    variables := ['age', 'bmi'], by := ['arm', 'sex'])
+ORDER BY variable
+----
+age	0.872123
+bmi	0.673101
+
+# force_categorical composes with p_value: when stage is treated as a
+# category (rather than numeric), the test switches from ANOVA to chi-square.
+# This 3×2 contingency on (stage, arm) — built so each arm has its own
+# stage distribution — yields a chi-square p-value distinct from the
+# ANOVA-on-integers result.
+statement ok
+CREATE TABLE staged_by_arm AS SELECT * FROM (VALUES
+    (1, 'A'), (1, 'A'), (2, 'A'), (3, 'A'),
+    (2, 'B'), (3, 'B'), (3, 'B'), (3, 'B')
+) AS t(stage, arm);
+
+# As a numeric variable: ANOVA on stage by arm.
+query R
+SELECT DISTINCT p_value FROM table_one('staged_by_arm',
+    variables := ['stage'], by := ['arm'])
+----
+0.113532
+
+# Forced to categorical: chi-square on the 3×2 contingency.
+query R
+SELECT DISTINCT p_value FROM table_one('staged_by_arm',
+    variables := ['stage'], by := ['arm'],
+    force_categorical := ['stage'])
+----
+0.223130

--- a/test/sql/table_one.test
+++ b/test/sql/table_one.test
@@ -69,7 +69,7 @@ Missing	n (%)	1 (25.0%)
 # Overall is always first; then strata alphabetical. For arm='A', age has
 # 4 valid values [54.2, 61.0, 45.7, 58.3] → mean=54.8, sd≈6.7.
 query TTT
-SELECT statistic, stratum, display FROM table_one('patients', variables := ['age'], by := 'arm')
+SELECT statistic, stratum, display FROM table_one('patients', variables := ['age'], by := ['arm'])
 WHERE statistic = 'mean (sd)' ORDER BY stratum
 ----
 mean (sd)	A	54.8 (6.7)
@@ -78,7 +78,7 @@ mean (sd)	Overall	55.6 (7.2)
 
 # Categorical with by — each level (including Missing) emitted once per stratum.
 query TTT
-SELECT level, statistic, stratum FROM table_one('patients', variables := ['sex'], by := 'arm')
+SELECT level, statistic, stratum FROM table_one('patients', variables := ['sex'], by := ['arm'])
 WHERE statistic = 'n (%)' ORDER BY stratum, level
 ----
 F	n (%)	A
@@ -94,7 +94,7 @@ Missing	n (%)	Overall
 # Each by-stratum's percentages sum to 100% within the stratum (with the
 # Missing row always present, even when its count is zero).
 query T
-SELECT display FROM table_one('patients', variables := ['sex'], by := 'arm')
+SELECT display FROM table_one('patients', variables := ['sex'], by := ['arm'])
 WHERE stratum = 'A' ORDER BY level
 ----
 2 (50.0%)
@@ -125,11 +125,67 @@ SELECT * FROM table_one('does_not_exist', variables := ['age'])
 Table
 
 statement error
-SELECT * FROM table_one('patients', variables := [], by := 'arm')
+SELECT * FROM table_one('patients', variables := [], by := ['arm'])
 ----
 'variables' must not be empty
 
 statement error
-SELECT * FROM table_one('patients', variables := ['age'], by := 'missing_col')
+SELECT * FROM table_one('patients', variables := ['age'], by := ['missing_col'])
 ----
 'by' column 'missing_col' not found
+
+# ─── Multi-column `by` ──────────────────────────────────────────────────────
+
+# Two-column stratification: Cartesian product of distinct (arm, sex) tuples.
+# Stratum label joins values in declared order with " / ". Every arm × sex
+# combination in the patients fixture has at least one row, so all four
+# tuples appear alongside Overall.
+query T rowsort
+SELECT DISTINCT stratum FROM table_one('patients',
+    variables := ['age'], by := ['arm', 'sex'])
+----
+A / F
+A / M
+B / F
+B / M
+Overall
+
+# Per-stratum numeric summary picks up the right subset. For arm=A, sex=F:
+# ages 54.2 and 61.0 → mean 57.6, sd ≈ 4.8.
+query TT
+SELECT statistic, display FROM table_one('patients',
+    variables := ['age'], by := ['arm', 'sex'])
+WHERE stratum = 'A / F' AND statistic IN ('n', 'mean (sd)') ORDER BY statistic
+----
+mean (sd)	57.6 (4.8)
+n	2
+
+# Three-or-more by columns work the same way (no special-cased limit).
+# Here arm × sex × (a constant-1 column) collapses back to arm × sex strata
+# with a "1" tail on every label.
+statement ok
+CREATE TABLE patients_const AS SELECT *, 1 AS site FROM patients;
+
+query T rowsort
+SELECT DISTINCT stratum FROM table_one('patients_const',
+    variables := ['age'], by := ['arm', 'sex', 'site'])
+----
+A / F / 1
+A / M / 1
+B / F / 1
+B / M / 1
+Overall
+
+# Empty `by` list is equivalent to no `by` — only the Overall stratum.
+query T rowsort
+SELECT DISTINCT stratum FROM table_one('patients',
+    variables := ['age'], by := [])
+----
+Overall
+
+# Missing column inside a multi-column `by` is rejected the same way as
+# the single-column case.
+statement error
+SELECT * FROM table_one('patients', variables := ['age'], by := ['arm', 'bogus'])
+----
+'by' column 'bogus' not found

--- a/test/sql/table_one.test
+++ b/test/sql/table_one.test
@@ -189,3 +189,85 @@ statement error
 SELECT * FROM table_one('patients', variables := ['age'], by := ['arm', 'bogus'])
 ----
 'by' column 'bogus' not found
+
+# ─── force_categorical / force_numerical overrides ──────────────────────────
+
+# Fixture: stage is an INTEGER (catalog → numeric) but really categorical.
+# height is VARCHAR holding numeric strings (catalog → categorical) but really
+# numeric.
+statement ok
+CREATE TABLE staged AS SELECT * FROM (VALUES
+    (1, '1.65'), (2, '1.80'), (2, '1.72'), (3, '1.55'), (3, '1.90')
+) AS t(stage, height);
+
+# Without overrides: stage is numeric (mean/sd row), height is categorical
+# (one row per distinct string).
+query TT
+SELECT statistic, display FROM table_one('staged', variables := ['stage'])
+WHERE statistic = 'mean (sd)'
+----
+mean (sd)	2.2 (0.8)
+
+query TT
+SELECT level, statistic FROM table_one('staged', variables := ['height'])
+WHERE statistic = 'n (%)' ORDER BY level
+----
+1.55	n (%)
+1.65	n (%)
+1.72	n (%)
+1.80	n (%)
+1.90	n (%)
+Missing	n (%)
+
+# force_categorical flips stage into the categorical branch: per-level n (%)
+# rows instead of mean/sd.
+query TTT
+SELECT level, statistic, display FROM table_one('staged',
+    variables := ['stage'], force_categorical := ['stage'])
+ORDER BY level
+----
+1	n (%)	1 (20.0%)
+2	n (%)	2 (40.0%)
+3	n (%)	2 (40.0%)
+Missing	n (%)	0 (0.0%)
+
+# force_numerical flips height into the numeric branch: mean/sd over the
+# parsed DOUBLEs.
+query TT
+SELECT statistic, display FROM table_one('staged',
+    variables := ['height'], force_numerical := ['height'])
+WHERE statistic IN ('n', 'mean (sd)') ORDER BY statistic
+----
+mean (sd)	1.7 (0.1)
+n	5
+
+# Both overrides at once on different variables.
+query TTT rowsort
+SELECT variable, statistic, display FROM table_one('staged',
+    variables := ['stage', 'height'],
+    force_categorical := ['stage'],
+    force_numerical := ['height'])
+WHERE statistic IN ('mean (sd)', 'n')
+----
+height	mean (sd)	1.7 (0.1)
+height	n	5
+
+# A variable in both override lists is rejected.
+statement error
+SELECT * FROM table_one('staged', variables := ['stage'],
+    force_categorical := ['stage'], force_numerical := ['stage'])
+----
+'stage' is listed in both force_categorical and force_numerical
+
+# An override entry that isn't in `variables` is rejected (catches typos).
+statement error
+SELECT * FROM table_one('staged', variables := ['stage'],
+    force_categorical := ['stge'])
+----
+force_categorical entry 'stge' is not in 'variables'
+
+statement error
+SELECT * FROM table_one('staged', variables := ['height'],
+    force_numerical := ['hieght'])
+----
+force_numerical entry 'hieght' is not in 'variables'


### PR DESCRIPTION
## Summary

v0.5 closes out a broad round of statistical primitives, ggsql improvements, and clinical-table polish.

### Added
- **`corr_matrix(data, variables [, method])`** table function — long-format pairwise correlation matrix `(row_var, col_var, coef, p_value, n)`. Pearson / Spearman / Kendall under a uniform `coef` column. All n² rows for drop-in `DRAW heatmap`. Upper triangle computed once, mirrored.
- **ggsql: `WITH … VISUALIZE`** — leading CTE clauses are now accepted in front of `VISUALIZE`. The captured block is prepended to each layer's projected SQL and composes with `FACET BY`, `SCALE`, `TITLE`, multi-layer `DRAW`. Statements without a top-level `VISUALIZE` fall through to DuckDB's parser unchanged.
- **`bin_edges` / `bin_label`** — auto-binning helpers. Sturges / FD / Scott / sqrt / Rice / auto rules; pairs naturally with `table_one`.
- **`poibin_cdf(probs LIST<DOUBLE>, k BIGINT)`** — Poisson Binomial CDF via Hong (2013) direct convolution.
- **Gamma / Beta / Exponential distributions** — full d/p/q triples in R-style API.
- **Kolmogorov-Smirnov tests** — `ks_test_1samp` (against fitted normal) and `ks_test_2samp` aggregates.
- **`table_one`**: between-group `p_value` column (ANOVA for numeric, chi-square for categorical); `force_categorical` / `force_numerical` overrides.
- **ggsql marks**: `heatmap`, `density`, `regression`.
- **ggsql**: `TITLE '<text>' [SUBTITLE '<text>']` clause; `SCALE <channel> LABEL '<text>'` operator.
- **Local DuckDB submodule patch** — fmt `_SECURE_SCL` check fixed for MSVC v145 (VS2026); see `patches/0001-fmt-secure-scl-msvc-v145.patch`.

### Changed
- **`table_one`**: `by` is now `LIST<VARCHAR>` (multi-column stratification); single-column callers must wrap in a list (`by := ['arm']`).

## Test plan

- [x] sqllogictest suite passes on Windows MSVC Release
- [x] WASM (mvp / eh / threads) builds clean
- [ ] Smoke-test the v0.5.0 build in Bedevere Wise (corr_matrix → heatmap, table_one with `by` + `p_value`, `WITH … VISUALIZE` flows)
- [ ] Verify the v0.5.0 GitHub Release artifacts download and load

🤖 Generated with [Claude Code](https://claude.com/claude-code)