### PR TITLE
Release 0.6.0-i-m-not-dead

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must stay LF — CRLF breaks the `#!/usr/bin/env bash` shebang
+# under Linux and Git Bash (and core.autocrlf=true would otherwise rewrite them).
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ cmake-build-*/
 # Test runtime
 duckdb_unittest_tempdir/
 
+# Benchmark generated data
+benchmark/.data/
+
 # IDE
 .idea/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ vcpkg_installed/
 
 # Claude
 .claude/
+
+# Sigillo
+.sigillo/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **Negative binomial and hypergeometric distributions** — d/p/q/r quartets
+  matching R's signatures. `dnbinom(k, size, prob)` / `pnbinom` / `qnbinom` /
+  `rnbinom`: PMF via lgamma + closed-form CDF identity
+  `P(X ≤ k) = I_prob(size, k+1)` (regularized incomplete beta from
+  `distributions.hpp`); quantile is monotone integer search seeded from the
+  normal approximation. `dhyper(x, m, n, k)` / `phyper` / `qhyper` /
+  `rhyper`: PMF via three log-binomial-coefficients; CDF is direct PMF
+  summation (no closed form), bounded by `min(m, k)` so it's tractable for
+  the population sizes sampling-without-replacement workloads actually use.
+  Cross-verified to 6 decimals against hand-computed PMFs and direct CDF
+  summation; rnbinom mean matches `size·(1-prob)/prob` and rhyper mean
+  matches `k·m/(m+n)` within sampling noise on 50k draws.
+
 - **`lm` / `lm_summary`: R-style formula DSL** — both functions now accept a
   `formula := '<lhs> ~ <rhs>'` named parameter as an alternative to the
   explicit `y := ...` / `x := [...]` form (they are mutually exclusive).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **`lm` / `lm_summary`: R-style formula DSL** — both functions now accept a
+  `formula := '<lhs> ~ <rhs>'` named parameter as an alternative to the
+  explicit `y := ...` / `x := [...]` form (they are mutually exclusive).
+  The DSL supports additive predictors (`y ~ x1 + x2 + x3`), intercept
+  removal via `- 1` or `+ 0`, bare and quoted (`"my col"`) identifiers, and
+  free whitespace. Not supported in v0.6: interactions (`x1:x2`), wildcards
+  (`*`, `^`, `.`), inline expressions (`I(x^2)`, `log(x)`) — wrap into a
+  CTE if needed. When the intercept is removed the model summary uses R's
+  *uncentered* R² convention (`TSS = Σ y²`, not `Σ(y - ȳ)²`); interpret
+  with care.
+
 - **`lm(table, y := 'col', x := ['c1', 'c2', ...])` and `lm_summary(...)`
   table functions** — OLS linear regression via Cholesky decomposition of
   `X'X`. `lm` returns one row per term (`(Intercept)` followed by each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The extension installs and loads in DuckDB under the technical name `stats_duck` —
 that name is preserved across releases for backward compatibility.
 
-## [Unreleased]
+## [0.6.0-i-m-not-dead] - 2026-06-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **`meta(table)` table function** — per-column dataset profile in one shot.
+  Returns one row per column with `(column_name, column_type, kind, n_rows,
+  n_missing, n_distinct, min, p25, median, p75, max, mean, stddev, top,
+  top_freq)`. `kind` is a semantic classification —
+  `numeric` / `categorical` / `temporal` / `boolean` / `other` — driving
+  which slots are populated: the distribution stats fill for numeric
+  columns (cast to DOUBLE; quantile_cont type 7, sample stddev), and `top`
+  / `top_freq` (the mode and its frequency, ties broken by smaller value)
+  fill for categorical and boolean. Dataset-level summaries fall out via
+  aggregation, e.g.
+  `SELECT count(*) FILTER (WHERE kind='numeric'), sum(n_missing) FROM meta('t')`.
+  Complements DuckDB's built-in `SUMMARIZE` statement: ours is a table
+  function (joinable, filterable, composable in CTEs), adds the kind
+  classifier, and reports the mode for categorical / boolean columns.
+
 - **Negative binomial and hypergeometric distributions** — d/p/q/r quartets
   matching R's signatures. `dnbinom(k, size, prob)` / `pnbinom` / `qnbinom` /
   `rnbinom`: PMF via lgamma + closed-form CDF identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The extension installs and loads in DuckDB under the technical name `stats_duck` —
 that name is preserved across releases for backward compatibility.
 
+## [Unreleased]
+
+### Added
+
+- ggsql: `violin` mark — per-category density rendered as horizontal
+  Vega-Lite area marks via the canonical `density` transform + `column`
+  facet idiom. Required aesthetics `x` (categorical) and `y` (numeric);
+  optional channels (`color`, `opacity`, ...) propagate through the
+  encoding. Composes with `FACET BY ... ROWS` (vega `row` channel) but
+  conflicts with `FACET BY ... COLS` because both would request the
+  `column` channel. Pairs naturally with `boxplot` for distribution
+  comparison overlays.
+
 ## [0.5.0-dead-person] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,24 @@ that name is preserved across releases for backward compatibility.
   `column` channel. Pairs naturally with `boxplot` for distribution
   comparison overlays.
 
+### Changed
+
+- **`read_stat()` now reads each file's data exactly once — XPT / SAS / SPSS /
+  Stata imports are no longer O(N²).** The reader previously re-invoked the
+  ReadStat parser for every 2048-row output chunk with an increasing row offset;
+  because ReadStat's row offset reads and decodes skipped rows rather than
+  seeking (and each chunk re-opened the file from byte 0), a full scan cost
+  ≈ N²/4096 row reads — a 200k-row, 7 MB XPT took ~67 s. The file is now parsed
+  a single time into a buffered, spillable column collection that `Execute`
+  streams from, so scans are linear in row count: that 200k file now reads in
+  ~1.3 s (52×), the real-world CDISC pilot `qs.xpt` (122k rows) drops from ~39 s
+  to ~1.1 s (36×), and 1.6M rows read in ~15 s (was ~70 min by extrapolation).
+  `bind` also stops after the header instead of reading the entire data section
+  just to discover the schema, so a query reads the data once, not twice.
+  Trade-off: the parse is now eager (the whole file is read at init, before the
+  first row is returned), so a tiny `LIMIT` on a very large file reads the whole
+  file rather than a single chunk.
+
 ## [0.5.0-dead-person] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **Weibull, log-normal, and Poisson distribution functions** — d/p/q
+  triples in the same R-style API as the existing distribution families.
+  `dweibull(x, shape, [scale])` / `pweibull` / `qweibull` (scale defaults
+  to 1; closed-form quantile). `dlnorm(x, [meanlog, [sdlog]])` / `plnorm`
+  / `qlnorm` (meanlog defaults to 0, sdlog to 1; reuses NormalCDF /
+  NormalQuantile). `dpois(k, lambda)` / `ppois` / `qpois` (discrete; CDF
+  uses the regularized upper incomplete gamma identity from Numerical
+  Recipes §6.2, quantile is integer search seeded from the normal
+  approximation). Non-integer `k` in `dpois` returns 0 (matches R's
+  warn-and-zero). Cross-verified against R to 6 decimal places.
+
 - ggsql: per-layer `STAT smooth | summary | identity` modifier — appended
   after a mark name as `DRAW <mark> STAT <name>`. `smooth` injects a
   Vega-Lite loess transform on `(x, y)` and groups by `color` when mapped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- ggsql: 2D `FACET BY <row_expr>, <col_expr>` — two comma-separated
+  expressions produce a row × column grid via vega-lite's facet operator
+  with both `row` and `column` sub-channels. Composes with `SCALE`,
+  `TITLE`, multi-layer `DRAW`, and `WITH … VISUALIZE`. The 1D form
+  (`FACET BY <expr>` with optional `ROWS` / `COLS` layout) is unchanged.
+  `ROWS` / `COLS` is rejected in the 2D form since the layout is fixed.
+  The bar mark's GROUP BY extends to both facet columns so per-cell
+  ordinal bins compute correctly.
+
 - ggsql: `violin` mark — per-category density rendered as horizontal
   Vega-Lite area marks via the canonical `density` transform + `column`
   facet idiom. Required aesthetics `x` (categorical) and `y` (numeric);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- `table_one`: new `effect_size` output column carrying the between-group
+  magnitude alongside `p_value`. Numeric variables get **η² (eta-squared)**
+  from `anova_oneway` (`ss_between / ss_total`); categorical variables
+  get **Cramér's V** computed inline as `√(χ²/(n · (min(rows, cols) - 1)))`
+  from `chisq_independence`. Both are in [0, 1] and larger means stronger
+  association, so a single uniform column name works across kinds — the
+  variable's `statistic` rows tell the consumer which is which. NULL under
+  the same conditions as `p_value` (no `by`, single stratum, test
+  infeasible). Repeated on every row of a variable so a downstream PIVOT
+  can grab it via `FIRST(effect_size)`.
+
 - **Weibull, log-normal, and Poisson distribution functions** — d/p/q
   triples in the same R-style API as the existing distribution families.
   `dweibull(x, shape, [scale])` / `pweibull` / `qweibull` (scale defaults

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **`lm(table, y := 'col', x := ['c1', 'c2', ...])` and `lm_summary(...)`
+  table functions** — OLS linear regression via Cholesky decomposition of
+  `X'X`. `lm` returns one row per term (`(Intercept)` followed by each
+  predictor in user-supplied order) with columns
+  `(term VARCHAR, estimate, std_error, t_statistic, p_value)`. `lm_summary`
+  returns a single-row model summary
+  `(r_squared, adj_r_squared, f_statistic, f_p_value, df_model BIGINT,
+  df_residual BIGINT, sigma, n BIGINT)`. Both share a bind path and a fit
+  routine — calling `lm` and `lm_summary` with the same arguments fits the
+  model twice; collapse with a CTE if you need both shapes from one fit.
+  Complete-case row filtering (any NULL in y or any x drops the row) at
+  the SQL level so the OLS solver always sees a complete design matrix.
+  Cross-verified against R on the built-in `cars` (simple) and `mtcars`
+  (multi-predictor) datasets to ≥4 decimals on coefficients / standard
+  errors / R² / F. Singular `X'X` (e.g. perfectly collinear predictors) or
+  insufficient data (`n ≤ p + 1`) raises a clear bind error rather than
+  silently NaN'ing.
+
 - **Random sampling functions** — completes the d/p/q/**r** quartet for every
   distribution family currently in the extension: `rnorm([mean=0, sd=1])`,
   `rt(df)`, `rchisq(df)`, `rf(df1, df2)`, `rgamma(shape, [rate=1])`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **`bootstrap(value DOUBLE, statistic VARCHAR, n_iters BIGINT [, seed BIGINT])`
+  → LIST<DOUBLE>** — buffer-based aggregate that resamples the input with
+  replacement `n_iters` times and emits the chosen summary statistic for
+  each resample. `statistic` ∈ `{mean, median, sum, stddev (alias sd),
+  variance (alias var), min, max}`. When `seed` is provided the RNG
+  (std::mt19937_64) is seeded deterministically — mixed with the per-row
+  index so multi-group `GROUP BY` bootstraps produce stable but distinct
+  streams. Empty input → NULL list. Composes naturally with `list_quantile`
+  for percentile CIs:
+  ```
+  WITH b AS (SELECT bootstrap(price, 'mean', 1000, 42) AS samples FROM t)
+  SELECT list_quantile(samples, 0.025) AS lo,
+         list_quantile(samples, 0.975) AS hi
+  FROM b;
+  ```
+
 - `table_one`: new `effect_size` output column carrying the between-group
   magnitude alongside `p_value`. Numeric variables get **η² (eta-squared)**
   from `anova_oneway` (`ss_between / ss_total`); categorical variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- **Random sampling functions** — completes the d/p/q/**r** quartet for every
+  distribution family currently in the extension: `rnorm([mean=0, sd=1])`,
+  `rt(df)`, `rchisq(df)`, `rf(df1, df2)`, `rgamma(shape, [rate=1])`,
+  `rbeta(alpha, beta)`, `rexp([rate=1])`, `rweibull(shape, [scale=1])`,
+  `rlnorm([meanlog=0, sdlog=1])`, `rpois(lambda)`. Per-row inverse-CDF on a
+  thread-local `std::mt19937_64` (seeded from `std::random_device` on first
+  use). The functions are marked VOLATILE and use explicit per-row loops
+  rather than `UnaryExecutor` / `BinaryExecutor` so that constant-vector
+  parameter inputs (`rnorm(0, 1)`) don't trip the per-chunk-cache fast path
+  that would otherwise produce only ~N/vector_size unique values across an
+  N-row scan. Uniform draws use the bit-shift method on the top 53 bits of a
+  single mt19937_64 draw (MSVC's `uniform_real_distribution` /
+  `generate_canonical` have biased tails on the platform we ship today).
+
 - **`bootstrap(value DOUBLE, statistic VARCHAR, n_iters BIGINT [, seed BIGINT])`
   → LIST<DOUBLE>** — buffer-based aggregate that resamples the input with
   replacement `n_iters` times and emits the chosen summary statistic for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ that name is preserved across releases for backward compatibility.
 
 ### Added
 
+- ggsql: per-layer `STAT smooth | summary | identity` modifier — appended
+  after a mark name as `DRAW <mark> STAT <name>`. `smooth` injects a
+  Vega-Lite loess transform on `(x, y)` and groups by `color` when mapped
+  (rejected on marks that already emit their own transform — `regression`,
+  `density`, `violin`, `histogram`). `summary` rewrites the layer's data
+  SQL to `AVG(y) GROUP BY x [, color, facet, facet2] ORDER BY x` so each
+  cell collapses to its mean. `identity` is the explicit no-op. Multi-
+  layer composition like `DRAW point DRAW line STAT smooth` produces the
+  canonical scatter-with-LOESS overlay without a separate transform
+  function.
+
 - ggsql: 2D `FACET BY <row_expr>, <col_expr>` — two comma-separated
   expressions produce a row × column grid via vega-lite's facet operator
   with both `row` and `column` sub-channels. Composes with `SCALE`,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: Massimo
 repository-code: "https://github.com/caerbannogwhite/the-stats-duck"
 url: "https://github.com/caerbannogwhite/the-stats-duck"
-version: 0.5.0-dead-person
-date-released: "2026-05-31"
+version: 0.6.0-i-m-not-dead
+date-released: "2026-06-15"
 license: Apache-2.0
 keywords:
   - duckdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(EXTENSION_SOURCES
     src/corr_matrix_function.cpp
     src/lm_function.cpp
     src/table_one_function.cpp
+    src/meta_function.cpp
     src/normality_function.cpp
     src/ks_test_function.cpp
     src/anova_function.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(EXTENSION_SOURCES
     src/sign_test_function.cpp
     src/adjust_p_function.cpp
     src/poibin_function.cpp
+    src/bootstrap_function.cpp
     src/auto_bin_function.cpp
     src/corr_matrix_function.cpp
     src/table_one_function.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(EXTENSION_SOURCES
     src/ttest_agg_function.cpp
     src/nonparametric_function.cpp
     src/distribution_functions.cpp
+    src/random_sampling_function.cpp
     src/summary_stats_function.cpp
     src/correlation_function.cpp
     src/rank_correlation_function.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(EXTENSION_SOURCES
     src/bootstrap_function.cpp
     src/auto_bin_function.cpp
     src/corr_matrix_function.cpp
+    src/lm_function.cpp
     src/table_one_function.cpp
     src/normality_function.cpp
     src/ks_test_function.cpp

--- a/README.md
+++ b/README.md
@@ -180,6 +180,45 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `bin_label(x, edges)` | Label for the bin containing `x` given an edge vector (typically from `bin_edges`) |
 | `bootstrap(x, statistic, n_iters [, seed])` *(aggregate)* | With-replacement resampling — emits `LIST<DOUBLE>` of length `n_iters`. `statistic` ∈ `{mean, median, sum, stddev, variance, min, max}` |
 
+### Dataset profile (table function)
+
+| Function       | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| `meta(data)`   | One row per column with kind classification + light stats |
+
+```sql
+SELECT * FROM meta('penguins');
+```
+
+Output columns (fixed schema):
+`column_name`, `column_type`, `kind`, `n_rows`, `n_missing`, `n_distinct`,
+`min`, `p25`, `median`, `p75`, `max`, `mean`, `stddev`, `top`, `top_freq`.
+
+- `kind` is a semantic classification —
+  `numeric` / `categorical` / `temporal` / `boolean` / `other` — derived
+  from the catalog type. It controls which distribution columns are
+  populated: numeric kinds fill `min` / `p25` / `median` / `p75` / `max` /
+  `mean` / `stddev` (cast to DOUBLE; `quantile_cont` type 7, sample
+  stddev), and `categorical` / `boolean` fill `top` (the mode, ties broken
+  by smaller value) and `top_freq` (its count).
+- `n_rows` is the source table's row count, repeated on every row so any
+  single row is self-contained.
+- Dataset-level summaries fall out via aggregation:
+
+  ```sql
+  SELECT count(*) FILTER (WHERE kind = 'numeric')     AS n_numeric,
+         count(*) FILTER (WHERE kind = 'categorical') AS n_categorical,
+         sum(n_missing)                               AS total_missing,
+         count(*) FILTER (WHERE n_missing > 0)        AS cols_with_nulls
+  FROM meta('penguins');
+  ```
+
+- Overlaps DuckDB's built-in `SUMMARIZE` but is a table function
+  (joinable, filterable, composable in CTEs), adds the kind classifier,
+  and reports a mode for categorical / boolean columns. Per-column
+  detail (skewness, kurtosis, custom quantile types, bias-corrected
+  variants) lives in `summary_stats(column)`.
+
 ### Table 1 summary (table function)
 
 | Function                                          | Description                                                |

--- a/README.md
+++ b/README.md
@@ -273,17 +273,19 @@ without a top-level `VISUALIZE` keyword fall through to DuckDB's normal SQL
 parser unchanged.
 
 **Marks:** `point`, `line`, `bar`, `histogram`, `text`, `area`, `rule`, `tick`,
-`errorbar`, `errorband`, `boxplot`, `heatmap`, `density`, `regression`. Custom
+`errorbar`, `errorband`, `boxplot`, `violin`, `heatmap`, `density`, `regression`. Custom
 marks register as `ggsql_mark_v1_<name>` scalar functions and are discovered
 via DuckDB's catalog, so other extensions can ship their own marks without
 modifying stats_duck.
 
 `heatmap` is a `rect` mark with ordinal x/y and quantitative color (correlation
 matrices, contingency tables). `density` runs Vega-Lite's KDE on the `x`
-aesthetic, grouped by `color` if mapped (one curve per category). `regression`
-fits a linear `y ~ x` model server-side via Vega-Lite's regression transform,
-also grouped by `color`. Use `DRAW point DRAW regression` for a scatter-with-
-fit overlay.
+aesthetic, grouped by `color` if mapped (one curve per category). `violin`
+renders one horizontal density per category of `x`, laid out via vega-lite's
+`column` facet (composes with `FACET BY ... ROWS` but conflicts with
+`FACET BY ... COLS`). `regression` fits a linear `y ~ x` model server-side
+via Vega-Lite's regression transform, also grouped by `color`. Use
+`DRAW point DRAW regression` for a scatter-with-fit overlay.
 
 **Aesthetic channels:** `x`, `y`, `color`, `fill`, `stroke`, `shape`, `size`,
 `opacity`, `tooltip`, `text`, `x2`, `y2`. Unknown channels are silently dropped.

--- a/README.md
+++ b/README.md
@@ -164,10 +164,17 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `dpois(k, lambda)`       | Poisson PMF (discrete) |
 | `ppois(q, lambda)`       | Poisson CDF |
 | `qpois(p, lambda)`       | Poisson quantile (integer search) |
+| `dnbinom(k, size, prob)` | Negative binomial PMF (count of failures before `size` successes; `prob` per-trial) |
+| `pnbinom(q, size, prob)` | Negative binomial CDF — closed form via regularized incomplete beta |
+| `qnbinom(p, size, prob)` | Negative binomial quantile (integer search) |
+| `dhyper(x, m, n, k)`     | Hypergeometric PMF (`m` successes / `n` failures / `k` draws without replacement) |
+| `phyper(q, m, n, k)`     | Hypergeometric CDF (direct PMF sum; tractable for typical population sizes) |
+| `qhyper(p, m, n, k)`     | Hypergeometric quantile |
 | `rnorm([mean], [sd])`    | Random sample from a normal — **volatile, per-row** |
 | `rt(df)` / `rchisq(df)` / `rf(df1, df2)` | Student-t / χ² / F samples |
 | `rgamma(shape, [rate])` / `rbeta(alpha, beta)` / `rexp([rate])` | Gamma / Beta / Exponential samples |
 | `rweibull(shape, [scale])` / `rlnorm([meanlog], [sdlog])` / `rpois(lambda)` | Weibull / Log-normal / Poisson samples |
+| `rnbinom(size, prob)` / `rhyper(m, n, k)` | Negative binomial / Hypergeometric samples |
 | `poibin_cdf(probs LIST<DOUBLE>, k BIGINT)` | Poisson Binomial CDF — `P(X ≤ k)` for `X = Σᵢ Bᵢ`, `Bᵢ ∼ Bernoulli(pᵢ)` |
 | `bin_edges(x [, method])` *(aggregate)* | Auto bin-edge vector for `x` — `sturges` (default), `fd`, `scott`, `sqrt`, `rice`, `auto` |
 | `bin_label(x, edges)` | Label for the bin containing `x` given an edge vector (typically from `bin_edges`) |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `dexp(x, [rate])`        | Exponential PDF (rate=1 default) |
 | `pexp(x, [rate])`        | Exponential CDF         |
 | `qexp(p, [rate])`        | Exponential quantile (closed form) |
+| `dweibull(x, shape, [scale])` | Weibull PDF (scale=1 default) |
+| `pweibull(x, shape, [scale])` | Weibull CDF |
+| `qweibull(p, shape, [scale])` | Weibull quantile (closed form) |
+| `dlnorm(x, [meanlog], [sdlog])` | Log-normal PDF (meanlog=0, sdlog=1 defaults) |
+| `plnorm(x, [meanlog], [sdlog])` | Log-normal CDF |
+| `qlnorm(p, [meanlog], [sdlog])` | Log-normal quantile |
+| `dpois(k, lambda)`       | Poisson PMF (discrete) |
+| `ppois(q, lambda)`       | Poisson CDF |
+| `qpois(p, lambda)`       | Poisson quantile (integer search) |
 | `poibin_cdf(probs LIST<DOUBLE>, k BIGINT)` | Poisson Binomial CDF — `P(X ≤ k)` for `X = Σᵢ Bᵢ`, `Bᵢ ∼ Bernoulli(pᵢ)` |
 | `bin_edges(x [, method])` *(aggregate)* | Auto bin-edge vector for `x` — `sturges` (default), `fd`, `scott`, `sqrt`, `rice`, `auto` |
 | `bin_label(x, edges)` | Label for the bin containing `x` given an edge vector (typically from `bin_edges`) |

--- a/README.md
+++ b/README.md
@@ -245,12 +245,28 @@ SELECT * FROM lm_summary('mtcars', y := 'mpg', x := ['wt', 'hp']);
 --   0.8268     0.8148         69.21        9.11e-12   2         29           2.593  32
 ```
 
+A `formula` named parameter accepts an R-style spec as an alternative to the
+explicit `y` / `x` form:
+
+```sql
+SELECT * FROM lm('mtcars', formula := 'mpg ~ wt + hp');
+SELECT * FROM lm('mtcars', formula := 'mpg ~ wt + hp - 1');  -- no intercept
+SELECT * FROM lm('weird_names', formula := '"My Y" ~ "x.with.dots"');
+```
+
+The formula grammar supports additive predictors, `- 1` or `+ 0` to drop the
+intercept, bare and `"..."`-quoted identifiers, and free whitespace.
+Interactions (`x1:x2`), wildcards (`*`, `^`, `.`) and inline expressions
+(`I(x^2)`, `log(x)`) are not supported in v0.6 — wrap into a CTE if you need
+transformed columns. `formula` and `y` / `x` are mutually exclusive.
+
 OLS via Cholesky decomposition of `X'X`. Rows with NULL in `y` or any `x` are
-dropped (complete-case). Term order follows the user-supplied `x` list, after
-the intercept. Calling `lm` and `lm_summary` with the same arguments fits the
-model twice — use a CTE if you need both shapes from a single fit. Errors on
-singular `X'X` (perfectly collinear predictors) or insufficient rows
-(`n ≤ p + 1`).
+dropped (complete-case). Term order follows the user-supplied predictor order,
+after the intercept. Calling `lm` and `lm_summary` with the same arguments
+fits the model twice — use a CTE if you need both shapes from a single fit.
+Errors on singular `X'X` (perfectly collinear predictors) or insufficient rows
+(`n ≤ k` parameters). When the intercept is removed, R²/adj-R² use the
+uncentered TSS = Σ y² to match R's `summary.lm` — interpret with care.
 
 ### Multiple-testing correction (scalar)
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ runs each layer's SQL and feeds the rows to vega-embed via the `datasets` API.
 VISUALIZE <expr> AS <aesthetic> [: <type>] (, <expr> AS <aesthetic> ...)
 FROM <table>
 DRAW <mark> (DRAW <mark>)*
-[FACET BY <expr> [ROWS | COLS]]
+[FACET BY <expr> [ROWS | COLS] | FACET BY <row_expr>, <col_expr>]
 [SCALE <channel> {TO <scheme> | ZERO true|false | DOMAIN <lo> <hi> | LABEL '<text>'}]*
 [TITLE '<text>' [SUBTITLE '<text>']]
 ```
@@ -508,6 +508,13 @@ VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW line;
 ```sql
 VISUALIZE bill_len AS x, bill_dep AS y FROM penguins
 DRAW point FACET BY species ROWS;
+```
+
+#### 2D facet grid — species rows × sex columns
+
+```sql
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins
+DRAW point FACET BY species, sex;
 ```
 
 #### SQL expressions in mappings

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | ------------------------------------------------- | ---------------------------------------------------------- |
 | `table_one(data, variables [, by])`               | Long-format descriptives table for mixed variable types    |
 | `corr_matrix(data, variables [, method])`         | Long-format pairwise correlation matrix (`pearson` / `spearman` / `kendall`) |
+| `lm(data, y, x)` / `lm_summary(data, y, x)`       | OLS regression — `lm` returns per-term coefficients, `lm_summary` returns model R² / F / σ |
 
 ```sql
 SELECT * FROM table_one(
@@ -229,6 +230,27 @@ PIVOT table_one('patients', variables := ['age', 'sex'], by := ['arm'])
     ON stratum USING first(display)
     GROUP BY variable, level, statistic;
 ```
+
+### Linear regression (table function)
+
+```sql
+SELECT * FROM lm('mtcars', y := 'mpg', x := ['wt', 'hp']);
+--   term        estimate  std_error  t_statistic  p_value
+--   (Intercept) 37.2273   1.5988     23.285       2.57e-20
+--   wt          -3.8778   0.6327     -6.129       1.12e-06
+--   hp          -0.0318   0.0090     -3.519       1.45e-03
+
+SELECT * FROM lm_summary('mtcars', y := 'mpg', x := ['wt', 'hp']);
+--   r_squared  adj_r_squared  f_statistic  f_p_value  df_model  df_residual  sigma  n
+--   0.8268     0.8148         69.21        9.11e-12   2         29           2.593  32
+```
+
+OLS via Cholesky decomposition of `X'X`. Rows with NULL in `y` or any `x` are
+dropped (complete-case). Term order follows the user-supplied `x` list, after
+the intercept. Calling `lm` and `lm_summary` with the same arguments fits the
+model twice — use a CTE if you need both shapes from a single fit. Errors on
+singular `X'X` (perfectly collinear predictors) or insufficient rows
+(`n ≤ p + 1`).
 
 ### Multiple-testing correction (scalar)
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `poibin_cdf(probs LIST<DOUBLE>, k BIGINT)` | Poisson Binomial CDF — `P(X ≤ k)` for `X = Σᵢ Bᵢ`, `Bᵢ ∼ Bernoulli(pᵢ)` |
 | `bin_edges(x [, method])` *(aggregate)* | Auto bin-edge vector for `x` — `sturges` (default), `fd`, `scott`, `sqrt`, `rice`, `auto` |
 | `bin_label(x, edges)` | Label for the bin containing `x` given an edge vector (typically from `bin_edges`) |
+| `bootstrap(x, statistic, n_iters [, seed])` *(aggregate)* | With-replacement resampling — emits `LIST<DOUBLE>` of length `n_iters`. `statistic` ∈ `{mean, median, sum, stddev, variance, min, max}` |
 
 ### Table 1 summary (table function)
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ SELECT * FROM table_one(
 ```
 
 Output columns (long format, fixed schema):
-`variable`, `level`, `statistic`, `stratum`, `display`, `p_value`
+`variable`, `level`, `statistic`, `stratum`, `display`, `p_value`, `effect_size`
 
 - Each numeric variable yields rows for `n`, `missing`, `mean (sd)`,
   `median [q1, q3]`, `min, max` — `level` is NULL.
@@ -203,6 +203,12 @@ Output columns (long format, fixed schema):
   ANOVA (`anova_oneway`); categorical variables use chi-square independence
   (`chisq_independence`). NULL when the underlying test is infeasible (zero
   variance, too few samples).
+- `effect_size` is the matching magnitude — **η² (eta-squared)** for
+  numeric variables (from ANOVA's `ss_between / ss_total`), **Cramér's V**
+  for categorical (`√(χ² / (n · (min(rows, cols) - 1)))`). Both are in
+  [0, 1] and larger means stronger association, so a single uniform
+  column name works across kinds. Same repetition and NULL handling as
+  `p_value`.
 - Variable types are auto-classified from the catalog: integer / floating-
   point types are numeric, everything else (VARCHAR, BOOLEAN, ENUM,
   date/time) is categorical. Override per-variable with

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ gives Q1=1.5 / Q3=3.5 (matching SAS PROC MEANS).
 | `dpois(k, lambda)`       | Poisson PMF (discrete) |
 | `ppois(q, lambda)`       | Poisson CDF |
 | `qpois(p, lambda)`       | Poisson quantile (integer search) |
+| `rnorm([mean], [sd])`    | Random sample from a normal — **volatile, per-row** |
+| `rt(df)` / `rchisq(df)` / `rf(df1, df2)` | Student-t / χ² / F samples |
+| `rgamma(shape, [rate])` / `rbeta(alpha, beta)` / `rexp([rate])` | Gamma / Beta / Exponential samples |
+| `rweibull(shape, [scale])` / `rlnorm([meanlog], [sdlog])` / `rpois(lambda)` | Weibull / Log-normal / Poisson samples |
 | `poibin_cdf(probs LIST<DOUBLE>, k BIGINT)` | Poisson Binomial CDF — `P(X ≤ k)` for `X = Σᵢ Bᵢ`, `Bᵢ ∼ Bernoulli(pᵢ)` |
 | `bin_edges(x [, method])` *(aggregate)* | Auto bin-edge vector for `x` — `sturges` (default), `fd`, `scott`, `sqrt`, `rice`, `auto` |
 | `bin_label(x, edges)` | Label for the bin containing `x` given an edge vector (typically from `bin_edges`) |

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ runs each layer's SQL and feeds the rows to vega-embed via the `datasets` API.
 [WITH [RECURSIVE] <cte> AS (...) [, <cte> AS (...)]*]
 VISUALIZE <expr> AS <aesthetic> [: <type>] (, <expr> AS <aesthetic> ...)
 FROM <table>
-DRAW <mark> (DRAW <mark>)*
+DRAW <mark> [STAT <identity|smooth|summary>] (DRAW <mark> [STAT ...])*
 [FACET BY <expr> [ROWS | COLS] | FACET BY <row_expr>, <col_expr>]
 [SCALE <channel> {TO <scheme> | ZERO true|false | DOMAIN <lo> <hi> | LABEL '<text>'}]*
 [TITLE '<text>' [SUBTITLE '<text>']]
@@ -515,6 +515,14 @@ DRAW point FACET BY species ROWS;
 ```sql
 VISUALIZE bill_len AS x, bill_dep AS y FROM penguins
 DRAW point FACET BY species, sex;
+```
+
+#### Scatter with LOESS overlay via STAT smooth
+
+```sql
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins
+DRAW point
+DRAW line STAT smooth;
 ```
 
 #### SQL expressions in mappings

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,112 @@
+# Benchmarks
+
+## `bench_xpt_read.sh` — XPT reader scan throughput
+
+Measures how `read_stat()` scales with row count when reading SAS Transport
+(`.xpt`) files. It generates files of increasing size with the extension's own
+`COPY … TO '*.xpt'` writer, then times a full-scan `count(*)` through the reader
+for each size.
+
+```sh
+# default: 25k / 50k / 100k / 200k rows, 1 rep each
+benchmark/bench_xpt_read.sh
+
+# custom sizes + repetitions (best wall time wins), and value-touching aggregate
+ROWS="100000 1000000 10000000" REPS=3 WITH_AGG=1 benchmark/bench_xpt_read.sh
+```
+
+It auto-detects the CLI and extension under `build/` (override with `DUCKDB=` /
+`STATS_DUCK_EXT=`). Timing comes from the CLI's `.timer on`, so process startup
+and the extension `LOAD` are excluded. Generated files land in
+`benchmark/.data/` (git-ignored, deleted on exit unless `KEEP_DATA=1`).
+
+The number to watch is the **ratio** column: per doubling of rows, ~2× time is
+linear, ~4× is quadratic.
+
+### Real datasets
+
+To benchmark existing `.xpt` files instead of synthetic ones, pass `FILES=` (a
+space-separated list) or `DIR=` (scanned for `*.xpt`). Row count is read from the
+query, so unknown-size files work. Unreadable files show `ERR`.
+
+```sh
+DIR=../icpsr-data benchmark/bench_xpt_read.sh
+FILES="/data/study1.xpt /data/study2.xpt" benchmark/bench_xpt_read.sh
+```
+
+**Keep licensed / access-controlled data outside the repo working tree.** Point
+the runner at a sibling directory (e.g. `../icpsr-data`), not anything under the
+repo. Datasets such as ICPSR/openICPSR releases are distributed under a
+click-through agreement (confidentiality of research subjects, country-of-concern
+sharing restrictions); committing or pushing them is redistribution and a terms
+violation. Storing them outside the tree makes an accidental `git add` (or a
+typo'd `.gitignore` path, or `git add -f`) structurally impossible — far safer
+than relying on the ignore rule for `benchmark/.data/`. Don't paste numbers
+derived from such files into committed docs either; the synthetic sweep below is
+what belongs in the repo.
+
+A good **public** real-world corpus is the [CDISC SDTM/ADaM pilot
+submission](https://github.com/cdisc-org/sdtm-adam-pilot-project) — synthetic
+demonstration data, freely redistributable, with realistic clinical-trial
+schemas (wide tables, many character columns, real labels/formats). Point the
+runner at its dataset folders with `DIR=`. Most datasets are small (≤8k rows,
+sub-second), but the long-format ones reach useful scale: `qs.xpt` is 121,749
+rows across ~50 columns and reads in **39 s** on the current reader. Its rows are
+~7× wider than the synthetic schema (≈265 vs 36 B/row), so at a comparable row
+count its per-row cost is ~2× higher (323 µs/row at 122k vs the synthetic 156 at
+100k): the O(N²) penalty scales with re-read *bytes*, so wide real tables suffer
+more, not less.
+
+Caveat: on the **current O(N²) reader** a large real file is effectively
+un-benchmarkable — extrapolating the baseline (`≈ 67 s × (N/200k)²`), 1M rows is
+~28 min and 5M rows ~12 h. Massive files are the right tool to confirm the *fix*
+scales linearly; for the baseline, the synthetic sweep is what completes.
+
+### Baseline — before any optimization
+
+Windows, MSVC `build/release`, AC power, warm page cache. 5-column schema
+(`int→double, double, double, varchar, date`):
+
+| rows | count(*) s | µs/row | ratio |
+|-----:|-----------:|-------:|------:|
+| 25k  |      1.30  |   52.0 |   —   |
+| 50k  |      4.38  |   87.6 | 3.4×  |
+| 100k |     15.61  |  156.1 | 3.6×  |
+| 200k |     67.29  |  336.5 | 4.3×  |
+
+~4× per doubling, and µs/row roughly doubles per step at the larger sizes: the
+scan is **O(N²)**. A 200k-row, 7 MB file takes 67 s. `WITH_AGG=1` (materializing
+every cell) costs essentially the same as `count(*)`, which tells you the
+re-parse — not value conversion — is the cost. (On battery the CPU throttles and
+these run ~1.3–1.4× slower; measure on AC.)
+
+### Why it's quadratic
+
+`ReadStatExecute` (`src/read_stat_function.cpp`) is called once per 2048-row
+DuckDB chunk, and **each call re-parses the file from the start**: it inits a
+fresh parser, re-opens the file, and uses `readstat_set_row_offset(state.offset)`
+to skip to where the previous chunk ended.
+
+The catch is that XPT's row-offset is not a seek. In
+`third_party/readstat/src/sas/readstat_xport_read.c` the skip path reads and
+decodes every skipped row, only suppressing the value callback:
+
+```c
+if (ctx->handle.value && !ctx->variables[i]->skip && !ctx->row_offset) { … }  // emit only at offset 0
+…
+if (ctx->row_offset) { ctx->row_offset--; }   // else: read the row off the VFS, decode it, discard
+else { ctx->parsed_row_count++; }
+```
+
+So chunk *k* reads `(k+1)·2048` rows, and a full scan of *N* rows reads/decodes
+≈ **N²/4096** rows. The large `sys` time in the baseline is the kernel servicing
+all those redundant reads (the file is re-read from byte 0 every chunk; for a
+remote `httpfs`/S3 file it would re-fetch). See the reader analysis in the
+project notes for the fix options (parse-once buffering; background-thread
+producer; projection pushdown via `READSTAT_HANDLER_SKIP_VARIABLE`).
+
+### What "fixed" looks like
+
+Once the file is parsed a single time, the ratio column should settle near
+**2.0×** (linear) and µs/row should flatten, letting you push `ROWS` into the
+millions without the run blowing up.

--- a/benchmark/bench_xpt_read.sh
+++ b/benchmark/bench_xpt_read.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# benchmark/bench_xpt_read.sh — XPT reader scan benchmark for stats_duck.
+#
+# Two modes:
+#   * synthetic (default): generates XPT files of increasing row count with the
+#     extension's own COPY ... TO '*.xpt' writer, then times a full-scan
+#     count(*) through read_stat() for each. The ratio between consecutive sizes
+#     exposes complexity — ~2x per doubling is linear, ~4x is quadratic.
+#   * real (FILES= or DIR=): times count(*) over existing .xpt files you supply.
+#     Row count is read from the query itself, so unknown-size files are fine.
+#
+# Timing uses the CLI's `.timer on` (per-statement), so process startup and the
+# extension LOAD are excluded. After the first pass files sit in the OS page
+# cache, so this measures warm-cache CPU + syscall cost — the algorithm, not disk.
+#
+# ── Using real datasets ──────────────────────────────────────────────────────
+# Point this at files that live OUTSIDE the repo working tree, e.g.
+#   DIR=../icpsr-data benchmark/bench_xpt_read.sh
+# Do NOT copy access-controlled / licensed data (e.g. ICPSR) into the repo: even
+# with benchmark/.data/ git-ignored, keeping such files outside the tree is the
+# only way to make an accidental commit structurally impossible. Never commit or
+# push them.
+#
+# Usage:
+#   benchmark/bench_xpt_read.sh
+#   ROWS="25000 50000 100000" REPS=3 benchmark/bench_xpt_read.sh
+#   WITH_AGG=1 benchmark/bench_xpt_read.sh
+#   FILES="/data/a.xpt /data/b.xpt" benchmark/bench_xpt_read.sh
+#   DIR=../icpsr-data REPS=1 benchmark/bench_xpt_read.sh
+#
+# Env:
+#   ROWS            synthetic mode: row counts (default "25000 50000 100000 200000")
+#   FILES           real mode: space-separated existing .xpt files
+#   DIR             real mode: directory to scan for *.xpt
+#   REPS            timed reps per file; best (min) wall time is reported (default 1)
+#   WITH_AGG        synthetic only: also time an aggregate touching every cell (default 0)
+#   DUCKDB          duckdb CLI (auto-detected under build/ if unset)
+#   STATS_DUCK_EXT  extension path (auto-detected under build/ if unset)
+#   KEEP_DATA       synthetic only: keep generated files (default 0 — removed on exit)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."   # repo root
+
+ROWS="${ROWS:-25000 50000 100000 200000}"
+REPS="${REPS:-1}"
+WITH_AGG="${WITH_AGG:-0}"
+FILES="${FILES:-}"
+DIR="${DIR:-}"
+DATA_DIR="benchmark/.data"
+
+detect() { for c in "$@"; do [ -e "$c" ] && { echo "$c"; return 0; }; done; return 1; }
+
+DUCKDB="${DUCKDB:-$(detect \
+  build/release/Release/duckdb.exe build/release/duckdb \
+  build/mingw_release/duckdb.exe build/debug/Debug/duckdb.exe || true)}"
+STATS_DUCK_EXT="${STATS_DUCK_EXT:-$(detect \
+  build/release/extension/stats_duck/stats_duck.duckdb_extension \
+  build/mingw_release/extension/stats_duck/stats_duck.duckdb_extension || true)}"
+
+[ -n "$DUCKDB" ] && [ -e "$DUCKDB" ] || { echo "error: no duckdb CLI found; set DUCKDB=" >&2; exit 1; }
+[ -n "$STATS_DUCK_EXT" ] && [ -e "$STATS_DUCK_EXT" ] || { echo "error: no stats_duck extension found; set STATS_DUCK_EXT=" >&2; exit 1; }
+
+echo "duckdb:    $DUCKDB"
+echo "extension: $STATS_DUCK_EXT"
+echo "reps:      $REPS"
+echo
+
+filesize() { stat -c %s "$1" 2>/dev/null || wc -c <"$1"; }
+
+# Normalize an absolute path for the (possibly native-Windows) duckdb CLI. Under
+# MSYS/Git-Bash the shell hands out /c/... paths the native CLI can't open;
+# cygpath -m rewrites them to C:/... Relative paths and non-MSYS systems pass
+# through untouched (cygpath is absent on Linux/macOS).
+winpath() {
+  case "$1" in
+    /*) command -v cygpath >/dev/null 2>&1 && cygpath -m "$1" || echo "$1" ;;
+    *)  echo "$1" ;;
+  esac
+}
+
+# Run count(*) once via .timer/.mode list; echo "ROWS REAL_SECONDS".
+# .mode list + .headers off makes the result a bare integer we can grep.
+# tr -d '\r' strips the CLI's CRLF line endings so the integer match is robust.
+# A read failure (unsupported/corrupt file) yields rows=ERR rather than a count.
+measure() {
+  local f="$1" out rows t wf
+  wf=$(winpath "$f")
+  out=$(printf "LOAD '%s';\n.headers off\n.mode list\n.timer on\nSELECT count(*) FROM read_stat('%s');\n" \
+        "$STATS_DUCK_EXT" "$wf" | "$DUCKDB" -unsigned 2>&1 | tr -d '\r') || true
+  rows=$(printf '%s\n' "$out" | grep -E '^[0-9]+$' | tail -1)
+  t=$(printf '%s\n' "$out" | sed -n 's/.*Run Time (s): real \([0-9.]*\).*/\1/p' | tail -1)
+  if [ -z "$rows" ] && printf '%s' "$out" | grep -qi "error"; then rows="ERR"; fi
+  echo "${rows:-NA} ${t:-NA}"
+}
+
+# measure REPS times; echo "ROWS BEST_SECONDS".
+best() {
+  local f="$1" rows="" best="" r res rr tt
+  for ((r=0; r<REPS; r++)); do
+    res=$(measure "$f"); rr=${res% *}; tt=${res#* }
+    rows="$rr"
+    if [ "$tt" != "NA" ] && { [ -z "$best" ] || awk "BEGIN{exit !($tt<$best)}"; }; then best="$tt"; fi
+  done
+  echo "$rows ${best:-NA}"
+}
+
+us_per_row() { awk "BEGIN{ if(\"$1\"==\"NA\"||$1==0||\"$2\"==\"NA\"){print \"NA\"}else{printf \"%.2f\",$2*1e6/$1} }"; }
+
+# ── real mode ────────────────────────────────────────────────────────────────
+if [ -n "$FILES$DIR" ]; then
+  list=()
+  for f in $FILES; do list+=("$f"); done
+  if [ -n "$DIR" ]; then
+    shopt -s nullglob
+    for f in "$DIR"/*.xpt "$DIR"/*.XPT; do list+=("$f"); done
+    shopt -u nullglob
+  fi
+  [ ${#list[@]} -gt 0 ] || { echo "error: no .xpt files in FILES/DIR" >&2; exit 1; }
+
+  printf "%-32s %-9s %-12s %-10s %-9s\n" "file" "MB" "rows" "count_s" "us/row"
+  printf -- "-------------------------------- --------- ------------ ---------- ---------\n"
+  for f in "${list[@]}"; do
+    [ -e "$f" ] || { echo "skip (missing): $f" >&2; continue; }
+    mb=$(awk "BEGIN{printf \"%.1f\", $(filesize "$f")/1048576}")
+    res=$(best "$f"); rows=${res% *}; t=${res#* }
+    printf "%-32s %-9s %-12s %-10s %-9s\n" "$(basename "$f")" "$mb" "$rows" "$t" "$(us_per_row "$rows" "$t")"
+  done
+  exit 0
+fi
+
+# ── synthetic mode ───────────────────────────────────────────────────────────
+mkdir -p "$DATA_DIR"
+cleanup() { [ "${KEEP_DATA:-0}" = "1" ] || rm -rf "$DATA_DIR"; }
+trap cleanup EXIT
+
+# 5-column schema: int->double, double, low-card double, varchar, date.
+# Exercises numeric, string (UTF-8 sanitize + heap copy) and date (per-cell
+# epoch detection) paths. Names <=8 chars / uppercase per XPT v5 rules.
+GEN="SELECT i AS ID, (i*1.5)::DOUBLE AS X, (i%7)::DOUBLE AS GRP, \
+('S'||(i%1000))::VARCHAR AS NM, (DATE '2000-01-01' + (i%3650)::INTEGER)::DATE AS DT \
+FROM range"
+
+echo "rows:      $ROWS   with_agg: $WITH_AGG"
+echo
+printf "%-10s %-9s %-10s %-11s %-8s\n" "rows" "file_MB" "count_s" "us/row" "ratio"
+printf -- "---------- --------- ---------- ----------- --------\n"
+
+prev=""
+for n in $ROWS; do
+  f="$DATA_DIR/n$n.xpt"
+  "$DUCKDB" -unsigned -c "LOAD '$STATS_DUCK_EXT'; COPY ($GEN($n) t(i)) TO '$f';" >/dev/null
+  mb=$(awk "BEGIN{printf \"%.1f\", $(filesize "$f")/1048576}")
+  res=$(best "$f"); t=${res#* }
+  ratio="-"
+  [ -n "$prev" ] && [ "$t" != "NA" ] && ratio=$(awk "BEGIN{printf \"%.2fx\", $t/$prev}")
+  printf "%-10s %-9s %-10s %-11s %-8s\n" "$n" "$mb" "$t" "$(us_per_row "$n" "$t")" "$ratio"
+  prev="$t"
+  if [ "$WITH_AGG" = "1" ]; then
+    out=$(printf "LOAD '%s';\n.timer on\nSELECT sum(X), max(DT), sum(length(NM)) FROM read_stat('%s');\n" \
+          "$STATS_DUCK_EXT" "$f" | "$DUCKDB" -unsigned 2>&1) || true
+    at=$(printf '%s\n' "$out" | sed -n 's/.*Run Time (s): real \([0-9.]*\).*/\1/p' | tail -1)
+    printf "%-10s %-9s %-10s %-11s %-8s\n" "  +agg" "" "${at:-NA}" "" ""
+  fi
+done

--- a/notes/engineering/2026-06-volatile-and-rng-bias.md
+++ b/notes/engineering/2026-06-volatile-and-rng-bias.md
@@ -1,0 +1,256 @@
+# Two RNG footguns we hit shipping the `r*` random-sampling functions
+
+*June 2026, while landing `rnorm` / `rt` / `rchisq` / `rf` / `rgamma` / `rbeta` / `rexp` / `rweibull` / `rlnorm` / `rpois` for v0.6.*
+
+This is the kind of bug that produces plausible-looking output for a long time
+before someone runs a careful Monte Carlo and notices the numbers don't quite
+match theory. We hit two such bugs back-to-back. Both are worth writing down
+because the diagnostic path was a small adventure and the fixes are non-obvious.
+
+## TL;DR
+
+1. **DuckDB's `UnaryExecutor` / `BinaryExecutor` short-circuit constant-vector
+   inputs by invoking the user lambda once per chunk and broadcasting the
+   result.** That is correct for pure functions and catastrophic for sampling
+   functions. Marking the function `VOLATILE` stops constant-folding at the
+   planner level but does not disable the executor-level fast path. Fix: drop
+   the helpers and run an explicit per-row loop via `UnifiedVectorFormat`.
+2. **MSVC's `std::uniform_real_distribution<double>` and
+   `std::generate_canonical<double, 53>` have biased tails in this toolchain.**
+   They produce uniform values whose CDF is visibly off from `U ~ Uniform(0, 1)`
+   when you feed them through an inverse-CDF transform with a heavy right tail
+   (exponential, gamma). Fix: take the top 53 bits of a single `mt19937_64`
+   draw and scale by `2^-53` manually.
+
+## What we shipped, then what we noticed
+
+The naive first draft of `rexp(rate)` looked like every other distribution
+scalar we'd written:
+
+```cpp
+static void RExp1Exec(DataChunk &args, ExpressionState &, Vector &result) {
+    UnaryExecutor::ExecuteWithNulls<double, double>(
+        args.data[0], result, args.size(),
+        [](double rate, ValidityMask &mask, idx_t idx) {
+            return SafeSample(
+                [&](double u) { return stats_duck::ExponentialQuantile(u, rate); },
+                mask, idx);
+        });
+}
+```
+
+We then ran a smoke test:
+
+```sql
+SELECT round(avg(rexp(1.0)), 2) AS mean,
+       round(max(rexp(1.0)), 1) AS mx
+FROM range(500000);
+```
+
+The exponential distribution with rate λ=1 has mean 1.0 and, for a sample of
+500k iid draws, an expected maximum near `log(500_000) + γ ≈ 13.7`. We got
+mean ≈ 0.92 to 1.1 (varying across runs) and max around 8. The mean was
+clearly biased and the right tail was conspicuously truncated.
+
+`rnorm()` (the zero-argument form) gave correct moments. `rgamma(2, 3)` was
+also slightly off. So the problem correlated with **which executor pattern we
+used**, not which distribution the quantile function was for.
+
+## Bug 1 — `UnaryExecutor` caches the lambda result for constant inputs
+
+The killer diagnostic was counting distinct values:
+
+```sql
+SELECT count(*) AS total, count(DISTINCT v) AS distinct_cnt
+FROM (SELECT rexp(1.0) AS v FROM range(500000));
+```
+
+```
+total: 500000
+distinct_cnt: 245
+```
+
+500,000 rows, **245 unique values**. The ratio `500000 / 245 ≈ 2041` is
+DuckDB's `STANDARD_VECTOR_SIZE` of 2048 — meaning each chunk got exactly one
+`u` value, replicated 2048 times.
+
+The compare-and-contrast was `rnorm()`, which used a hand-written per-row loop
+(it took no arguments so we couldn't use `UnaryExecutor` anyway). That one
+returned all distinct values across 500k rows. The difference wasn't the
+distribution — it was the executor.
+
+### Why this happens
+
+`UnaryExecutor::ExecuteWithNulls` has a fast path for `ConstantVector` inputs:
+when `args.data[0]` is a constant `1.0`, the executor reads the scalar once,
+invokes the user lambda once, and broadcasts the single result across the
+chunk. That is a sound optimisation for pure scalar functions — and DuckDB's
+expression framework has every reason to assume scalars are pure unless told
+otherwise.
+
+### Why `VOLATILE` doesn't save you
+
+We had already set:
+
+```cpp
+ScalarFunction f(...);
+f.stability = FunctionStability::VOLATILE;
+```
+
+`FunctionStability::VOLATILE` tells the **planner** "don't constant-fold or
+common-subexpression-eliminate calls to this function." It does not propagate
+to the executor's per-vector code path. The executor's constant-input fast
+path is purely a runtime optimisation, and it will fire whether the function
+is volatile or not.
+
+So `VOLATILE` does the job of stopping
+`SELECT rnorm(0, 1) + rnorm(0, 1) FROM range(N)` from being folded into
+`2 * rnorm(0, 1)`, but it doesn't stop `rnorm(0, 1)` itself from being
+broadcast inside one vector.
+
+### The fix
+
+Drop `UnaryExecutor` / `BinaryExecutor` and write the per-row loop ourselves
+through `UnifiedVectorFormat` (which still handles constant / flat /
+dictionary input encodings, but in a loop we control):
+
+```cpp
+template <typename Quantile>
+static inline void RunPerRow1(DataChunk &args, Vector &result, Quantile &&q) {
+    idx_t count = args.size();
+    UnifiedVectorFormat a0;
+    args.data[0].ToUnifiedFormat(count, a0);
+    auto v0 = UnifiedVectorFormat::GetData<double>(a0);
+    result.SetVectorType(VectorType::FLAT_VECTOR);
+    auto out = FlatVector::GetData<double>(result);
+    auto &mask = FlatVector::Validity(result);
+    for (idx_t i = 0; i < count; i++) {
+        auto i0 = a0.sel->get_index(i);
+        if (!a0.validity.RowIsValid(i0)) {
+            mask.SetInvalid(i);
+            (void)NextUniform(); // keep RNG advance independent of NULLs
+            out[i] = 0.0;
+            continue;
+        }
+        out[i] = SafeSampleOne(
+            [&](double u) { return q(u, v0[i0]); }, mask, i);
+    }
+}
+```
+
+The result: 500,000 rows, 500,000 distinct values, mean ≈ 0.997, max ≈ 14.
+The numbers now match `Exp(1)` theory tightly.
+
+### Takeaways
+
+- The `UnaryExecutor` constant-input optimisation is a property of the
+  **executor**, not the function metadata. Volatility flags do not turn it
+  off.
+- If a scalar function genuinely needs side-effecting per-row state — RNG
+  draws, counters, time samples — assume the helpers will broadcast and
+  write the loop yourself.
+- The single most useful diagnostic for this class of bug is
+  `count(*) = count(DISTINCT v)`. If the function is supposed to vary per
+  row and that equation fails, you have an executor caching issue, full stop.
+
+## Bug 2 — MSVC's uniform-real distribution clips the tail
+
+Once the per-row loop was in place, the broad shape of the distribution was
+correct but `rexp(1.0)` still had a too-light right tail. The diagnostic:
+
+| Statistic                      | Expected (Exp(1), n=500k) | Observed (first NextUniform) |
+| ------------------------------ | ------------------------- | ---------------------------- |
+| `count(v > 5)`                 | ≈ 3370                    | 4096                         |
+| `count(v > 8)`                 | ≈ 167                     | 0                            |
+| `count(v > 10)`                | ≈ 23                      | 0                            |
+| Implied `max(u)` (= 1 - exp(-max(v))) | ≈ 1 - 1.5×10⁻⁶     | ≈ 0.999665                   |
+
+We were drawing 500k uniforms but the largest one was around 0.99966. The
+probability of *no* draw exceeding 0.999665 in 500k is `(0.999665)^500000 ≈
+e^-167 ≈ 10⁻⁷²`. Something was capping `u` from above.
+
+The first NextUniform was:
+
+```cpp
+std::uniform_real_distribution<double> dist(
+    std::nextafter(0.0, 1.0),
+    std::nextafter(1.0, 0.0));
+double u = dist(rng);
+```
+
+This was a deliberate "open interval (0, 1)" — we picked it so the inverse-CDF
+transforms below (`log(1-u)`, `qnorm(u)`) couldn't hit the endpoints. On the
+MSVC STL we ship against, that distribution does not produce uniformly
+distributed draws across its declared support: the upper tail is squeezed
+in. The same is true of `std::generate_canonical<double, 53>` on this
+toolchain.
+
+We did not chase the MSVC implementation to find exactly why. The bias is
+known — there are multi-year-old reports against MSVC STL's
+`uniform_real_distribution` for similar symptoms — and we needed a working
+RNG more than a culprit.
+
+### The fix
+
+Generate the uniform double manually from a single 64-bit `mt19937_64` draw:
+
+```cpp
+static inline double NextUniform() {
+    auto &rng = TLSRng();
+    uint64_t bits = rng() >> 11;            // keep the top 53 bits
+    double u = static_cast<double>(bits) * (1.0 / static_cast<double>(1ULL << 53));
+    if (u <= 0.0) {
+        u = std::numeric_limits<double>::min();
+    }
+    return u;
+}
+```
+
+This is the bit-shift method (sometimes called "Vigna's"): every IEEE 754
+double in `[0, 1)` with 53-bit precision gets equal probability mass. The
+upper bound is `1 - 2^-53`, so we don't need to nudge that side; we still
+nudge the lower side to keep `log(0)` and `qnorm(0)` out of reach.
+
+After the fix, the tail counts match Exp(1) theory at three-significant-figure
+precision out to the 10⁻⁵ quantile.
+
+### Takeaways
+
+- `std::uniform_real_distribution<double>` and `std::generate_canonical` are
+  fine for "give me a roughly uniform double" but not for **inverse-CDF
+  sampling**, where tail accuracy matters disproportionately.
+- For inverse-CDF, prefer the explicit bit-shift method from a 64-bit
+  generator. It costs one `rng()` call, one shift, one multiply.
+- Validating an RNG by checking moments alone is not enough — a distribution
+  that clips its upper tail can keep mean and standard deviation close to
+  theory while drastically misreporting the tail behaviour that actual
+  Monte-Carlo workloads care about. Always look at tail counts (e.g.
+  `count(v > threshold)`) against theoretical probabilities.
+
+## Diagnostic checklist for the next time
+
+If a sampling or perturbation function is producing weird-looking output:
+
+1. **`count(*) = count(DISTINCT v)`** — catches per-chunk replication.
+2. **Tail counts against theoretical probabilities** — catches uniform-RNG
+   bias that moment checks miss.
+3. **Inverse round-trip** for sanity (`pnorm(rnorm())` should have mean 0.5,
+   stddev `1/√12`).
+4. **Run the smoke test more than once** — the thread-local RNG seeds from
+   `std::random_device` once per thread, so symptoms drift between runs. A
+   single suspicious number could be sampling noise; a moving target across
+   reruns is a strong signal of the kind of bug we hit here.
+
+## Where this lives in the code
+
+- `src/random_sampling_function.cpp`
+  - `NextUniform()` — bit-shift uniform.
+  - `RunPerRow0/1/2` — generic per-row loops that bypass the broadcast
+    fast path.
+- `src/include/distributions.hpp` — quantile functions that the r* family
+  composes with (unchanged by this work — the bugs were upstream of them).
+
+If you ever need to add another VOLATILE scalar function that has side
+effects per row (counters, timestamps with sub-millisecond resolution, more
+sampling routines), reuse the `RunPerRow*` pattern. It is the only safe
+way today.

--- a/notes/engineering/2026-06-xpt-reader-quadratic.md
+++ b/notes/engineering/2026-06-xpt-reader-quadratic.md
@@ -1,0 +1,127 @@
+# The XPT reader was O(N²): ReadStat's `row_offset` reads, it doesn't seek
+
+*June 2026, while making the `read_stat()` SAS / SPSS / Stata reader performant.*
+
+Reading a SAS Transport (`.xpt`) file with `read_stat()` was pathologically slow
+— not "needs tuning" slow, *quadratic* slow. A 200k-row, 7 MB synthetic file took
+67 s; the real-world CDISC pilot `qs.xpt` (121,749 rows, ~50 columns) took 39 s.
+These files are small. Something was deeply wrong with how we scanned them.
+
+## TL;DR
+
+1. **`read_stat()` re-parsed the whole file from the start for every 2048-row
+   output chunk.** DuckDB pulls a table function chunk by chunk; the old
+   `ReadStatExecute` answered each pull by spinning up a *fresh* ReadStat parser
+   with `row_offset = chunk_start`, `row_limit = STANDARD_VECTOR_SIZE`.
+2. **ReadStat's `row_offset` is not a seek.** It reads and decodes every skipped
+   row off the VFS and merely suppresses the value callback. So chunk *k* reads
+   `(k+1)·2048` rows, and a full scan of *N* rows reads ≈ **N²/4096** rows. Each
+   chunk also re-opened the file and re-read its header records — and for an
+   httpfs/S3 path, re-fetched the bytes.
+3. **Fix: parse once.** Parse the entire file a single time at `InitGlobal` into
+   a spillable `ColumnDataCollection`; `Execute` streams chunks out of it.
+   O(N²) → O(N). Separately, `bind` was reading the *whole data section* just to
+   learn the schema — it now aborts after the header.
+
+## How we found it
+
+`benchmark/bench_xpt_read.sh` times a full-scan `count(*)` over synthetic XPT
+files of growing size. The ratio between consecutive sizes is the tell — ~2× per
+row doubling is linear, ~4× is quadratic:
+
+| rows | count(*) s | µs/row | ratio |
+|-----:|-----------:|-------:|------:|
+| 25k  |   1.30 |  52.0 |  —   |
+| 50k  |   4.38 |  87.6 | 3.4× |
+| 100k |  15.61 | 156.1 | 3.6× |
+| 200k |  67.29 | 336.5 | 4.3× |
+
+~4× per doubling, and the per-row cost itself doubles each step. That's N², not a
+constant factor. The kernel `sys` time dominated (67 s wall, ~70 s sys at 200k):
+the signature of re-reading the same bytes over and over.
+
+## Why `row_offset` doesn't help
+
+The natural assumption is that `readstat_set_row_offset(parser, k)` seeks past the
+first *k* rows. It does not. From `third_party/readstat/src/sas/readstat_xport_read.c`,
+the per-cell loop:
+
+```c
+if (ctx->handle.value && !ctx->variables[i]->skip && !ctx->row_offset) {
+    ctx->handle.value(ctx->parsed_row_count, variable, value, ctx->user_ctx); // emit only at offset 0
+}
+...
+if (ctx->row_offset) { ctx->row_offset--; }   // else: the row was read off the VFS and decoded — then dropped
+else { ctx->parsed_row_count++; }
+```
+
+The row's bytes are read (`xport_read_row`) and each variable is decoded into a
+`readstat_value_t`; `row_offset` only gates the *callback*. So "skip to row k"
+costs a full read+decode of rows `0..k-1`. With a fresh parser per chunk, the
+work is `Σ (k+1)·2048 ≈ N²/4096`.
+
+A second, quieter cost: `readstat_parse_xport` unconditionally calls
+`xport_read_data()` whenever the file has columns — it does **not** check whether
+a value handler is registered. Our `bind` registered only metadata + variable
+handlers (to read the schema) with `row_limit = 0`, and `row_limit = 0` means *no
+limit*, not *no rows*. So every `bind` streamed and decoded the entire data
+section just to throw it away — one extra full read per query.
+
+## The fix
+
+`ReadStatInitGlobal` now parses the file exactly once into a
+`ColumnDataCollection` (allocated against the client context, so it spills to the
+buffer manager on native; in WASM it stays resident, which is fine for the data
+sizes WASM handles). The ReadStat value handler stages rows into a `DataChunk`
+and appends it whenever it fills:
+
+```cpp
+while (oi - lc.flushed >= STANDARD_VECTOR_SIZE) {       // crossed a vector boundary
+    lc.staging->SetCardinality(STANDARD_VECTOR_SIZE);
+    lc.buffer->Append(*lc.append_state, *lc.staging);
+    lc.staging->Reset();
+    lc.flushed += STANDARD_VECTOR_SIZE;
+}
+```
+
+`Execute` is now just `InitializeScan` once, then `Scan` per pull. And `bind`
+registers a value handler that returns `READSTAT_HANDLER_ABORT` on the first
+value — the schema is fully known from the header (every variable handler fires
+before any row), so we stop before the data section. `READSTAT_ERROR_USER_ABORT`
+is treated as success (an empty file finishes with `READSTAT_OK`, no value seen).
+
+Result: the 200k synthetic scan dropped 67 s → 1.3 s (52×), `qs.xpt` (122k rows)
+39 s → 1.1 s (36×), and µs/row went flat at ~6.4 (it had climbed 52 → 336 across
+the sweep) — the O(N) signature. 1.6M rows now read in ~15 s; pre-fix that was
+~70 min by extrapolation. All 448 reader/round-trip test assertions still pass.
+
+## Trade-offs, and why not threads
+
+Parsing once is **eager**: the whole file is read at `InitGlobal`, before the
+first row is returned. That's a regression for one shape — `SELECT * FROM
+read_stat('huge.xpt') LIMIT 5` now reads the whole file instead of one chunk —
+but XPT is overwhelmingly a full-dataset import format, and the O(N²) full scan
+was the case that actually hurt.
+
+The streaming-and-O(N) ideal is a producer thread: run ReadStat start-to-finish
+once on a worker, push filled chunks through a bounded queue, let `Execute`
+consume, abort on early-out. That keeps `LIMIT` cheap *and* memory constant. We
+didn't do it because ReadStat is a push parser (it owns the loop and can't be
+suspended without a separate stack), so the producer needs a real thread — and
+`wasm_mvp` / `wasm_eh` are single-threaded. It would mean two code paths
+(threaded native + `wasm_threads`, buffered fallback for mvp/eh). Parse-once is
+the WASM-safe baseline that ships everywhere; the threaded path is a future option
+if the eager read ever bites.
+
+## Left on the table (constant-factor wins, now visible)
+
+With the quadratic gone, these finally show up on the meter:
+
+- **Projection pushdown.** ReadStat supports `READSTAT_HANDLER_SKIP_VARIABLE`;
+  wiring `column_ids` → skip flags avoids decoding + allocating unselected
+  columns (big for wide tables — see `qs.xpt`'s ~50 columns).
+- **String fast-path.** `SanitizeUtf8` heap-allocates a `std::string` for every
+  string cell; validate in place and `AddString` straight from ReadStat's buffer
+  on the (overwhelmingly common) already-valid path.
+- **Hoist epoch detection.** `DetectEpochSystem` runs a chain of string compares
+  per *temporal cell*; compute it once per column at bind.

--- a/notes/engineering/README.md
+++ b/notes/engineering/README.md
@@ -16,3 +16,9 @@ that has been written down than to re-derive it.
   `VOLATILE` flag does not disable this), and MSVC's
   `std::uniform_real_distribution<double>` clips the upper tail. Fixes and
   diagnostic checklist.
+
+- [`2026-06-xpt-reader-quadratic.md`](2026-06-xpt-reader-quadratic.md) — the
+  `read_stat()` XPT/SAS/SPSS reader was O(N²) because it re-parsed the file per
+  output chunk and ReadStat's `row_offset` reads-and-decodes skipped rows instead
+  of seeking (and `bind` read the whole data section for the schema). Fix:
+  parse-once buffering + header-only bind; why not a producer thread (WASM).

--- a/notes/engineering/README.md
+++ b/notes/engineering/README.md
@@ -1,0 +1,18 @@
+# Engineering notes
+
+Short writeups about non-obvious decisions and bugs that future contributors
+(or future-us) will want to know about. Each note is dated and self-contained;
+they are not living documentation, they are postmortems / decision records.
+
+If you hit a subtle bug while developing on stats_duck and the fix was longer
+than the diagnosis, please add a note here. It is much easier to find a thing
+that has been written down than to re-derive it.
+
+## Inventory
+
+- [`2026-06-volatile-and-rng-bias.md`](2026-06-volatile-and-rng-bias.md) — two
+  RNG footguns hit while landing the `r*` random-sampling family: DuckDB's
+  `UnaryExecutor` caches the lambda result for constant-vector inputs (the
+  `VOLATILE` flag does not disable this), and MSVC's
+  `std::uniform_real_distribution<double>` clips the upper tail. Fixes and
+  diagnostic checklist.

--- a/src/bootstrap_function.cpp
+++ b/src/bootstrap_function.cpp
@@ -1,0 +1,373 @@
+#include "bootstrap_function.hpp"
+
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+namespace {
+
+//===--------------------------------------------------------------------===//
+// Statistic kinds.
+//===--------------------------------------------------------------------===//
+
+enum class BootstrapStat {
+	MEAN,
+	MEDIAN,
+	SUM,
+	STDDEV,
+	VARIANCE,
+	MIN,
+	MAX,
+};
+
+static BootstrapStat ParseStat(const std::string &name) {
+	if (name == "mean") return BootstrapStat::MEAN;
+	if (name == "median") return BootstrapStat::MEDIAN;
+	if (name == "sum") return BootstrapStat::SUM;
+	if (name == "stddev" || name == "sd") return BootstrapStat::STDDEV;
+	if (name == "variance" || name == "var") return BootstrapStat::VARIANCE;
+	if (name == "min") return BootstrapStat::MIN;
+	if (name == "max") return BootstrapStat::MAX;
+	throw BinderException(
+	    "bootstrap: unknown statistic '%s' — supported: 'mean', 'median', 'sum', "
+	    "'stddev' (alias 'sd'), 'variance' (alias 'var'), 'min', 'max'",
+	    name);
+}
+
+//===--------------------------------------------------------------------===//
+// Bind data (carries the constant statistic, n_iters, seed through Finalize).
+//===--------------------------------------------------------------------===//
+
+struct BootstrapBindData : public FunctionData {
+	BootstrapStat stat = BootstrapStat::MEAN;
+	int64_t n_iters = 0;
+	int64_t seed = 0;
+	bool has_seed = false;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto copy = make_uniq<BootstrapBindData>();
+		copy->stat = stat;
+		copy->n_iters = n_iters;
+		copy->seed = seed;
+		copy->has_seed = has_seed;
+		return std::move(copy);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<BootstrapBindData>();
+		return stat == other.stat && n_iters == other.n_iters && seed == other.seed &&
+		       has_seed == other.has_seed;
+	}
+};
+
+//! Pull the constant statistic name + n_iters off the bound arguments. The
+//! statistic and n_iters are erased from the function signature so the
+//! aggregate runs as a single-input aggregate over the value column.
+static unique_ptr<FunctionData>
+BootstrapBindCommon(ClientContext &context, AggregateFunction &function,
+                    vector<unique_ptr<Expression>> &arguments, bool has_seed) {
+	auto bd = make_uniq<BootstrapBindData>();
+	bd->has_seed = has_seed;
+
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("bootstrap: 'statistic' must be a constant string");
+	}
+	Value stat_val = ExpressionExecutor::EvaluateScalar(context, *arguments[1]);
+	if (stat_val.IsNull()) {
+		throw BinderException("bootstrap: 'statistic' must not be NULL");
+	}
+	bd->stat = ParseStat(StringUtil::Lower(stat_val.GetValue<string>()));
+
+	if (!arguments[2]->IsFoldable()) {
+		throw BinderException("bootstrap: 'n_iters' must be a constant integer");
+	}
+	Value n_val = ExpressionExecutor::EvaluateScalar(context, *arguments[2]);
+	if (n_val.IsNull()) {
+		throw BinderException("bootstrap: 'n_iters' must not be NULL");
+	}
+	bd->n_iters = n_val.GetValue<int64_t>();
+	if (bd->n_iters <= 0) {
+		throw BinderException("bootstrap: 'n_iters' must be > 0 (got %lld)",
+		                      static_cast<long long>(bd->n_iters));
+	}
+
+	if (has_seed) {
+		if (!arguments[3]->IsFoldable()) {
+			throw BinderException("bootstrap: 'seed' must be a constant integer");
+		}
+		Value seed_val = ExpressionExecutor::EvaluateScalar(context, *arguments[3]);
+		if (seed_val.IsNull()) {
+			throw BinderException("bootstrap: 'seed' must not be NULL");
+		}
+		bd->seed = seed_val.GetValue<int64_t>();
+	}
+
+	// Erase the constant args from highest to lowest index so positions remain
+	// valid as each erase shifts the tail down.
+	if (has_seed) {
+		Function::EraseArgument(function, arguments, 3);
+	}
+	Function::EraseArgument(function, arguments, 2);
+	Function::EraseArgument(function, arguments, 1);
+	return std::move(bd);
+}
+
+static unique_ptr<FunctionData>
+BootstrapBindNoSeed(ClientContext &context, AggregateFunction &function,
+                    vector<unique_ptr<Expression>> &arguments) {
+	return BootstrapBindCommon(context, function, arguments, false);
+}
+
+static unique_ptr<FunctionData>
+BootstrapBindSeeded(ClientContext &context, AggregateFunction &function,
+                    vector<unique_ptr<Expression>> &arguments) {
+	return BootstrapBindCommon(context, function, arguments, true);
+}
+
+//===--------------------------------------------------------------------===//
+// State (buffer-based — lazy alloc, heap-owned vector).
+//===--------------------------------------------------------------------===//
+
+struct BootstrapState {
+	std::vector<double> *values;
+};
+
+static void BootstrapInit(const AggregateFunction &, data_ptr_t state_p) {
+	auto &state = *reinterpret_cast<BootstrapState *>(state_p);
+	state.values = nullptr;
+}
+
+static void BootstrapUpdate(Vector inputs[], AggregateInputData &, idx_t,
+                            Vector &state_vector, idx_t count) {
+	UnifiedVectorFormat idata;
+	inputs[0].ToUnifiedFormat(count, idata);
+	auto states = FlatVector::GetData<BootstrapState *>(state_vector);
+	auto values = UnifiedVectorFormat::GetData<double>(idata);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = idata.sel->get_index(i);
+		if (!idata.validity.RowIsValid(idx)) {
+			continue;
+		}
+		double v = values[idx];
+		if (std::isnan(v)) {
+			continue;
+		}
+		auto &state = *states[i];
+		if (!state.values) {
+			state.values = new std::vector<double>();
+		}
+		state.values->push_back(v);
+	}
+}
+
+static void BootstrapCombine(Vector &source, Vector &target, AggregateInputData &, idx_t count) {
+	auto src = FlatVector::GetData<BootstrapState *>(source);
+	auto tgt = FlatVector::GetData<BootstrapState *>(target);
+	for (idx_t i = 0; i < count; i++) {
+		auto &s = *src[i];
+		auto &t = *tgt[i];
+		if (!s.values || s.values->empty()) {
+			continue;
+		}
+		if (!t.values) {
+			t.values = new std::vector<double>();
+		}
+		t.values->insert(t.values->end(), s.values->begin(), s.values->end());
+	}
+}
+
+static void BootstrapDestroy(Vector &state_vector, AggregateInputData &, idx_t count) {
+	auto states = FlatVector::GetData<BootstrapState *>(state_vector);
+	for (idx_t i = 0; i < count; i++) {
+		delete states[i]->values;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Statistic computation on a resample-index view of the source values.
+//===--------------------------------------------------------------------===//
+
+//! Compute the requested summary statistic from a resample described by indices
+//! into the original `values` vector. The resample is the multiset
+//! { values[indices[i]] : i ∈ [0, n) } — duplicates allowed, sample size n.
+//! For MEDIAN we copy the resample into a scratch buffer so we can nth_element
+//! in place without disturbing the indices.
+static double ComputeStat(BootstrapStat stat, const std::vector<double> &values,
+                          const std::vector<size_t> &indices, std::vector<double> &scratch) {
+	size_t n = indices.size();
+	switch (stat) {
+	case BootstrapStat::MEAN: {
+		double s = 0.0;
+		for (size_t i = 0; i < n; i++) {
+			s += values[indices[i]];
+		}
+		return s / static_cast<double>(n);
+	}
+	case BootstrapStat::SUM: {
+		double s = 0.0;
+		for (size_t i = 0; i < n; i++) {
+			s += values[indices[i]];
+		}
+		return s;
+	}
+	case BootstrapStat::MIN: {
+		double m = values[indices[0]];
+		for (size_t i = 1; i < n; i++) {
+			double v = values[indices[i]];
+			if (v < m) m = v;
+		}
+		return m;
+	}
+	case BootstrapStat::MAX: {
+		double m = values[indices[0]];
+		for (size_t i = 1; i < n; i++) {
+			double v = values[indices[i]];
+			if (v > m) m = v;
+		}
+		return m;
+	}
+	case BootstrapStat::VARIANCE:
+	case BootstrapStat::STDDEV: {
+		if (n < 2) {
+			return std::numeric_limits<double>::quiet_NaN();
+		}
+		// Two-pass mean+SS for numerical safety on heavy-tailed bootstrap draws.
+		double mean = 0.0;
+		for (size_t i = 0; i < n; i++) {
+			mean += values[indices[i]];
+		}
+		mean /= static_cast<double>(n);
+		double sq = 0.0;
+		for (size_t i = 0; i < n; i++) {
+			double d = values[indices[i]] - mean;
+			sq += d * d;
+		}
+		double var = sq / static_cast<double>(n - 1);
+		return stat == BootstrapStat::STDDEV ? std::sqrt(var) : var;
+	}
+	case BootstrapStat::MEDIAN: {
+		scratch.resize(n);
+		for (size_t i = 0; i < n; i++) {
+			scratch[i] = values[indices[i]];
+		}
+		if (n % 2 == 1) {
+			auto mid = scratch.begin() + n / 2;
+			std::nth_element(scratch.begin(), mid, scratch.end());
+			return *mid;
+		}
+		auto hi = scratch.begin() + n / 2;
+		std::nth_element(scratch.begin(), hi, scratch.end());
+		double right = *hi;
+		auto lo = scratch.begin() + n / 2 - 1;
+		std::nth_element(scratch.begin(), lo, hi);
+		return 0.5 * (*lo + right);
+	}
+	}
+	return std::numeric_limits<double>::quiet_NaN(); // unreachable
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize — emit LIST<DOUBLE> of n_iters resampled statistic values.
+//===--------------------------------------------------------------------===//
+
+static void BootstrapFinalize(Vector &state_vector, AggregateInputData &input_data, Vector &result,
+                              idx_t count, idx_t offset) {
+	auto &bd = input_data.bind_data->Cast<BootstrapBindData>();
+	auto states = FlatVector::GetData<BootstrapState *>(state_vector);
+	auto list_entries = FlatVector::GetData<list_entry_t>(result);
+
+	// Pre-allocate the seed-derived RNG once; per-row we re-seed deterministically
+	// from (seed, row index) when a seed is supplied so each group in a GROUP BY
+	// gets a stable but distinct stream.
+	std::vector<std::vector<double>> per_row(count);
+	std::vector<bool> per_row_null(count, false);
+	idx_t total_new_elements = 0;
+
+	for (idx_t i = 0; i < count; i++) {
+		auto &state = *states[i];
+		if (!state.values || state.values->empty()) {
+			per_row_null[i] = true;
+			continue;
+		}
+		auto &vals = *state.values;
+		size_t n = vals.size();
+
+		std::mt19937_64 rng;
+		if (bd.has_seed) {
+			// Mix the per-row index into the seed so multi-group bootstraps
+			// (one row per GROUP BY key) don't all produce identical streams.
+			rng.seed(static_cast<uint64_t>(bd.seed) ^
+			         (static_cast<uint64_t>(i + offset) * 0x9E3779B97F4A7C15ULL));
+		} else {
+			std::random_device rd;
+			rng.seed((static_cast<uint64_t>(rd()) << 32) | rd());
+		}
+		std::uniform_int_distribution<size_t> dist(0, n - 1);
+
+		auto &out = per_row[i];
+		out.reserve(static_cast<size_t>(bd.n_iters));
+		std::vector<size_t> indices(n);
+		std::vector<double> scratch;
+		for (int64_t it = 0; it < bd.n_iters; it++) {
+			for (size_t k = 0; k < n; k++) {
+				indices[k] = dist(rng);
+			}
+			out.push_back(ComputeStat(bd.stat, vals, indices, scratch));
+		}
+		total_new_elements += out.size();
+	}
+
+	idx_t child_anchor = ListVector::GetListSize(result);
+	ListVector::Reserve(result, child_anchor + total_new_elements);
+	auto &child = ListVector::GetEntry(result);
+	auto child_data = FlatVector::GetData<double>(child);
+	idx_t out_offset = child_anchor;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = i + offset;
+		if (per_row_null[i]) {
+			FlatVector::SetNull(result, idx, true);
+			list_entries[idx] = list_entry_t(out_offset, 0);
+			continue;
+		}
+		auto &samples = per_row[i];
+		list_entries[idx] = list_entry_t(out_offset, samples.size());
+		for (idx_t j = 0; j < samples.size(); j++) {
+			child_data[out_offset + j] = samples[j];
+		}
+		out_offset += samples.size();
+	}
+	ListVector::SetListSize(result, out_offset);
+}
+
+} // namespace
+
+void RegisterBootstrap(ExtensionLoader &loader) {
+	auto list_double = LogicalType::LIST(LogicalType::DOUBLE);
+	auto make_fn = [&](vector<LogicalType> args, bind_aggregate_function_t bind) {
+		AggregateFunction fn("bootstrap", std::move(args), list_double, AggregateFunction::StateSize<BootstrapState>,
+		                     BootstrapInit, BootstrapUpdate, BootstrapCombine, BootstrapFinalize,
+		                     nullptr, bind, BootstrapDestroy);
+		return fn;
+	};
+
+	AggregateFunctionSet set("bootstrap");
+	set.AddFunction(make_fn({LogicalType::DOUBLE, LogicalType::VARCHAR, LogicalType::BIGINT},
+	                        BootstrapBindNoSeed));
+	set.AddFunction(make_fn({LogicalType::DOUBLE, LogicalType::VARCHAR, LogicalType::BIGINT,
+	                         LogicalType::BIGINT},
+	                        BootstrapBindSeeded));
+	loader.RegisterFunction(set);
+}
+
+} // namespace duckdb

--- a/src/distribution_functions.cpp
+++ b/src/distribution_functions.cpp
@@ -1,6 +1,7 @@
 #include "distribution_functions.hpp"
 #include "distributions.hpp"
 
+#include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/common/vector_operations/ternary_executor.hpp"
@@ -467,6 +468,90 @@ static void QPoisExec(DataChunk &args, ExpressionState &, Vector &result) {
 	    });
 }
 
+// ── Negative Binomial ───────────────────────────────────────────────────────
+// dnbinom(x, size, prob) / pnbinom(q, size, prob) / qnbinom(p, size, prob).
+
+static void DNBinomExec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double k, double size, double prob, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::NegBinomPMF(k, size, prob); }, mask, idx);
+	    });
+}
+
+static void PNBinomExec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double k, double size, double prob, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::NegBinomCDF(k, size, prob); }, mask, idx);
+	    });
+}
+
+static void QNBinomExec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double p, double size, double prob, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::NegBinomQuantile(p, size, prob); }, mask, idx);
+	    });
+}
+
+// ── Hypergeometric ──────────────────────────────────────────────────────────
+// dhyper(x, m, n, k) / phyper(q, m, n, k) / qhyper(p, m, n, k) — four
+// arguments. DuckDB doesn't ship a 4-ary helper, so we drive the loop directly
+// via UnifiedVectorFormat (which still handles constant / flat / dictionary
+// input encodings correctly).
+
+template <typename Fn>
+static void RunQuaternaryWithNulls(DataChunk &args, Vector &result, Fn &&fn) {
+	idx_t count = args.size();
+	UnifiedVectorFormat a0, a1, a2, a3;
+	args.data[0].ToUnifiedFormat(count, a0);
+	args.data[1].ToUnifiedFormat(count, a1);
+	args.data[2].ToUnifiedFormat(count, a2);
+	args.data[3].ToUnifiedFormat(count, a3);
+	auto v0 = UnifiedVectorFormat::GetData<double>(a0);
+	auto v1 = UnifiedVectorFormat::GetData<double>(a1);
+	auto v2 = UnifiedVectorFormat::GetData<double>(a2);
+	auto v3 = UnifiedVectorFormat::GetData<double>(a3);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto out = FlatVector::GetData<double>(result);
+	auto &mask = FlatVector::Validity(result);
+	for (idx_t i = 0; i < count; i++) {
+		auto i0 = a0.sel->get_index(i);
+		auto i1 = a1.sel->get_index(i);
+		auto i2 = a2.sel->get_index(i);
+		auto i3 = a3.sel->get_index(i);
+		if (!a0.validity.RowIsValid(i0) || !a1.validity.RowIsValid(i1) ||
+		    !a2.validity.RowIsValid(i2) || !a3.validity.RowIsValid(i3)) {
+			mask.SetInvalid(i);
+			out[i] = 0.0;
+			continue;
+		}
+		out[i] = SafeCall([&] { return fn(v0[i0], v1[i1], v2[i2], v3[i3]); }, mask, i);
+	}
+}
+
+static void DHyperExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunQuaternaryWithNulls(args, result,
+	                        [](double x, double m, double n, double k) {
+		                        return stats_duck::HyperGeomPMF(x, m, n, k);
+	                        });
+}
+
+static void PHyperExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunQuaternaryWithNulls(args, result,
+	                        [](double q, double m, double n, double k) {
+		                        return stats_duck::HyperGeomCDF(q, m, n, k);
+	                        });
+}
+
+static void QHyperExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunQuaternaryWithNulls(args, result,
+	                        [](double p, double m, double n, double k) {
+		                        return stats_duck::HyperGeomQuantile(p, m, n, k);
+	                        });
+}
+
 } // namespace
 
 void RegisterDistributionFunctions(ExtensionLoader &loader) {
@@ -609,6 +694,18 @@ void RegisterDistributionFunctions(ExtensionLoader &loader) {
 	loader.RegisterFunction(ScalarFunction("dpois", {DBL, DBL}, DBL, DPoisExec));
 	loader.RegisterFunction(ScalarFunction("ppois", {DBL, DBL}, DBL, PPoisExec));
 	loader.RegisterFunction(ScalarFunction("qpois", {DBL, DBL}, DBL, QPoisExec));
+
+	// ── Negative Binomial ───────────────────────────────────────────────────
+	// Discrete: dnbinom(k, size, prob) / pnbinom(q, size, prob) / qnbinom(p, size, prob).
+	loader.RegisterFunction(ScalarFunction("dnbinom", {DBL, DBL, DBL}, DBL, DNBinomExec));
+	loader.RegisterFunction(ScalarFunction("pnbinom", {DBL, DBL, DBL}, DBL, PNBinomExec));
+	loader.RegisterFunction(ScalarFunction("qnbinom", {DBL, DBL, DBL}, DBL, QNBinomExec));
+
+	// ── Hypergeometric ──────────────────────────────────────────────────────
+	// Discrete: dhyper(x, m, n, k) / phyper(q, m, n, k) / qhyper(p, m, n, k).
+	loader.RegisterFunction(ScalarFunction("dhyper", {DBL, DBL, DBL, DBL}, DBL, DHyperExec));
+	loader.RegisterFunction(ScalarFunction("phyper", {DBL, DBL, DBL, DBL}, DBL, PHyperExec));
+	loader.RegisterFunction(ScalarFunction("qhyper", {DBL, DBL, DBL, DBL}, DBL, QHyperExec));
 }
 
 } // namespace duckdb

--- a/src/distribution_functions.cpp
+++ b/src/distribution_functions.cpp
@@ -314,6 +314,159 @@ static void QExp2Exec(DataChunk &args, ExpressionState &, Vector &result) {
 	    });
 }
 
+// ── Weibull ─────────────────────────────────────────────────────────────────
+// dweibull(x, shape [, scale]); scale defaults to 1.
+
+static void DWeibull2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double shape, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::WeibullPDF(x, shape); }, mask, idx);
+	    });
+}
+
+static void DWeibull3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double shape, double scale, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::WeibullPDF(x, shape, scale); }, mask, idx);
+	    });
+}
+
+static void PWeibull2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double shape, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::WeibullCDF(x, shape); }, mask, idx);
+	    });
+}
+
+static void PWeibull3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double shape, double scale, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::WeibullCDF(x, shape, scale); }, mask, idx);
+	    });
+}
+
+static void QWeibull2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double p, double shape, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::WeibullQuantile(p, shape); }, mask, idx);
+	    });
+}
+
+static void QWeibull3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double p, double shape, double scale, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::WeibullQuantile(p, shape, scale); }, mask, idx);
+	    });
+}
+
+// ── Log-normal ──────────────────────────────────────────────────────────────
+// dlnorm(x [, meanlog [, sdlog]]); both default to 0 and 1 respectively.
+
+static void DLNormStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	UnaryExecutor::ExecuteWithNulls<double, double>(
+	    args.data[0], result, args.size(),
+	    [](double x, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalPDF(x); }, mask, idx);
+	    });
+}
+
+static void DLNorm2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double meanlog, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalPDF(x, meanlog); }, mask, idx);
+	    });
+}
+
+static void DLNorm3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double meanlog, double sdlog, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalPDF(x, meanlog, sdlog); }, mask, idx);
+	    });
+}
+
+static void PLNormStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	UnaryExecutor::ExecuteWithNulls<double, double>(
+	    args.data[0], result, args.size(),
+	    [](double x, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalCDF(x); }, mask, idx);
+	    });
+}
+
+static void PLNorm2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double x, double meanlog, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalCDF(x, meanlog); }, mask, idx);
+	    });
+}
+
+static void PLNorm3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double x, double meanlog, double sdlog, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalCDF(x, meanlog, sdlog); }, mask, idx);
+	    });
+}
+
+static void QLNormStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	UnaryExecutor::ExecuteWithNulls<double, double>(
+	    args.data[0], result, args.size(),
+	    [](double p, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalQuantile(p); }, mask, idx);
+	    });
+}
+
+static void QLNorm2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double p, double meanlog, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalQuantile(p, meanlog); }, mask, idx);
+	    });
+}
+
+static void QLNorm3Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	TernaryExecutor::ExecuteWithNulls<double, double, double, double>(
+	    args.data[0], args.data[1], args.data[2], result, args.size(),
+	    [](double p, double meanlog, double sdlog, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::LogNormalQuantile(p, meanlog, sdlog); }, mask, idx);
+	    });
+}
+
+// ── Poisson ─────────────────────────────────────────────────────────────────
+// Discrete; lambda > 0. R: dpois(x, lambda) / ppois(q, lambda) / qpois(p, lambda).
+
+static void DPoisExec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double k, double lambda, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::PoissonPMF(k, lambda); }, mask, idx);
+	    });
+}
+
+static void PPoisExec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double q, double lambda, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::PoissonCDF(q, lambda); }, mask, idx);
+	    });
+}
+
+static void QPoisExec(DataChunk &args, ExpressionState &, Vector &result) {
+	BinaryExecutor::ExecuteWithNulls<double, double, double>(
+	    args.data[0], args.data[1], result, args.size(),
+	    [](double p, double lambda, ValidityMask &mask, idx_t idx) {
+		    return SafeCall([&] { return stats_duck::PoissonQuantile(p, lambda); }, mask, idx);
+	    });
+}
+
 } // namespace
 
 void RegisterDistributionFunctions(ExtensionLoader &loader) {
@@ -404,6 +557,58 @@ void RegisterDistributionFunctions(ExtensionLoader &loader) {
 		qexp.AddFunction(ScalarFunction({DBL, DBL}, DBL, QExp2Exec));
 		loader.RegisterFunction(qexp);
 	}
+
+	// ── Weibull ─────────────────────────────────────────────────────────────
+	// dweibull(x, shape) defaults scale = 1 (matches R's `dweibull(x, shape, scale = 1)`).
+	{
+		ScalarFunctionSet dweibull("dweibull");
+		dweibull.AddFunction(ScalarFunction({DBL, DBL}, DBL, DWeibull2Exec));
+		dweibull.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, DWeibull3Exec));
+		loader.RegisterFunction(dweibull);
+	}
+	{
+		ScalarFunctionSet pweibull("pweibull");
+		pweibull.AddFunction(ScalarFunction({DBL, DBL}, DBL, PWeibull2Exec));
+		pweibull.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, PWeibull3Exec));
+		loader.RegisterFunction(pweibull);
+	}
+	{
+		ScalarFunctionSet qweibull("qweibull");
+		qweibull.AddFunction(ScalarFunction({DBL, DBL}, DBL, QWeibull2Exec));
+		qweibull.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, QWeibull3Exec));
+		loader.RegisterFunction(qweibull);
+	}
+
+	// ── Log-normal ──────────────────────────────────────────────────────────
+	// dlnorm() / dlnorm(x, meanlog) / dlnorm(x, meanlog, sdlog). Defaults
+	// meanlog = 0, sdlog = 1 — matches R's `dlnorm(x, meanlog = 0, sdlog = 1)`.
+	{
+		ScalarFunctionSet dlnorm("dlnorm");
+		dlnorm.AddFunction(ScalarFunction({DBL}, DBL, DLNormStdExec));
+		dlnorm.AddFunction(ScalarFunction({DBL, DBL}, DBL, DLNorm2Exec));
+		dlnorm.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, DLNorm3Exec));
+		loader.RegisterFunction(dlnorm);
+	}
+	{
+		ScalarFunctionSet plnorm("plnorm");
+		plnorm.AddFunction(ScalarFunction({DBL}, DBL, PLNormStdExec));
+		plnorm.AddFunction(ScalarFunction({DBL, DBL}, DBL, PLNorm2Exec));
+		plnorm.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, PLNorm3Exec));
+		loader.RegisterFunction(plnorm);
+	}
+	{
+		ScalarFunctionSet qlnorm("qlnorm");
+		qlnorm.AddFunction(ScalarFunction({DBL}, DBL, QLNormStdExec));
+		qlnorm.AddFunction(ScalarFunction({DBL, DBL}, DBL, QLNorm2Exec));
+		qlnorm.AddFunction(ScalarFunction({DBL, DBL, DBL}, DBL, QLNorm3Exec));
+		loader.RegisterFunction(qlnorm);
+	}
+
+	// ── Poisson ─────────────────────────────────────────────────────────────
+	// Discrete: dpois(k, lambda) / ppois(q, lambda) / qpois(p, lambda).
+	loader.RegisterFunction(ScalarFunction("dpois", {DBL, DBL}, DBL, DPoisExec));
+	loader.RegisterFunction(ScalarFunction("ppois", {DBL, DBL}, DBL, PPoisExec));
+	loader.RegisterFunction(ScalarFunction("qpois", {DBL, DBL}, DBL, QPoisExec));
 }
 
 } // namespace duckdb

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -56,6 +56,50 @@ struct CompiledResult {
 	vector<pair<string, string>> layer_sqls;
 };
 
+// Apply the layer's STAT modifier to a freshly-rendered MarkResult.
+//   identity / "" : no-op
+//   smooth        : prepend a Vega-Lite loess transform on (x, y), grouped by
+//                   color if mapped. Rejected if the mark already emitted its
+//                   own `"transform":` block (regression / density / violin /
+//                   histogram), since two transform keys would be ambiguous.
+//   summary       : rewrite data_sql to `SELECT x [, color, facet, facet2],
+//                   AVG(y) AS y FROM (projected) GROUP BY ... ORDER BY x`.
+void ApplyStat(MarkResult &rendered, const VisualizeStatement &stmt, const DrawLayer &layer,
+               const string &projected_sql) {
+	if (layer.stat.empty() || layer.stat == "identity") {
+		return;
+	}
+	if (layer.stat == "smooth") {
+		if (rendered.layer_body.compare(0, 12, "\"transform\":") == 0) {
+			throw InvalidInputException(
+			    "ggsql: STAT smooth is not allowed on '%s' (mark already emits a transform)",
+			    layer.mark);
+		}
+		string loess = "\"transform\":[{\"loess\":\"y\",\"on\":\"x\"";
+		if (HasAesthetic(stmt, "color")) {
+			loess += ",\"groupby\":[\"color\"]";
+		}
+		loess += "}],";
+		rendered.layer_body = loess + rendered.layer_body;
+		return;
+	}
+	if (layer.stat == "summary") {
+		string group_by = "x";
+		if (HasAesthetic(stmt, "color")) {
+			group_by += ", color";
+		}
+		if (HasAesthetic(stmt, "facet")) {
+			group_by += ", facet";
+		}
+		if (HasAesthetic(stmt, "facet2")) {
+			group_by += ", facet2";
+		}
+		rendered.data_sql = "SELECT " + group_by + ", AVG(y) AS y FROM (" + projected_sql +
+		                    ") GROUP BY " + group_by + " ORDER BY x";
+		return;
+	}
+}
+
 MarkResult RenderLayer(ClientContext &context, const VisualizeStatement &stmt,
                        const DrawLayer &layer, const string &projected_sql) {
 	const auto &info = LookupMark(context, layer.mark);
@@ -65,7 +109,9 @@ MarkResult RenderLayer(ClientContext &context, const VisualizeStatement &stmt,
 		}
 	}
 	MarkContext ctx{stmt.aesthetics, projected_sql};
-	return info.render(ctx);
+	MarkResult rendered = info.render(ctx);
+	ApplyStat(rendered, stmt, layer, projected_sql);
+	return rendered;
 }
 
 bool HasFacet(const VisualizeStatement &stmt) {

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -77,6 +77,15 @@ bool HasFacet(const VisualizeStatement &stmt) {
 	return false;
 }
 
+bool Has2DFacet(const VisualizeStatement &stmt) {
+	for (const auto &a : stmt.aesthetics) {
+		if (StringUtil::CIEquals(a.aesthetic, "facet2")) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // Inject channel sub-objects (e.g. `,"scale":{...}` for TO/ZERO/DOMAIN,
 // `,"axis":{...}` for LABEL) into each encoding channel that has at least one
 // matching ScaleSpec. Relies on the current encoding format using only
@@ -175,8 +184,14 @@ CompiledResult Compile(ClientContext &context, const VisualizeStatement &stmt) {
 	}
 	string projected_sql = BuildProjectedSql(stmt);
 	bool faceted = HasFacet(stmt);
+	bool faceted_2d = Has2DFacet(stmt);
 	string facet_block;
-	if (faceted) {
+	if (faceted_2d) {
+		// 2D grid: row × column. Vega-Lite's facet operator with both `row` and
+		// `column` sub-channels.
+		facet_block = "\"facet\":{\"row\":{\"field\":\"facet\",\"type\":\"nominal\"},"
+		              "\"column\":{\"field\":\"facet2\",\"type\":\"nominal\"}},\"spec\":";
+	} else if (faceted) {
 		if (stmt.facet_layout == "rows") {
 			facet_block = "\"facet\":{\"row\":{\"field\":\"facet\",\"type\":\"nominal\"}},\"spec\":";
 		} else if (stmt.facet_layout == "cols") {

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -330,36 +330,72 @@ ParseResult ParseGgsql(const string &query) {
 		return result;
 	}
 
-	// Optional `FACET BY <expr>`. Stored as a synthetic aesthetic named "facet";
-	// "facet" is reserved — Compile() detects it to wrap the spec in a Vega-Lite
-	// facet operator and BuildProjectedSql carries it through.
+	// Optional `FACET BY <row_expr> [, <col_expr>] [ROWS|COLS]`. The 1D form
+	// stores a synthetic aesthetic named "facet" and an optional facet_layout
+	// ("rows" / "cols" / "" grid). The 2D form (two comma-separated expressions)
+	// stores both `facet` (row) and `facet2` (column) and produces a row × column
+	// grid; ROWS/COLS is rejected in the 2D form since the layout is fixed.
+	// Compile() detects these aesthetics to wrap the spec in a Vega-Lite facet
+	// operator and BuildProjectedSql carries them through as projected columns.
 	if (!at_end() && IEqual(peek(), "FACET")) {
 		i++; // consume FACET (case-insensitive — already verified)
 		if (!consume("BY")) {
 			return result;
 		}
-		if (at_end() || IEqual(peek(), "SCALE") || IEqual(peek(), "ROWS") ||
-		    IEqual(peek(), "COLS") || IEqual(peek(), "TITLE") || IEqual(peek(), "SUBTITLE")) {
+		auto is_facet_terminator = [&]() {
+			return at_end() || IEqual(peek(), "SCALE") || IEqual(peek(), "ROWS") ||
+			       IEqual(peek(), "COLS") || IEqual(peek(), "TITLE") || IEqual(peek(), "SUBTITLE");
+		};
+		if (is_facet_terminator() || peek() == ",") {
 			result.error = "Expected expression after 'FACET BY'";
 			return result;
 		}
-		string expr;
-		while (!at_end() && !IEqual(peek(), "SCALE") && !IEqual(peek(), "ROWS") &&
-		       !IEqual(peek(), "COLS") && !IEqual(peek(), "TITLE") &&
-		       !IEqual(peek(), "SUBTITLE")) {
-			if (!expr.empty()) {
-				expr += " ";
+		string row_expr;
+		while (!is_facet_terminator() && peek() != ",") {
+			if (!row_expr.empty()) {
+				row_expr += " ";
 			}
-			expr += tokens[i++];
+			row_expr += tokens[i++];
 		}
 		AestheticMapping facet;
-		facet.expression = std::move(expr);
+		facet.expression = std::move(row_expr);
 		facet.aesthetic = "facet";
 		result.stmt.aesthetics.push_back(std::move(facet));
 
-		// Optional layout: ROWS (vertical stack), COLS (horizontal stack), or
-		// nothing (grid — Vega-Lite default).
+		bool two_dim = false;
+		if (!at_end() && peek() == ",") {
+			i++; // consume ","
+			if (is_facet_terminator() || peek() == ",") {
+				result.error = "Expected column expression after 'FACET BY <row>,'";
+				return result;
+			}
+			string col_expr;
+			while (!is_facet_terminator() && peek() != ",") {
+				if (!col_expr.empty()) {
+					col_expr += " ";
+				}
+				col_expr += tokens[i++];
+			}
+			if (!at_end() && peek() == ",") {
+				result.error = "FACET BY accepts at most two expressions (row, column)";
+				return result;
+			}
+			AestheticMapping facet2;
+			facet2.expression = std::move(col_expr);
+			facet2.aesthetic = "facet2";
+			result.stmt.aesthetics.push_back(std::move(facet2));
+			two_dim = true;
+		}
+
+		// Optional layout for 1D facet: ROWS (vertical), COLS (horizontal), or
+		// nothing (grid — Vega-Lite default). The 2D form has a fixed row ×
+		// column layout, so ROWS/COLS would be redundant or contradictory.
 		if (!at_end() && (IEqual(peek(), "ROWS") || IEqual(peek(), "COLS"))) {
+			if (two_dim) {
+				result.error =
+				    "FACET BY <row>, <col> does not accept ROWS/COLS (always row × column)";
+				return result;
+			}
 			result.stmt.facet_layout = StringUtil::Lower(tokens[i]);
 			i++;
 		}

--- a/src/ggsql_grammar.cpp
+++ b/src/ggsql_grammar.cpp
@@ -322,6 +322,23 @@ ParseResult ParseGgsql(const string &query) {
 		}
 		DrawLayer layer;
 		layer.mark = tokens[i++];
+		// Optional `STAT <name>` modifier — applies a per-layer transform.
+		// Recognized: identity (no-op), smooth (loess on y ~ x), summary
+		// (aggregate AVG(y) by x). Unknown stat names are a parse error.
+		if (!at_end() && IEqual(peek(), "STAT")) {
+			i++;
+			if (at_end()) {
+				result.error = "Expected stat name after 'STAT'";
+				return result;
+			}
+			string stat_name = StringUtil::Lower(tokens[i++]);
+			if (stat_name != "identity" && stat_name != "smooth" && stat_name != "summary") {
+				result.error = "Unknown stat '" + stat_name +
+				               "' (expected identity, smooth, or summary)";
+				return result;
+			}
+			layer.stat = std::move(stat_name);
+		}
 		result.stmt.layers.push_back(std::move(layer));
 	}
 

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -251,6 +251,25 @@ MarkResult RenderDensity(const MarkContext &ctx) {
 	return r;
 }
 
+MarkResult RenderViolin(const MarkContext &ctx) {
+	// Canonical Vega-Lite violin: density transform grouped by the categorical x,
+	// each category rendered as a horizontal density column. `column` is a
+	// single-channel facet — it composes with `FACET BY ... ROWS` (uses `row`)
+	// but conflicts with `FACET BY ... COLS` (would request `column` twice).
+	string transform = "\"transform\":[{\"density\":\"y\",\"groupby\":[\"x\"]}]";
+	string encoding =
+	    "{\"y\":{\"field\":\"value\",\"type\":\"quantitative\"},"
+	    "\"x\":{\"field\":\"density\",\"type\":\"quantitative\",\"stack\":\"center\","
+	    "\"impute\":null,\"axis\":null},"
+	    "\"column\":{\"field\":\"x\",\"type\":\"nominal\"}";
+	encoding += BuildOptionalChannels(ctx);
+	encoding += "}";
+	MarkResult r;
+	r.layer_body = transform + ",\"mark\":\"area\",\"encoding\":" + encoding;
+	r.data_sql = ctx.projected_sql;
+	return r;
+}
+
 MarkResult RenderRegression(const MarkContext &ctx) {
 	// Vega-Lite regression transform fits y ~ x and emits the same field names
 	// back as the smoothed line. Grouped by color when mapped so each category
@@ -354,6 +373,7 @@ void RegisterBuiltinMarks(ExtensionLoader &loader) {
 	// directly. Color is the grouping aesthetic for both transforms.
 	RegisterMark(loader, "heatmap", {"x", "y", "color"}, RenderHeatmap);
 	RegisterMark(loader, "density", {"x"}, RenderDensity);
+	RegisterMark(loader, "violin", {"x", "y"}, RenderViolin);
 	RegisterMark(loader, "regression", {"x", "y"}, RenderRegression);
 }
 

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -259,7 +259,7 @@ MarkResult RenderDensity(const MarkContext &ctx) {
 
 MarkResult RenderViolin(const MarkContext &ctx) {
 	// Canonical Vega-Lite violin: density transform grouped by the categorical x,
-	// each category rendered as a horizontal density column. `column` is a
+	// each category a vertical violin in its own `column` facet. `column` is a
 	// single-channel facet — it composes with `FACET BY ... ROWS` (uses `row`)
 	// but conflicts with `FACET BY ... COLS` (would request `column` twice).
 	string transform = "\"transform\":[{\"density\":\"y\",\"groupby\":[\"x\"]}]";
@@ -271,7 +271,11 @@ MarkResult RenderViolin(const MarkContext &ctx) {
 	encoding += BuildOptionalChannels(ctx);
 	encoding += "}";
 	MarkResult r;
-	r.layer_body = transform + ",\"mark\":\"area\",\"encoding\":" + encoding;
+	// orient:horizontal is load-bearing — it makes the area sweep along y (the
+	// value axis, monotonic after the density transform). The default vertical
+	// orientation sweeps along x = the stacked density, which is non-monotonic
+	// and renders as a jagged comb instead of a smooth violin.
+	r.layer_body = transform + ",\"mark\":{\"type\":\"area\",\"orient\":\"horizontal\"},\"encoding\":" + encoding;
 	r.data_sql = ctx.projected_sql;
 	return r;
 }

--- a/src/ggsql_marks.cpp
+++ b/src/ggsql_marks.cpp
@@ -133,10 +133,16 @@ MarkResult RenderLine(const MarkContext &ctx) {
 }
 
 MarkResult RenderBar(const MarkContext &ctx) {
-	// When faceting is active, the `facet` column rides through projected_sql
+	// When faceting is active, the facet column(s) ride through projected_sql
 	// and must be carried through bar's GROUP BY so each facet partition keeps
-	// its own ordinal x bins.
-	string group_by = HasAesthetic(ctx, "facet") ? string("x, facet") : string("x");
+	// its own ordinal x bins. 2D facet adds a second `facet2` column.
+	string group_by = "x";
+	if (HasAesthetic(ctx, "facet")) {
+		group_by += ", facet";
+	}
+	if (HasAesthetic(ctx, "facet2")) {
+		group_by += ", facet2";
+	}
 	MarkResult r;
 	r.layer_body =
 	    "\"mark\":\"bar\",\"encoding\":" + BuildEncoding(ctx, kStandardChannels, {{"x", "ordinal"}});

--- a/src/include/bootstrap_function.hpp
+++ b/src/include/bootstrap_function.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+//! Register `bootstrap(value DOUBLE, statistic VARCHAR, n_iters BIGINT[, seed BIGINT])
+//! → LIST<DOUBLE>`. Buffer-based aggregate that resamples the input with
+//! replacement n_iters times and emits the chosen summary statistic per
+//! resample.
+void RegisterBootstrap(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/distributions.hpp
+++ b/src/include/distributions.hpp
@@ -606,4 +606,164 @@ inline double ExponentialQuantile(double p, double rate = 1.0) {
 	return -std::log(1.0 - p) / rate;
 }
 
+// ── Weibull distribution ────────────────────────────────────────────────────
+// Shape k > 0, scale λ > 0. Support x ≥ 0. PDF = (k/λ)·(x/λ)^(k-1)·e^(-(x/λ)^k).
+// CDF and quantile are both closed-form via log/exp. Special case k=1 → Exp(1/λ).
+// R parameterisation: dweibull(x, shape, scale = 1).
+
+inline double WeibullPDF(double x, double shape, double scale = 1.0) {
+	if (shape <= 0.0 || scale <= 0.0) {
+		throw std::invalid_argument("shape and scale must be > 0");
+	}
+	if (x < 0.0) {
+		return 0.0;
+	}
+	if (x == 0.0) {
+		// Limit: shape > 1 → 0; shape = 1 → 1/scale; shape < 1 → +inf.
+		if (shape > 1.0) {
+			return 0.0;
+		}
+		if (shape == 1.0) {
+			return 1.0 / scale;
+		}
+		return std::numeric_limits<double>::infinity();
+	}
+	double ratio = x / scale;
+	return (shape / scale) * std::pow(ratio, shape - 1.0) * std::exp(-std::pow(ratio, shape));
+}
+
+inline double WeibullCDF(double x, double shape, double scale = 1.0) {
+	if (shape <= 0.0 || scale <= 0.0) {
+		throw std::invalid_argument("shape and scale must be > 0");
+	}
+	if (x <= 0.0) {
+		return 0.0;
+	}
+	return 1.0 - std::exp(-std::pow(x / scale, shape));
+}
+
+inline double WeibullQuantile(double p, double shape, double scale = 1.0) {
+	if (shape <= 0.0 || scale <= 0.0) {
+		throw std::invalid_argument("shape and scale must be > 0");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	if (p == 0.0) {
+		return 0.0;
+	}
+	if (p == 1.0) {
+		return std::numeric_limits<double>::infinity();
+	}
+	return scale * std::pow(-std::log(1.0 - p), 1.0 / shape);
+}
+
+// ── Log-normal distribution ─────────────────────────────────────────────────
+// Parameters meanlog (μ) and sdlog (σ > 0); X = exp(μ + σZ) where Z ~ N(0,1).
+// Support x > 0. R parameterisation: dlnorm(x, meanlog = 0, sdlog = 1).
+
+inline double LogNormalPDF(double x, double meanlog = 0.0, double sdlog = 1.0) {
+	if (sdlog <= 0.0) {
+		throw std::invalid_argument("sdlog must be > 0");
+	}
+	if (x <= 0.0) {
+		return 0.0;
+	}
+	double z = (std::log(x) - meanlog) / sdlog;
+	return std::exp(-0.5 * z * z) / (x * sdlog * std::sqrt(2.0 * STATS_DUCK_PI));
+}
+
+inline double LogNormalCDF(double x, double meanlog = 0.0, double sdlog = 1.0) {
+	if (sdlog <= 0.0) {
+		throw std::invalid_argument("sdlog must be > 0");
+	}
+	if (x <= 0.0) {
+		return 0.0;
+	}
+	return NormalCDF(std::log(x), meanlog, sdlog);
+}
+
+inline double LogNormalQuantile(double p, double meanlog = 0.0, double sdlog = 1.0) {
+	if (sdlog <= 0.0) {
+		throw std::invalid_argument("sdlog must be > 0");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	if (p == 0.0) {
+		return 0.0;
+	}
+	if (p == 1.0) {
+		return std::numeric_limits<double>::infinity();
+	}
+	return std::exp(NormalQuantile(p, meanlog, sdlog));
+}
+
+// ── Poisson distribution ────────────────────────────────────────────────────
+// Discrete; rate λ > 0. PMF on k = 0, 1, 2, …  CDF: P(X ≤ k) = Q(k+1, λ) via
+// the regularized upper incomplete gamma, exploiting the identity
+//   Σ_{i=0..k} e^-λ λ^i / i! = Q(k+1, λ)  (Numerical Recipes §6.2).
+// Quantile is monotone integer search seeded from the normal approximation
+// k ≈ λ + Φ^-1(p)·sqrt(λ).
+
+inline double PoissonPMF(double k, double lambda) {
+	if (lambda <= 0.0) {
+		throw std::invalid_argument("lambda must be > 0");
+	}
+	if (k < 0.0) {
+		return 0.0;
+	}
+	double k_int = std::floor(k);
+	if (k_int != k) {
+		// Non-integer k → PMF is 0 (matches R's dpois(non-int) → 0 with warning).
+		return 0.0;
+	}
+	// e^(-λ) · λ^k / k!  via logs to avoid overflow for moderate λ.
+	double log_pmf = -lambda + k_int * std::log(lambda) - std::lgamma(k_int + 1.0);
+	return std::exp(log_pmf);
+}
+
+inline double PoissonCDF(double k, double lambda) {
+	if (lambda <= 0.0) {
+		throw std::invalid_argument("lambda must be > 0");
+	}
+	if (k < 0.0) {
+		return 0.0;
+	}
+	double k_int = std::floor(k);
+	// P(X ≤ k) = Q(k+1, λ).
+	return GammaQ(k_int + 1.0, lambda);
+}
+
+inline double PoissonQuantile(double p, double lambda) {
+	if (lambda <= 0.0) {
+		throw std::invalid_argument("lambda must be > 0");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	if (p == 0.0) {
+		return 0.0;
+	}
+	if (p == 1.0) {
+		return std::numeric_limits<double>::infinity();
+	}
+	// Normal approximation seed; clamp to ≥ 0.
+	double seed = lambda + NormalQuantile(p) * std::sqrt(lambda);
+	double k = std::floor(std::max(0.0, seed));
+	double cdf = PoissonCDF(k, lambda);
+	// March in the direction of p.
+	if (cdf < p) {
+		while (cdf < p) {
+			k += 1.0;
+			cdf = PoissonCDF(k, lambda);
+		}
+		return k;
+	}
+	while (k > 0.0 && PoissonCDF(k - 1.0, lambda) >= p) {
+		k -= 1.0;
+	}
+	return k;
+}
+
 } // namespace stats_duck

--- a/src/include/distributions.hpp
+++ b/src/include/distributions.hpp
@@ -766,4 +766,161 @@ inline double PoissonQuantile(double p, double lambda) {
 	return k;
 }
 
+// ── Negative Binomial distribution ──────────────────────────────────────────
+// R parameterisation: dnbinom(x, size, prob). size > 0 is the target number of
+// successes (not required to be integer — Gamma-Poisson mixture admits any
+// positive real), prob ∈ (0, 1] is the per-trial success probability. Support
+// is k = 0, 1, 2, …  CDF closed-form identity:
+//   P(X ≤ k) = I_prob(size, k + 1)
+// where I_x(a, b) is the regularized incomplete beta function (see
+// BetaIncomplete). Quantile is monotone integer search seeded from the normal
+// approximation.
+
+inline double NegBinomPMF(double k, double size, double prob) {
+	if (size <= 0.0 || prob <= 0.0 || prob > 1.0) {
+		throw std::invalid_argument("size must be > 0 and prob in (0, 1]");
+	}
+	if (k < 0.0) {
+		return 0.0;
+	}
+	double k_int = std::floor(k);
+	if (k_int != k) {
+		// Non-integer k → 0 (matches R's warn-and-zero convention).
+		return 0.0;
+	}
+	// log PMF = lgamma(k + size) - lgamma(size) - lgamma(k + 1)
+	//          + size·log(prob) + k·log(1 - prob)
+	double log_pmf = std::lgamma(k_int + size) - std::lgamma(size) - std::lgamma(k_int + 1.0) +
+	                 size * std::log(prob) + k_int * std::log(1.0 - prob);
+	return std::exp(log_pmf);
+}
+
+inline double NegBinomCDF(double k, double size, double prob) {
+	if (size <= 0.0 || prob <= 0.0 || prob > 1.0) {
+		throw std::invalid_argument("size must be > 0 and prob in (0, 1]");
+	}
+	if (k < 0.0) {
+		return 0.0;
+	}
+	double k_int = std::floor(k);
+	return BetaIncomplete(size, k_int + 1.0, prob);
+}
+
+inline double NegBinomQuantile(double p, double size, double prob) {
+	if (size <= 0.0 || prob <= 0.0 || prob > 1.0) {
+		throw std::invalid_argument("size must be > 0 and prob in (0, 1]");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	if (p == 0.0) {
+		return 0.0;
+	}
+	if (p == 1.0) {
+		return std::numeric_limits<double>::infinity();
+	}
+	// Normal approximation seed: mean = size·(1-prob)/prob, variance same / prob.
+	double mean = size * (1.0 - prob) / prob;
+	double var = mean / prob;
+	double seed = mean + NormalQuantile(p) * std::sqrt(var);
+	double k = std::floor(std::max(0.0, seed));
+	double cdf = NegBinomCDF(k, size, prob);
+	if (cdf < p) {
+		while (cdf < p) {
+			k += 1.0;
+			cdf = NegBinomCDF(k, size, prob);
+		}
+		return k;
+	}
+	while (k > 0.0 && NegBinomCDF(k - 1.0, size, prob) >= p) {
+		k -= 1.0;
+	}
+	return k;
+}
+
+// ── Hypergeometric distribution ─────────────────────────────────────────────
+// R parameterisation: dhyper(x, m, n, k). m = total successes in population,
+// n = total failures, k = number drawn without replacement. Population size is
+// N = m + n. PMF support: max(0, k - n) ≤ x ≤ min(m, k). No closed-form CDF;
+// we sum the PMF over the support up to floor(x). All three parameters are
+// taken as real-valued (matches R's permissive signature) but are interpreted
+// as floor()-truncated counts; non-integer x in the PMF / quantile yields 0
+// to match R's warn-and-zero.
+
+namespace detail {
+inline double LogChoose(double a, double b) {
+	// log C(a, b) = lgamma(a+1) - lgamma(b+1) - lgamma(a-b+1)
+	return std::lgamma(a + 1.0) - std::lgamma(b + 1.0) - std::lgamma(a - b + 1.0);
+}
+} // namespace detail
+
+inline double HyperGeomPMF(double x, double m, double n, double k) {
+	if (m < 0.0 || n < 0.0 || k < 0.0 || k > m + n) {
+		throw std::invalid_argument("hyper: m, n, k must be >= 0 and k <= m + n");
+	}
+	double x_int = std::floor(x);
+	if (x_int != x) {
+		return 0.0;
+	}
+	double lo = std::max(0.0, k - n);
+	double hi = std::min(m, k);
+	if (x_int < lo || x_int > hi) {
+		return 0.0;
+	}
+	double log_pmf =
+	    detail::LogChoose(m, x_int) + detail::LogChoose(n, k - x_int) - detail::LogChoose(m + n, k);
+	return std::exp(log_pmf);
+}
+
+inline double HyperGeomCDF(double q, double m, double n, double k) {
+	if (m < 0.0 || n < 0.0 || k < 0.0 || k > m + n) {
+		throw std::invalid_argument("hyper: m, n, k must be >= 0 and k <= m + n");
+	}
+	double q_int = std::floor(q);
+	double lo = std::max(0.0, k - n);
+	double hi = std::min(m, k);
+	if (q_int < lo) {
+		return 0.0;
+	}
+	if (q_int >= hi) {
+		return 1.0;
+	}
+	// Linear sum from lo. Support is bounded by min(m, k) so this is fine for
+	// the population sizes biostat / sampling-without-replacement workloads
+	// actually use. A normal-approximation fast path would help for huge m, k.
+	double cdf = 0.0;
+	for (double i = lo; i <= q_int; i += 1.0) {
+		cdf += HyperGeomPMF(i, m, n, k);
+	}
+	if (cdf > 1.0) {
+		cdf = 1.0; // clamp tiny rounding overshoots
+	}
+	return cdf;
+}
+
+inline double HyperGeomQuantile(double p, double m, double n, double k) {
+	if (m < 0.0 || n < 0.0 || k < 0.0 || k > m + n) {
+		throw std::invalid_argument("hyper: m, n, k must be >= 0 and k <= m + n");
+	}
+	if (p < 0.0 || p > 1.0) {
+		throw std::invalid_argument("p must be in [0, 1]");
+	}
+	double lo = std::max(0.0, k - n);
+	double hi = std::min(m, k);
+	if (p == 0.0) {
+		return lo;
+	}
+	if (p == 1.0) {
+		return hi;
+	}
+	double cdf = 0.0;
+	for (double x = lo; x <= hi; x += 1.0) {
+		cdf += HyperGeomPMF(x, m, n, k);
+		if (cdf >= p) {
+			return x;
+		}
+	}
+	return hi;
+}
+
 } // namespace stats_duck

--- a/src/include/ggsql_grammar.hpp
+++ b/src/include/ggsql_grammar.hpp
@@ -10,6 +10,11 @@ namespace ggsql {
 
 struct DrawLayer {
 	string mark;
+	// Optional STAT modifier. Empty or "identity" means no transform. "smooth"
+	// injects a Vega-Lite loess transform on (x, y). "summary" rewrites the
+	// layer's data SQL to aggregate by x (and color / facet if mapped) with
+	// AVG(y). Unknown names are rejected at parse time.
+	string stat;
 };
 
 struct ScaleSpec {

--- a/src/include/lm_function.hpp
+++ b/src/include/lm_function.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+//! Register the `lm` and `lm_summary` table functions.
+//!
+//!   lm('table_name', y := 'col', x := ['c1', 'c2', ...])
+//!     → (term VARCHAR, estimate DOUBLE, std_error DOUBLE,
+//!        t_statistic DOUBLE, p_value DOUBLE)
+//!
+//!   lm_summary('table_name', y := 'col', x := ['c1', 'c2', ...])
+//!     → (r_squared DOUBLE, adj_r_squared DOUBLE, f_statistic DOUBLE,
+//!        f_p_value DOUBLE, df_model BIGINT, df_residual BIGINT,
+//!        sigma DOUBLE, n BIGINT)
+//!
+//! Both fit an OLS model y = β₀ + Σ βᵢ·xᵢ via Cholesky decomposition of X'X.
+//! Rows with NULL in y or any x are excluded pairwise-complete style.
+void RegisterLm(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/meta_function.hpp
+++ b/src/include/meta_function.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+//! Registers meta(table_name) — a table function returning one row per column
+//! with metadata + light per-column stats. Output schema:
+//!   (column_name VARCHAR, column_type VARCHAR, kind VARCHAR,
+//!    n_rows BIGINT, n_missing BIGINT, n_distinct BIGINT,
+//!    min DOUBLE, p25 DOUBLE, median DOUBLE, p75 DOUBLE, max DOUBLE,
+//!    mean DOUBLE, stddev DOUBLE,
+//!    top VARCHAR, top_freq BIGINT)
+//!
+//! `kind` is one of 'numeric' / 'categorical' / 'temporal' / 'boolean' / 'other'.
+//! Numeric stats (min, p25, median, p75, max, mean, stddev) are NULL for
+//! non-numeric columns; `top` / `top_freq` (the mode and its count) are NULL
+//! for non-categorical / non-boolean columns. `n_rows` is the total row count
+//! in the source table and is repeated on every row so any single row is
+//! self-contained.
+//!
+//! Dataset-level summaries fall out via aggregation, e.g.
+//!   SELECT count(*) FILTER (WHERE kind='numeric') FROM meta('penguins');
+void RegisterMeta(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/random_sampling_function.hpp
+++ b/src/include/random_sampling_function.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+//! Register per-row random-sampling functions (`rnorm`, `rt`, `rchisq`, `rf`,
+//! `rgamma`, `rbeta`, `rexp`, `rweibull`, `rlnorm`, `rpois`). Each function is
+//! VOLATILE, draws a uniform sample from a thread-local std::mt19937_64 seeded
+//! from std::random_device, and returns the inverse-CDF transform.
+void RegisterRandomSampling(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/lm_function.cpp
+++ b/src/lm_function.cpp
@@ -125,11 +125,12 @@ static void CholeskySolve(const std::vector<double> &L, const std::vector<double
 struct LmFit {
 	idx_t n;                          // number of complete-case rows
 	idx_t p;                          // number of predictors (excluding intercept)
-	std::vector<std::string> terms;   // length p + 1 — "(Intercept)" then each x
-	std::vector<double> beta;         // length p + 1
-	std::vector<double> std_error;    // length p + 1
-	std::vector<double> t_statistic;  // length p + 1
-	std::vector<double> p_value;      // length p + 1
+	bool has_intercept;               // intercept term present in the design
+	std::vector<std::string> terms;   // length k — "(Intercept)" iff has_intercept, then each x
+	std::vector<double> beta;         // length k
+	std::vector<double> std_error;    // length k
+	std::vector<double> t_statistic;  // length k
+	std::vector<double> p_value;      // length k
 	double r_squared;
 	double adj_r_squared;
 	double f_statistic;
@@ -190,49 +191,58 @@ static YXBuffers MaterializeYX(Connection &conn, const std::string &table, const
 
 //===--------------------------------------------------------------------===//
 // FitOls — OLS fit via Cholesky on X'X. Populates every field of LmFit.
+// When has_intercept is false, the design has no constant column. R²/F use
+// the "uncentered" formulation (TSS = Σ y², not Σ(y - ȳ)²) to match R's
+// summary.lm output for no-intercept models — interpret with care.
 //===--------------------------------------------------------------------===//
 
 static LmFit FitOls(Connection &conn, const std::string &table, const std::string &y_col,
-                    const std::vector<std::string> &x_cols) {
+                    const std::vector<std::string> &x_cols, bool has_intercept) {
 	LmFit fit;
 	fit.ok = false;
 	fit.p = x_cols.size();
-	fit.terms.reserve(fit.p + 1);
-	fit.terms.emplace_back("(Intercept)");
+	fit.has_intercept = has_intercept;
+	fit.terms.reserve(fit.p + (has_intercept ? 1 : 0));
+	if (has_intercept) {
+		fit.terms.emplace_back("(Intercept)");
+	}
 	for (auto &xc : x_cols) {
 		fit.terms.push_back(xc);
 	}
 
 	auto buf = MaterializeYX(conn, table, y_col, x_cols);
 	fit.n = buf.y.size();
-	idx_t k = fit.p + 1; // number of parameters
+	idx_t k = fit.terms.size(); // number of parameters
 
 	if (fit.n <= k) {
 		fit.error = StringUtil::Format(
-		    "lm: need n > p + 1 (got n=%llu, p=%llu); not enough complete-case rows",
-		    static_cast<unsigned long long>(fit.n), static_cast<unsigned long long>(fit.p));
+		    "lm: need n > k (k=%llu params), got n=%llu — not enough complete-case rows",
+		    static_cast<unsigned long long>(k), static_cast<unsigned long long>(fit.n));
 		return fit;
 	}
 
-	// Build A = X'X and b = X'y. X has an implicit intercept column (all 1s)
-	// at index 0; predictor columns occupy indices 1..p. We use row-major
-	// storage: A[i*k + j] is the (i, j) entry.
+	// Column accessor: column j of X for row r. j=0 is the intercept (1)
+	// when has_intercept is true; otherwise it's the first predictor.
+	auto Xcol = [&](idx_t r, idx_t j) -> double {
+		if (has_intercept) {
+			if (j == 0) {
+				return 1.0;
+			}
+			return buf.x[j - 1][r];
+		}
+		return buf.x[j][r];
+	};
+
+	// Build A = X'X (upper triangle only) and b = X'y. Row-major.
 	std::vector<double> A(k * k, 0.0);
 	std::vector<double> b(k, 0.0);
 	for (idx_t row = 0; row < fit.n; row++) {
-		// row vector x_row of length k: [1, x_1[row], x_2[row], ...]
-		// Update upper triangle (then symmetrize below).
 		double y_v = buf.y[row];
-		// First: A[0][*] and b[0]
-		A[0 * k + 0] += 1.0;
-		b[0] += y_v;
-		for (idx_t j = 1; j < k; j++) {
-			double xj = buf.x[j - 1][row];
-			A[0 * k + j] += xj;
-			A[j * k + j] += xj * xj;
-			b[j] += xj * y_v;
-			for (idx_t i = 1; i < j; i++) {
-				double xi = buf.x[i - 1][row];
+		for (idx_t i = 0; i < k; i++) {
+			double xi = Xcol(row, i);
+			b[i] += xi * y_v;
+			for (idx_t j = i; j < k; j++) {
+				double xj = Xcol(row, j);
 				A[i * k + j] += xi * xj;
 			}
 		}
@@ -257,24 +267,29 @@ static LmFit FitOls(Connection &conn, const std::string &table, const std::strin
 	// Solve LL'·β = b
 	CholeskySolve(L, b, fit.beta, k);
 
-	// Compute residuals e = y - X·β and RSS.
+	// Compute residuals e = y - X·β and RSS, plus a few sums we'll reuse for
+	// the model summary.
 	double rss = 0.0;
 	double y_sum = 0.0;
+	double y_sq_sum = 0.0;
 	for (idx_t row = 0; row < fit.n; row++) {
-		double yhat = fit.beta[0];
-		for (idx_t j = 1; j < k; j++) {
-			yhat += fit.beta[j] * buf.x[j - 1][row];
+		double yhat = 0.0;
+		for (idx_t j = 0; j < k; j++) {
+			yhat += fit.beta[j] * Xcol(row, j);
 		}
 		double e = buf.y[row] - yhat;
 		rss += e * e;
 		y_sum += buf.y[row];
+		y_sq_sum += buf.y[row] * buf.y[row];
 	}
 	double y_mean = y_sum / static_cast<double>(fit.n);
-	double tss = 0.0;
+	double tss_centered = 0.0;
 	for (idx_t row = 0; row < fit.n; row++) {
 		double dy = buf.y[row] - y_mean;
-		tss += dy * dy;
+		tss_centered += dy * dy;
 	}
+	// "Uncentered" TSS used by R when there's no intercept.
+	double tss = has_intercept ? tss_centered : y_sq_sum;
 
 	fit.df_model = fit.p;
 	fit.df_residual = fit.n - k;
@@ -306,12 +321,18 @@ static LmFit FitOls(Connection &conn, const std::string &table, const std::strin
 		}
 	}
 
-	// Model-level statistics.
+	// Model-level statistics. R² is centered when an intercept is present
+	// (TSS = Σ(y - ȳ)²); R reports the *uncentered* version when there's no
+	// intercept (TSS = Σ y²), which we mirror — that's what `tss` holds above.
+	// For adj-R², the divisor n - p uses the full parameter count k matching
+	// R: with intercept k = p + 1 and divisor n - p - 1 = df_residual; without
+	// intercept k = p and divisor n - p = df_residual.
 	if (tss > 0.0) {
 		fit.r_squared = 1.0 - rss / tss;
 		double n_d = static_cast<double>(fit.n);
+		double r_n = has_intercept ? n_d - 1.0 : n_d;
 		fit.adj_r_squared =
-		    1.0 - (1.0 - fit.r_squared) * (n_d - 1.0) / static_cast<double>(fit.df_residual);
+		    1.0 - (1.0 - fit.r_squared) * r_n / static_cast<double>(fit.df_residual);
 	} else {
 		fit.r_squared = std::numeric_limits<double>::quiet_NaN();
 		fit.adj_r_squared = std::numeric_limits<double>::quiet_NaN();
@@ -334,13 +355,221 @@ static LmFit FitOls(Connection &conn, const std::string &table, const std::strin
 }
 
 //===--------------------------------------------------------------------===//
-// Shared bind data — both lm and lm_summary need the same trio (table, y, x).
+// Formula DSL — a small subset of R's formula syntax.
+//
+// Grammar (v0.6):
+//   formula    := IDENT  '~'  rhs
+//   rhs        := term  (('+' | '-')  term)*
+//   term       := IDENT          (predictor column)
+//                | '0'            (alias for '- 1' — drop intercept)
+//                | '1'            (no-op when '+' / drops intercept when '-')
+//
+// Identifiers are bare `[A-Za-z_][A-Za-z0-9_.]*` or `"..."` (SQL-quoted, with
+// '""' escape). Whitespace between tokens is ignored. The intercept is
+// included by default and can be removed with `- 1` or `+ 0` (matches R's
+// convention; both spellings appear in the wild).
+//
+// Not supported in v0.6: interactions (`x1:x2`), wildcards (`*`, `^`,
+// `.`), inline expressions (`I(x^2)`, `log(x)`), or transformations. Quote
+// computed columns into a CTE if you need them today.
+//===--------------------------------------------------------------------===//
+
+struct FormulaParse {
+	bool ok = false;
+	std::string error;
+	std::string y;
+	std::vector<std::string> x;
+	bool intercept = true;
+};
+
+namespace fml {
+
+enum TokKind { IDENT, TILDE, PLUS, MINUS, ZERO, ONE, END_TOK };
+
+struct Tok {
+	TokKind kind;
+	std::string text;
+	idx_t pos;
+};
+
+static bool IsIdentStart(char c) {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
+}
+static bool IsIdentCont(char c) {
+	return IsIdentStart(c) || (c >= '0' && c <= '9') || c == '.';
+}
+
+static std::vector<Tok> Tokenize(const std::string &s, std::string &error) {
+	std::vector<Tok> tokens;
+	idx_t i = 0;
+	while (i < s.size()) {
+		char c = s[i];
+		if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+			i++;
+			continue;
+		}
+		idx_t start = i;
+		if (c == '~') { tokens.push_back({TILDE, "", start}); i++; continue; }
+		if (c == '+') { tokens.push_back({PLUS, "", start}); i++; continue; }
+		if (c == '-') { tokens.push_back({MINUS, "", start}); i++; continue; }
+		if (c >= '0' && c <= '9') {
+			std::string num;
+			while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
+				num += s[i];
+				i++;
+			}
+			if (num == "0") {
+				tokens.push_back({ZERO, "", start});
+			} else if (num == "1") {
+				tokens.push_back({ONE, "", start});
+			} else {
+				error = StringUtil::Format(
+				    "formula: unexpected number '%s' at position %llu — only '0' / '1' are valid",
+				    num, static_cast<unsigned long long>(start));
+				return tokens;
+			}
+			continue;
+		}
+		if (c == '"') {
+			std::string id;
+			i++;
+			while (i < s.size()) {
+				if (s[i] == '"') {
+					if (i + 1 < s.size() && s[i + 1] == '"') {
+						id += '"';
+						i += 2;
+						continue;
+					}
+					break;
+				}
+				id += s[i];
+				i++;
+			}
+			if (i >= s.size()) {
+				error = "formula: unterminated quoted identifier";
+				return tokens;
+			}
+			i++; // closing "
+			tokens.push_back({IDENT, id, start});
+			continue;
+		}
+		if (IsIdentStart(c)) {
+			std::string id;
+			while (i < s.size() && IsIdentCont(s[i])) {
+				id += s[i];
+				i++;
+			}
+			tokens.push_back({IDENT, id, start});
+			continue;
+		}
+		error = StringUtil::Format("formula: unexpected character '%c' at position %llu",
+		                            c, static_cast<unsigned long long>(start));
+		return tokens;
+	}
+	tokens.push_back({END_TOK, "", i});
+	return tokens;
+}
+
+} // namespace fml
+
+static FormulaParse ParseFormula(const std::string &formula) {
+	FormulaParse out;
+	std::string err;
+	auto tokens = fml::Tokenize(formula, err);
+	if (!err.empty()) {
+		out.error = err;
+		return out;
+	}
+	if (tokens.empty() || tokens[0].kind != fml::IDENT) {
+		out.error = "formula: expected response column name on LHS of '~'";
+		return out;
+	}
+	out.y = tokens[0].text;
+	if (tokens.size() < 2 || tokens[1].kind != fml::TILDE) {
+		out.error = "formula: expected '~' after response column";
+		return out;
+	}
+	idx_t i = 2;
+	if (i >= tokens.size() || tokens[i].kind == fml::END_TOK) {
+		out.error = "formula: expected at least one term after '~'";
+		return out;
+	}
+	bool first = true;
+	while (i < tokens.size() && tokens[i].kind != fml::END_TOK) {
+		bool subtract = false;
+		if (!first) {
+			if (tokens[i].kind == fml::PLUS) {
+				subtract = false;
+				i++;
+			} else if (tokens[i].kind == fml::MINUS) {
+				subtract = true;
+				i++;
+			} else {
+				out.error = "formula: expected '+' or '-' between terms";
+				return out;
+			}
+			if (i >= tokens.size() || tokens[i].kind == fml::END_TOK) {
+				out.error = "formula: expected term after operator";
+				return out;
+			}
+		}
+		first = false;
+		auto &t = tokens[i];
+		if (t.kind == fml::ZERO) {
+			// `+ 0` drops the intercept; `- 0` is a no-op.
+			if (!subtract) {
+				out.intercept = false;
+			}
+			i++;
+			continue;
+		}
+		if (t.kind == fml::ONE) {
+			// `+ 1` is the default (intercept on); `- 1` drops the intercept.
+			if (subtract) {
+				out.intercept = false;
+			}
+			i++;
+			continue;
+		}
+		if (t.kind == fml::IDENT) {
+			if (subtract) {
+				out.error =
+				    "formula: subtracting a predictor (other than '- 1' / '- 0' to drop the "
+				    "intercept) is not supported — wrap into a CTE if you need to omit a column";
+				return out;
+			}
+			for (auto &x : out.x) {
+				if (x == t.text) {
+					out.error = "formula: duplicate predictor '" + t.text + "'";
+					return out;
+				}
+			}
+			out.x.push_back(t.text);
+			i++;
+			continue;
+		}
+		out.error = "formula: unexpected token in RHS";
+		return out;
+	}
+	if (out.x.empty()) {
+		out.error =
+		    "formula: at least one predictor is required (intercept-only models are not supported)";
+		return out;
+	}
+	out.ok = true;
+	return out;
+}
+
+//===--------------------------------------------------------------------===//
+// Shared bind data — both lm and lm_summary need the same trio (table, y, x)
+// plus a flag for whether the design has an intercept column.
 //===--------------------------------------------------------------------===//
 
 struct LmBindData : public TableFunctionData {
 	std::string data_table;
 	std::string y_col;
 	std::vector<std::string> x_cols;
+	bool has_intercept = true;
 	bool is_summary;
 };
 
@@ -355,25 +584,50 @@ static unique_ptr<FunctionData> LmBindCommon(ClientContext &context, TableFuncti
 	}
 	bd->data_table = input.inputs[0].GetValue<string>();
 
+	// Two ways to specify the model:
+	//   formula := 'y ~ x1 + x2'             (R-style DSL, ergonomic)
+	//   y := 'y_col', x := ['x1', 'x2']      (explicit lists, easy to generate)
+	// They are mutually exclusive — passing both is a bind error.
+	auto it_formula = input.named_parameters.find("formula");
 	auto it_y = input.named_parameters.find("y");
-	if (it_y == input.named_parameters.end() || it_y->second.IsNull()) {
-		throw BinderException("%s: 'y' (response column name) is required", fname);
-	}
-	bd->y_col = it_y->second.GetValue<string>();
-
 	auto it_x = input.named_parameters.find("x");
-	if (it_x == input.named_parameters.end() || it_x->second.IsNull()) {
-		throw BinderException("%s: 'x' (predictor list) is required", fname);
+	bool has_formula = it_formula != input.named_parameters.end() && !it_formula->second.IsNull();
+	bool has_y = it_y != input.named_parameters.end() && !it_y->second.IsNull();
+	bool has_x = it_x != input.named_parameters.end() && !it_x->second.IsNull();
+
+	if (has_formula && (has_y || has_x)) {
+		throw BinderException(
+		    "%s: cannot specify 'formula' together with 'y' or 'x' — choose one form", fname);
 	}
-	auto &x_children = ListValue::GetChildren(it_x->second);
-	for (auto &v : x_children) {
-		if (v.IsNull()) {
-			throw BinderException("%s: 'x' list entries must not be NULL", fname);
+
+	if (has_formula) {
+		auto parsed = ParseFormula(it_formula->second.GetValue<string>());
+		if (!parsed.ok) {
+			throw BinderException("%s: %s", fname, parsed.error);
 		}
-		bd->x_cols.push_back(v.GetValue<string>());
-	}
-	if (bd->x_cols.empty()) {
-		throw BinderException("%s: 'x' must contain at least one predictor column", fname);
+		bd->y_col = std::move(parsed.y);
+		bd->x_cols = std::move(parsed.x);
+		bd->has_intercept = parsed.intercept;
+	} else {
+		if (!has_y) {
+			throw BinderException("%s: either 'formula' or ('y' + 'x') is required", fname);
+		}
+		bd->y_col = it_y->second.GetValue<string>();
+		if (!has_x) {
+			throw BinderException("%s: 'x' (predictor list) is required when not using formula",
+			                      fname);
+		}
+		auto &x_children = ListValue::GetChildren(it_x->second);
+		for (auto &v : x_children) {
+			if (v.IsNull()) {
+				throw BinderException("%s: 'x' list entries must not be NULL", fname);
+			}
+			bd->x_cols.push_back(v.GetValue<string>());
+		}
+		if (bd->x_cols.empty()) {
+			throw BinderException("%s: 'x' must contain at least one predictor column", fname);
+		}
+		bd->has_intercept = true;
 	}
 
 	// Catalog lookup — y and every x must exist and be numeric.
@@ -437,7 +691,7 @@ static unique_ptr<GlobalTableFunctionState> LmInitGlobal(ClientContext &context,
 	auto &bd = input.bind_data->Cast<LmBindData>();
 	auto state = make_uniq<LmGlobalState>();
 	Connection conn(*context.db);
-	state->fit = FitOls(conn, bd.data_table, bd.y_col, bd.x_cols);
+	state->fit = FitOls(conn, bd.data_table, bd.y_col, bd.x_cols, bd.has_intercept);
 	if (!state->fit.ok) {
 		throw InvalidInputException(state->fit.error);
 	}
@@ -496,6 +750,7 @@ void RegisterLm(ExtensionLoader &loader) {
 		TableFunction fn("lm", {LogicalType::VARCHAR}, LmExecute, LmBind, LmInitGlobal);
 		fn.named_parameters["y"] = LogicalType::VARCHAR;
 		fn.named_parameters["x"] = LogicalType::LIST(LogicalType::VARCHAR);
+		fn.named_parameters["formula"] = LogicalType::VARCHAR;
 		loader.RegisterFunction(fn);
 	}
 	{
@@ -503,6 +758,7 @@ void RegisterLm(ExtensionLoader &loader) {
 		                 LmInitGlobal);
 		fn.named_parameters["y"] = LogicalType::VARCHAR;
 		fn.named_parameters["x"] = LogicalType::LIST(LogicalType::VARCHAR);
+		fn.named_parameters["formula"] = LogicalType::VARCHAR;
 		loader.RegisterFunction(fn);
 	}
 }

--- a/src/lm_function.cpp
+++ b/src/lm_function.cpp
@@ -1,0 +1,510 @@
+#include "lm_function.hpp"
+
+#include "distributions.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+namespace {
+
+//===--------------------------------------------------------------------===//
+// Helpers shared by both lm and lm_summary.
+//===--------------------------------------------------------------------===//
+
+static std::string QuoteIdent(const std::string &raw) {
+	std::string out;
+	out.reserve(raw.size() + 2);
+	out.push_back('"');
+	for (char c : raw) {
+		if (c == '"') {
+			out.push_back('"');
+		}
+		out.push_back(c);
+	}
+	out.push_back('"');
+	return out;
+}
+
+//! Same numeric kind check used by corr_matrix / table_one — everything we can
+//! cast to DOUBLE without losing the intent of the column.
+static bool IsNumericKind(LogicalTypeId tid) {
+	switch (tid) {
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::UHUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return true;
+	default:
+		return false;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Linear-algebra primitives (small dense — p is rarely above a few dozen).
+// Row-major storage: M[i,j] = M[i*ncols + j].
+//===--------------------------------------------------------------------===//
+
+//! In-place Cholesky decomposition of a symmetric positive-definite matrix A
+//! (size n × n). On success returns true and overwrites the lower triangle
+//! with L such that A = L·L'. On failure (A not positive-definite, e.g. due
+//! to perfectly collinear predictors) returns false.
+static bool CholeskyDecompose(std::vector<double> &A, idx_t n) {
+	for (idx_t j = 0; j < n; j++) {
+		double diag = A[j * n + j];
+		for (idx_t k = 0; k < j; k++) {
+			diag -= A[j * n + k] * A[j * n + k];
+		}
+		if (diag <= 0.0 || !std::isfinite(diag)) {
+			return false;
+		}
+		A[j * n + j] = std::sqrt(diag);
+		for (idx_t i = j + 1; i < n; i++) {
+			double s = A[i * n + j];
+			for (idx_t k = 0; k < j; k++) {
+				s -= A[i * n + k] * A[j * n + k];
+			}
+			A[i * n + j] = s / A[j * n + j];
+		}
+	}
+	return true;
+}
+
+//! Solve LL'·x = b given L (lower triangle of A in row-major form). Forward
+//! then backward substitution.
+static void CholeskySolve(const std::vector<double> &L, const std::vector<double> &b,
+                          std::vector<double> &x, idx_t n) {
+	std::vector<double> z(n, 0.0);
+	// Forward: L·z = b
+	for (idx_t i = 0; i < n; i++) {
+		double s = b[i];
+		for (idx_t j = 0; j < i; j++) {
+			s -= L[i * n + j] * z[j];
+		}
+		z[i] = s / L[i * n + i];
+	}
+	// Backward: L'·x = z
+	x.assign(n, 0.0);
+	for (idx_t ii = 0; ii < n; ii++) {
+		idx_t i = n - 1 - ii;
+		double s = z[i];
+		for (idx_t j = i + 1; j < n; j++) {
+			s -= L[j * n + i] * x[j];
+		}
+		x[i] = s / L[i * n + i];
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Fit results.
+//===--------------------------------------------------------------------===//
+
+struct LmFit {
+	idx_t n;                          // number of complete-case rows
+	idx_t p;                          // number of predictors (excluding intercept)
+	std::vector<std::string> terms;   // length p + 1 — "(Intercept)" then each x
+	std::vector<double> beta;         // length p + 1
+	std::vector<double> std_error;    // length p + 1
+	std::vector<double> t_statistic;  // length p + 1
+	std::vector<double> p_value;      // length p + 1
+	double r_squared;
+	double adj_r_squared;
+	double f_statistic;
+	double f_p_value;
+	double sigma;                     // residual standard error
+	idx_t df_residual;                // n - p - 1
+	idx_t df_model;                   // p
+	bool ok;                          // false → fit failed (insufficient data / singular)
+	std::string error;                // populated when ok = false
+};
+
+//===--------------------------------------------------------------------===//
+// Materialize y + X by streaming the source table once via an internal
+// Connection. Filters all rows with NULL in y or any x (complete-case).
+//===--------------------------------------------------------------------===//
+
+struct YXBuffers {
+	std::vector<double> y;
+	std::vector<std::vector<double>> x; // x[j] is column j of X (size n)
+};
+
+static YXBuffers MaterializeYX(Connection &conn, const std::string &table, const std::string &y_col,
+                               const std::vector<std::string> &x_cols) {
+	std::stringstream sql;
+	sql << "SELECT " << QuoteIdent(y_col) << "::DOUBLE";
+	for (auto &xc : x_cols) {
+		sql << ", " << QuoteIdent(xc) << "::DOUBLE";
+	}
+	sql << " FROM " << QuoteIdent(table);
+	sql << " WHERE " << QuoteIdent(y_col) << " IS NOT NULL";
+	for (auto &xc : x_cols) {
+		sql << " AND " << QuoteIdent(xc) << " IS NOT NULL";
+	}
+	auto result = conn.Query(sql.str());
+	if (result->HasError()) {
+		throw InvalidInputException("lm: failed to materialize data — %s", result->GetError());
+	}
+	YXBuffers buf;
+	buf.x.assign(x_cols.size(), {});
+	while (true) {
+		auto chunk = result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+		auto y_vec = FlatVector::GetData<double>(chunk->data[0]);
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			buf.y.push_back(y_vec[i]);
+		}
+		for (idx_t j = 0; j < x_cols.size(); j++) {
+			auto x_vec = FlatVector::GetData<double>(chunk->data[1 + j]);
+			for (idx_t i = 0; i < chunk->size(); i++) {
+				buf.x[j].push_back(x_vec[i]);
+			}
+		}
+	}
+	return buf;
+}
+
+//===--------------------------------------------------------------------===//
+// FitOls — OLS fit via Cholesky on X'X. Populates every field of LmFit.
+//===--------------------------------------------------------------------===//
+
+static LmFit FitOls(Connection &conn, const std::string &table, const std::string &y_col,
+                    const std::vector<std::string> &x_cols) {
+	LmFit fit;
+	fit.ok = false;
+	fit.p = x_cols.size();
+	fit.terms.reserve(fit.p + 1);
+	fit.terms.emplace_back("(Intercept)");
+	for (auto &xc : x_cols) {
+		fit.terms.push_back(xc);
+	}
+
+	auto buf = MaterializeYX(conn, table, y_col, x_cols);
+	fit.n = buf.y.size();
+	idx_t k = fit.p + 1; // number of parameters
+
+	if (fit.n <= k) {
+		fit.error = StringUtil::Format(
+		    "lm: need n > p + 1 (got n=%llu, p=%llu); not enough complete-case rows",
+		    static_cast<unsigned long long>(fit.n), static_cast<unsigned long long>(fit.p));
+		return fit;
+	}
+
+	// Build A = X'X and b = X'y. X has an implicit intercept column (all 1s)
+	// at index 0; predictor columns occupy indices 1..p. We use row-major
+	// storage: A[i*k + j] is the (i, j) entry.
+	std::vector<double> A(k * k, 0.0);
+	std::vector<double> b(k, 0.0);
+	for (idx_t row = 0; row < fit.n; row++) {
+		// row vector x_row of length k: [1, x_1[row], x_2[row], ...]
+		// Update upper triangle (then symmetrize below).
+		double y_v = buf.y[row];
+		// First: A[0][*] and b[0]
+		A[0 * k + 0] += 1.0;
+		b[0] += y_v;
+		for (idx_t j = 1; j < k; j++) {
+			double xj = buf.x[j - 1][row];
+			A[0 * k + j] += xj;
+			A[j * k + j] += xj * xj;
+			b[j] += xj * y_v;
+			for (idx_t i = 1; i < j; i++) {
+				double xi = buf.x[i - 1][row];
+				A[i * k + j] += xi * xj;
+			}
+		}
+	}
+	// Symmetrize A (only upper triangle was populated above).
+	for (idx_t i = 0; i < k; i++) {
+		for (idx_t j = 0; j < i; j++) {
+			A[i * k + j] = A[j * k + i];
+		}
+	}
+
+	// Cholesky decompose A. A copy is kept around so we can recover the
+	// variance-covariance matrix below — the decomposition writes over A.
+	std::vector<double> L = A;
+	if (!CholeskyDecompose(L, k)) {
+		fit.error =
+		    "lm: design matrix is singular (X'X not positive-definite); "
+		    "check for perfectly collinear predictors or a constant column";
+		return fit;
+	}
+
+	// Solve LL'·β = b
+	CholeskySolve(L, b, fit.beta, k);
+
+	// Compute residuals e = y - X·β and RSS.
+	double rss = 0.0;
+	double y_sum = 0.0;
+	for (idx_t row = 0; row < fit.n; row++) {
+		double yhat = fit.beta[0];
+		for (idx_t j = 1; j < k; j++) {
+			yhat += fit.beta[j] * buf.x[j - 1][row];
+		}
+		double e = buf.y[row] - yhat;
+		rss += e * e;
+		y_sum += buf.y[row];
+	}
+	double y_mean = y_sum / static_cast<double>(fit.n);
+	double tss = 0.0;
+	for (idx_t row = 0; row < fit.n; row++) {
+		double dy = buf.y[row] - y_mean;
+		tss += dy * dy;
+	}
+
+	fit.df_model = fit.p;
+	fit.df_residual = fit.n - k;
+	double sigma2 = rss / static_cast<double>(fit.df_residual);
+	fit.sigma = std::sqrt(sigma2);
+
+	// Compute the diagonal of A⁻¹ by solving A·v_i = e_i for each i, taking
+	// v_i[i]. Same Cholesky factor; O(k) solves of O(k²) each.
+	fit.std_error.assign(k, 0.0);
+	fit.t_statistic.assign(k, 0.0);
+	fit.p_value.assign(k, 0.0);
+	std::vector<double> ei(k, 0.0);
+	std::vector<double> vi(k, 0.0);
+	for (idx_t i = 0; i < k; i++) {
+		std::fill(ei.begin(), ei.end(), 0.0);
+		ei[i] = 1.0;
+		CholeskySolve(L, ei, vi, k);
+		double var_ii = sigma2 * vi[i];
+		fit.std_error[i] = var_ii > 0.0 ? std::sqrt(var_ii) : 0.0;
+		if (fit.std_error[i] > 0.0) {
+			fit.t_statistic[i] = fit.beta[i] / fit.std_error[i];
+			double abs_t = std::fabs(fit.t_statistic[i]);
+			// Two-sided t-test p-value: 2 · P(T > |t|) on df_residual.
+			double tail = 1.0 - stats_duck::StudentTCDF(abs_t, static_cast<double>(fit.df_residual));
+			fit.p_value[i] = 2.0 * tail;
+		} else {
+			fit.t_statistic[i] = std::numeric_limits<double>::quiet_NaN();
+			fit.p_value[i] = std::numeric_limits<double>::quiet_NaN();
+		}
+	}
+
+	// Model-level statistics.
+	if (tss > 0.0) {
+		fit.r_squared = 1.0 - rss / tss;
+		double n_d = static_cast<double>(fit.n);
+		fit.adj_r_squared =
+		    1.0 - (1.0 - fit.r_squared) * (n_d - 1.0) / static_cast<double>(fit.df_residual);
+	} else {
+		fit.r_squared = std::numeric_limits<double>::quiet_NaN();
+		fit.adj_r_squared = std::numeric_limits<double>::quiet_NaN();
+	}
+	// F-statistic for the joint hypothesis β_1 = ... = β_p = 0.
+	if (fit.df_model > 0 && fit.df_residual > 0 && rss > 0.0 && tss > 0.0) {
+		double ess = tss - rss;
+		fit.f_statistic = (ess / static_cast<double>(fit.df_model)) /
+		                  (rss / static_cast<double>(fit.df_residual));
+		fit.f_p_value = 1.0 - stats_duck::FCDF(fit.f_statistic,
+		                                       static_cast<double>(fit.df_model),
+		                                       static_cast<double>(fit.df_residual));
+	} else {
+		fit.f_statistic = std::numeric_limits<double>::quiet_NaN();
+		fit.f_p_value = std::numeric_limits<double>::quiet_NaN();
+	}
+
+	fit.ok = true;
+	return fit;
+}
+
+//===--------------------------------------------------------------------===//
+// Shared bind data — both lm and lm_summary need the same trio (table, y, x).
+//===--------------------------------------------------------------------===//
+
+struct LmBindData : public TableFunctionData {
+	std::string data_table;
+	std::string y_col;
+	std::vector<std::string> x_cols;
+	bool is_summary;
+};
+
+static unique_ptr<FunctionData> LmBindCommon(ClientContext &context, TableFunctionBindInput &input,
+                                              bool is_summary) {
+	auto bd = make_uniq<LmBindData>();
+	bd->is_summary = is_summary;
+	const char *fname = is_summary ? "lm_summary" : "lm";
+
+	if (input.inputs.empty() || input.inputs[0].IsNull()) {
+		throw BinderException("%s: 'data' (source table name) is required", fname);
+	}
+	bd->data_table = input.inputs[0].GetValue<string>();
+
+	auto it_y = input.named_parameters.find("y");
+	if (it_y == input.named_parameters.end() || it_y->second.IsNull()) {
+		throw BinderException("%s: 'y' (response column name) is required", fname);
+	}
+	bd->y_col = it_y->second.GetValue<string>();
+
+	auto it_x = input.named_parameters.find("x");
+	if (it_x == input.named_parameters.end() || it_x->second.IsNull()) {
+		throw BinderException("%s: 'x' (predictor list) is required", fname);
+	}
+	auto &x_children = ListValue::GetChildren(it_x->second);
+	for (auto &v : x_children) {
+		if (v.IsNull()) {
+			throw BinderException("%s: 'x' list entries must not be NULL", fname);
+		}
+		bd->x_cols.push_back(v.GetValue<string>());
+	}
+	if (bd->x_cols.empty()) {
+		throw BinderException("%s: 'x' must contain at least one predictor column", fname);
+	}
+
+	// Catalog lookup — y and every x must exist and be numeric.
+	auto &catalog = Catalog::GetCatalog(context, INVALID_CATALOG);
+	auto entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, DEFAULT_SCHEMA,
+	                              bd->data_table, OnEntryNotFound::THROW_EXCEPTION);
+	auto &tbl = entry->Cast<TableCatalogEntry>();
+	auto &cols = tbl.GetColumns();
+
+	auto check_col = [&](const std::string &c, const char *role) {
+		if (!cols.ColumnExists(c)) {
+			throw BinderException("%s: %s column '%s' not found in table '%s'", fname, role, c,
+			                      bd->data_table);
+		}
+		auto &col = cols.GetColumn(c);
+		if (!IsNumericKind(col.GetType().id())) {
+			throw BinderException(
+			    "%s: %s column '%s' is not numeric (type %s); OLS requires numeric columns",
+			    fname, role, c, col.GetType().ToString());
+		}
+	};
+	check_col(bd->y_col, "response");
+	for (auto &xc : bd->x_cols) {
+		check_col(xc, "predictor");
+	}
+	return std::move(bd);
+}
+
+static unique_ptr<FunctionData> LmBind(ClientContext &context, TableFunctionBindInput &input,
+                                       vector<LogicalType> &return_types, vector<string> &names) {
+	auto bd = LmBindCommon(context, input, /*is_summary=*/false);
+	names = {"term", "estimate", "std_error", "t_statistic", "p_value"};
+	return_types = {LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::DOUBLE,
+	                LogicalType::DOUBLE, LogicalType::DOUBLE};
+	return bd;
+}
+
+static unique_ptr<FunctionData> LmSummaryBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types,
+                                              vector<string> &names) {
+	auto bd = LmBindCommon(context, input, /*is_summary=*/true);
+	names = {"r_squared",   "adj_r_squared", "f_statistic", "f_p_value",
+	         "df_model",    "df_residual",   "sigma",       "n"};
+	return_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
+	                LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT,
+	                LogicalType::DOUBLE, LogicalType::BIGINT};
+	return bd;
+}
+
+//===--------------------------------------------------------------------===//
+// Global state — holds the fit result and a cursor over emitted rows.
+//===--------------------------------------------------------------------===//
+
+struct LmGlobalState : public GlobalTableFunctionState {
+	LmFit fit;
+	idx_t cursor = 0;
+};
+
+static unique_ptr<GlobalTableFunctionState> LmInitGlobal(ClientContext &context,
+                                                         TableFunctionInitInput &input) {
+	auto &bd = input.bind_data->Cast<LmBindData>();
+	auto state = make_uniq<LmGlobalState>();
+	Connection conn(*context.db);
+	state->fit = FitOls(conn, bd.data_table, bd.y_col, bd.x_cols);
+	if (!state->fit.ok) {
+		throw InvalidInputException(state->fit.error);
+	}
+	return std::move(state);
+}
+
+//===--------------------------------------------------------------------===//
+// Execute — stream pre-computed rows.
+//===--------------------------------------------------------------------===//
+
+static inline void SetDoubleOrNull(DataChunk &output, idx_t col, idx_t row, double v) {
+	if (std::isnan(v)) {
+		FlatVector::SetNull(output.data[col], row, true);
+	} else {
+		output.SetValue(col, row, Value::DOUBLE(v));
+	}
+}
+
+static void LmExecute(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	auto &state = input.global_state->Cast<LmGlobalState>();
+	idx_t emitted = 0;
+	while (state.cursor < state.fit.terms.size() && emitted < STANDARD_VECTOR_SIZE) {
+		idx_t i = state.cursor++;
+		output.SetValue(0, emitted, Value(state.fit.terms[i]));
+		SetDoubleOrNull(output, 1, emitted, state.fit.beta[i]);
+		SetDoubleOrNull(output, 2, emitted, state.fit.std_error[i]);
+		SetDoubleOrNull(output, 3, emitted, state.fit.t_statistic[i]);
+		SetDoubleOrNull(output, 4, emitted, state.fit.p_value[i]);
+		emitted++;
+	}
+	output.SetCardinality(emitted);
+}
+
+static void LmSummaryExecute(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	auto &state = input.global_state->Cast<LmGlobalState>();
+	if (state.cursor > 0) {
+		output.SetCardinality(0);
+		return;
+	}
+	state.cursor = 1;
+	SetDoubleOrNull(output, 0, 0, state.fit.r_squared);
+	SetDoubleOrNull(output, 1, 0, state.fit.adj_r_squared);
+	SetDoubleOrNull(output, 2, 0, state.fit.f_statistic);
+	SetDoubleOrNull(output, 3, 0, state.fit.f_p_value);
+	output.SetValue(4, 0, Value::BIGINT(static_cast<int64_t>(state.fit.df_model)));
+	output.SetValue(5, 0, Value::BIGINT(static_cast<int64_t>(state.fit.df_residual)));
+	SetDoubleOrNull(output, 6, 0, state.fit.sigma);
+	output.SetValue(7, 0, Value::BIGINT(static_cast<int64_t>(state.fit.n)));
+	output.SetCardinality(1);
+}
+
+} // namespace
+
+void RegisterLm(ExtensionLoader &loader) {
+	{
+		TableFunction fn("lm", {LogicalType::VARCHAR}, LmExecute, LmBind, LmInitGlobal);
+		fn.named_parameters["y"] = LogicalType::VARCHAR;
+		fn.named_parameters["x"] = LogicalType::LIST(LogicalType::VARCHAR);
+		loader.RegisterFunction(fn);
+	}
+	{
+		TableFunction fn("lm_summary", {LogicalType::VARCHAR}, LmSummaryExecute, LmSummaryBind,
+		                 LmInitGlobal);
+		fn.named_parameters["y"] = LogicalType::VARCHAR;
+		fn.named_parameters["x"] = LogicalType::LIST(LogicalType::VARCHAR);
+		loader.RegisterFunction(fn);
+	}
+}
+
+} // namespace duckdb

--- a/src/meta_function.cpp
+++ b/src/meta_function.cpp
@@ -1,0 +1,371 @@
+#include "meta_function.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// meta — per-column dataset profile.
+//
+// At bind time we resolve the source table in the catalog and capture each
+// declared column's name, type-as-text, and a semantic kind (numeric /
+// categorical / temporal / boolean / other). At init-global time we open an
+// internal Connection and run three batches:
+//   1. one combined query with count(*), count(col_i), count(DISTINCT col_i)
+//      across all columns — the cheap metadata that applies to every kind;
+//   2. one combined query computing min / p25 / median / p75 / max / avg /
+//      stddev_samp for the numeric columns only (cast to DOUBLE);
+//   3. one mode query per categorical / boolean column, giving (top, top_freq)
+//      with ties broken by the smaller value.
+// Execute then streams the pre-built rows STANDARD_VECTOR_SIZE at a time.
+
+namespace {
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+static std::string QuoteIdent(const std::string &raw) {
+	std::string out;
+	out.reserve(raw.size() + 2);
+	out.push_back('"');
+	for (char c : raw) {
+		if (c == '"') {
+			out.push_back('"');
+		}
+		out.push_back(c);
+	}
+	out.push_back('"');
+	return out;
+}
+
+enum class ColKind {
+	NUMERIC,
+	CATEGORICAL,
+	TEMPORAL,
+	BOOLEAN,
+	OTHER,
+};
+
+static const char *KindToString(ColKind k) {
+	switch (k) {
+	case ColKind::NUMERIC:
+		return "numeric";
+	case ColKind::CATEGORICAL:
+		return "categorical";
+	case ColKind::TEMPORAL:
+		return "temporal";
+	case ColKind::BOOLEAN:
+		return "boolean";
+	case ColKind::OTHER:
+		return "other";
+	}
+	return "other";
+}
+
+//! Same numeric classifier used by corr_matrix / lm / table_one — anything
+//! that casts to DOUBLE cleanly. We split out boolean and temporal from
+//! "other" since both have natural per-column profiling (mode and min/max-as-
+//! text respectively); the meta output currently fills mode for boolean but
+//! leaves temporal min/max NULL (typed numeric column would lose meaning).
+static ColKind ClassifyKind(LogicalTypeId tid) {
+	switch (tid) {
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::UHUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return ColKind::NUMERIC;
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::ENUM:
+		return ColKind::CATEGORICAL;
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return ColKind::TEMPORAL;
+	case LogicalTypeId::BOOLEAN:
+		return ColKind::BOOLEAN;
+	default:
+		return ColKind::OTHER;
+	}
+}
+
+// ── BindData / state ───────────────────────────────────────────────────────
+
+struct MetaRow {
+	std::string column_name;
+	std::string column_type;
+	ColKind kind = ColKind::OTHER;
+	int64_t n_rows = 0;
+	int64_t n_missing = 0;
+	int64_t n_distinct = 0;
+	double min = std::nan("");
+	double p25 = std::nan("");
+	double median = std::nan("");
+	double p75 = std::nan("");
+	double max = std::nan("");
+	double mean = std::nan("");
+	double stddev = std::nan("");
+	std::string top;
+	bool has_top = false;
+	int64_t top_freq = 0;
+};
+
+struct MetaBindData : public TableFunctionData {
+	std::string data_table;
+	std::vector<std::string> column_names;
+	std::vector<std::string> column_types;
+	std::vector<ColKind> kinds;
+};
+
+struct MetaGlobalState : public GlobalTableFunctionState {
+	std::vector<MetaRow> rows;
+	idx_t cursor = 0;
+};
+
+// ── Bind ───────────────────────────────────────────────────────────────────
+
+static unique_ptr<FunctionData> MetaBind(ClientContext &context, TableFunctionBindInput &input,
+                                         vector<LogicalType> &return_types,
+                                         vector<string> &names) {
+	auto bd = make_uniq<MetaBindData>();
+
+	if (input.inputs.empty() || input.inputs[0].IsNull()) {
+		throw BinderException("meta: 'data' (source table name) is required");
+	}
+	bd->data_table = input.inputs[0].GetValue<string>();
+
+	auto &catalog = Catalog::GetCatalog(context, INVALID_CATALOG);
+	auto entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, DEFAULT_SCHEMA,
+	                              bd->data_table, OnEntryNotFound::THROW_EXCEPTION);
+	auto &tbl = entry->Cast<TableCatalogEntry>();
+	auto &cols = tbl.GetColumns();
+	for (auto &col : cols.Logical()) {
+		bd->column_names.push_back(col.GetName());
+		bd->column_types.push_back(col.GetType().ToString());
+		bd->kinds.push_back(ClassifyKind(col.GetType().id()));
+	}
+
+	names = {"column_name", "column_type", "kind",   "n_rows", "n_missing",
+	         "n_distinct",  "min",         "p25",    "median", "p75",
+	         "max",         "mean",        "stddev", "top",    "top_freq"};
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::BIGINT,  LogicalType::BIGINT,  LogicalType::BIGINT,
+	                LogicalType::DOUBLE,  LogicalType::DOUBLE,  LogicalType::DOUBLE,
+	                LogicalType::DOUBLE,  LogicalType::DOUBLE,  LogicalType::DOUBLE,
+	                LogicalType::DOUBLE,  LogicalType::VARCHAR, LogicalType::BIGINT};
+	return std::move(bd);
+}
+
+// ── Init / fetch ──────────────────────────────────────────────────────────
+
+static unique_ptr<GlobalTableFunctionState> MetaInitGlobal(ClientContext &context,
+                                                           TableFunctionInitInput &input) {
+	auto &bd = input.bind_data->Cast<MetaBindData>();
+	auto state = make_uniq<MetaGlobalState>();
+
+	const idx_t K = bd.column_names.size();
+	state->rows.reserve(K);
+	for (idx_t i = 0; i < K; i++) {
+		MetaRow row;
+		row.column_name = bd.column_names[i];
+		row.column_type = bd.column_types[i];
+		row.kind = bd.kinds[i];
+		state->rows.push_back(std::move(row));
+	}
+
+	if (K == 0) {
+		return std::move(state);
+	}
+
+	Connection conn(*context.db);
+	auto quoted_table = QuoteIdent(bd.data_table);
+
+	// 1. count(*) + per-column (non-null, distinct) — applies to every kind.
+	{
+		std::stringstream sql;
+		sql << "SELECT count(*)";
+		for (idx_t i = 0; i < K; i++) {
+			auto qname = QuoteIdent(bd.column_names[i]);
+			sql << ", count(" << qname << ")";
+			sql << ", count(DISTINCT " << qname << ")";
+		}
+		sql << " FROM " << quoted_table;
+		auto result = conn.Query(sql.str());
+		if (result->HasError()) {
+			throw InvalidInputException("meta: failed to compute counts on '%s' (%s)",
+			                            bd.data_table, result->GetError());
+		}
+		auto chunk = result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			throw InvalidInputException("meta: empty result from counts query");
+		}
+		auto n_rows = chunk->GetValue(0, 0).GetValue<int64_t>();
+		for (idx_t i = 0; i < K; i++) {
+			state->rows[i].n_rows = n_rows;
+			auto non_null = chunk->GetValue(1 + 2 * i, 0).GetValue<int64_t>();
+			state->rows[i].n_missing = n_rows - non_null;
+			state->rows[i].n_distinct = chunk->GetValue(2 + 2 * i, 0).GetValue<int64_t>();
+		}
+	}
+
+	// 2. Numeric distribution — min, p25, median, p75, max, mean, stddev_samp.
+	//    Single combined query keyed by numeric-column index.
+	std::vector<idx_t> numeric_idxs;
+	for (idx_t i = 0; i < K; i++) {
+		if (bd.kinds[i] == ColKind::NUMERIC) {
+			numeric_idxs.push_back(i);
+		}
+	}
+	if (!numeric_idxs.empty()) {
+		std::stringstream sql;
+		sql << "SELECT ";
+		for (size_t j = 0; j < numeric_idxs.size(); j++) {
+			idx_t i = numeric_idxs[j];
+			auto qcast = QuoteIdent(bd.column_names[i]) + "::DOUBLE";
+			if (j > 0) {
+				sql << ", ";
+			}
+			sql << "min(" << qcast << "), "
+			    << "quantile_cont(" << qcast << ", 0.25), "
+			    << "quantile_cont(" << qcast << ", 0.5), "
+			    << "quantile_cont(" << qcast << ", 0.75), "
+			    << "max(" << qcast << "), "
+			    << "avg(" << qcast << "), "
+			    << "stddev_samp(" << qcast << ")";
+		}
+		sql << " FROM " << quoted_table;
+		auto result = conn.Query(sql.str());
+		if (result->HasError()) {
+			throw InvalidInputException("meta: failed to compute numeric stats on '%s' (%s)",
+			                            bd.data_table, result->GetError());
+		}
+		auto chunk = result->Fetch();
+		if (chunk && chunk->size() > 0) {
+			for (size_t j = 0; j < numeric_idxs.size(); j++) {
+				idx_t i = numeric_idxs[j];
+				idx_t base = 7 * j;
+				auto get_dbl = [&](idx_t col_in_chunk) -> double {
+					auto v = chunk->GetValue(col_in_chunk, 0);
+					if (v.IsNull()) {
+						return std::nan("");
+					}
+					return v.GetValue<double>();
+				};
+				state->rows[i].min = get_dbl(base + 0);
+				state->rows[i].p25 = get_dbl(base + 1);
+				state->rows[i].median = get_dbl(base + 2);
+				state->rows[i].p75 = get_dbl(base + 3);
+				state->rows[i].max = get_dbl(base + 4);
+				state->rows[i].mean = get_dbl(base + 5);
+				state->rows[i].stddev = get_dbl(base + 6);
+			}
+		}
+	}
+
+	// 3. Mode (top, top_freq) for categorical and boolean columns. One query
+	//    per column — could be folded into a single GROUPING SETS pass, but
+	//    that adds complexity for little gain when categorical columns are
+	//    a small share of the typical schema.
+	for (idx_t i = 0; i < K; i++) {
+		if (bd.kinds[i] != ColKind::CATEGORICAL && bd.kinds[i] != ColKind::BOOLEAN) {
+			continue;
+		}
+		auto qname = QuoteIdent(bd.column_names[i]);
+		std::stringstream sql;
+		sql << "SELECT " << qname << "::VARCHAR AS v, count(*) AS c "
+		    << "FROM " << quoted_table << " WHERE " << qname << " IS NOT NULL"
+		    << " GROUP BY 1 ORDER BY 2 DESC, 1 ASC LIMIT 1";
+		auto result = conn.Query(sql.str());
+		if (result->HasError()) {
+			// Don't fail the whole call on a single mode query failure; just
+			// leave top/top_freq NULL for this column.
+			continue;
+		}
+		auto chunk = result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			continue;
+		}
+		if (chunk->GetValue(0, 0).IsNull()) {
+			continue;
+		}
+		state->rows[i].top = chunk->GetValue(0, 0).GetValue<string>();
+		state->rows[i].has_top = true;
+		state->rows[i].top_freq = chunk->GetValue(1, 0).GetValue<int64_t>();
+	}
+
+	return std::move(state);
+}
+
+// ── Execute ───────────────────────────────────────────────────────────────
+
+static inline void SetDoubleOrNull(DataChunk &output, idx_t col, idx_t row, double v) {
+	if (std::isnan(v)) {
+		FlatVector::SetNull(output.data[col], row, true);
+	} else {
+		output.SetValue(col, row, Value::DOUBLE(v));
+	}
+}
+
+static void MetaExecute(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	auto &state = input.global_state->Cast<MetaGlobalState>();
+	idx_t emitted = 0;
+	while (state.cursor < state.rows.size() && emitted < STANDARD_VECTOR_SIZE) {
+		const auto &r = state.rows[state.cursor++];
+		output.SetValue(0, emitted, Value(r.column_name));
+		output.SetValue(1, emitted, Value(r.column_type));
+		output.SetValue(2, emitted, Value(KindToString(r.kind)));
+		output.SetValue(3, emitted, Value::BIGINT(r.n_rows));
+		output.SetValue(4, emitted, Value::BIGINT(r.n_missing));
+		output.SetValue(5, emitted, Value::BIGINT(r.n_distinct));
+		SetDoubleOrNull(output, 6, emitted, r.min);
+		SetDoubleOrNull(output, 7, emitted, r.p25);
+		SetDoubleOrNull(output, 8, emitted, r.median);
+		SetDoubleOrNull(output, 9, emitted, r.p75);
+		SetDoubleOrNull(output, 10, emitted, r.max);
+		SetDoubleOrNull(output, 11, emitted, r.mean);
+		SetDoubleOrNull(output, 12, emitted, r.stddev);
+		if (r.has_top) {
+			output.SetValue(13, emitted, Value(r.top));
+			output.SetValue(14, emitted, Value::BIGINT(r.top_freq));
+		} else {
+			FlatVector::SetNull(output.data[13], emitted, true);
+			FlatVector::SetNull(output.data[14], emitted, true);
+		}
+		emitted++;
+	}
+	output.SetCardinality(emitted);
+}
+
+} // namespace
+
+void RegisterMeta(ExtensionLoader &loader) {
+	TableFunction fn("meta", {LogicalType::VARCHAR}, MetaExecute, MetaBind, MetaInitGlobal);
+	loader.RegisterFunction(fn);
+}
+
+} // namespace duckdb

--- a/src/random_sampling_function.cpp
+++ b/src/random_sampling_function.cpp
@@ -146,6 +146,37 @@ static inline void RunPerRow2(DataChunk &args, Vector &result, Quantile &&q) {
 	}
 }
 
+template <typename Quantile>
+static inline void RunPerRow3(DataChunk &args, Vector &result, Quantile &&q) {
+	idx_t count = args.size();
+	UnifiedVectorFormat a0, a1, a2;
+	args.data[0].ToUnifiedFormat(count, a0);
+	args.data[1].ToUnifiedFormat(count, a1);
+	args.data[2].ToUnifiedFormat(count, a2);
+	auto v0 = UnifiedVectorFormat::GetData<double>(a0);
+	auto v1 = UnifiedVectorFormat::GetData<double>(a1);
+	auto v2 = UnifiedVectorFormat::GetData<double>(a2);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto out = FlatVector::GetData<double>(result);
+	auto &mask = FlatVector::Validity(result);
+	for (idx_t i = 0; i < count; i++) {
+		auto i0 = a0.sel->get_index(i);
+		auto i1 = a1.sel->get_index(i);
+		auto i2 = a2.sel->get_index(i);
+		if (!a0.validity.RowIsValid(i0) || !a1.validity.RowIsValid(i1) ||
+		    !a2.validity.RowIsValid(i2)) {
+			mask.SetInvalid(i);
+			(void)NextUniform();
+			out[i] = 0.0;
+			continue;
+		}
+		double p0 = v0[i0];
+		double p1 = v1[i1];
+		double p2 = v2[i2];
+		out[i] = SafeSampleOne([&](double u) { return q(u, p0, p1, p2); }, mask, i);
+	}
+}
+
 //===--------------------------------------------------------------------===//
 // rnorm: 0 / 1 / 2 args (defaults mean=0, sd=1).
 //===--------------------------------------------------------------------===//
@@ -265,6 +296,28 @@ static void RPoisExec(DataChunk &args, ExpressionState &, Vector &result) {
 }
 
 //===--------------------------------------------------------------------===//
+// rnbinom(size, prob) — inverse-CDF; NegBinomQuantile is monotone integer
+// search seeded from the normal approximation, same shape as rpois.
+//===--------------------------------------------------------------------===//
+
+static void RNBinomExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow2(args, result, [](double u, double size, double prob) {
+		return stats_duck::NegBinomQuantile(u, size, prob);
+	});
+}
+
+//===--------------------------------------------------------------------===//
+// rhyper(m, n, k) — inverse-CDF; HyperGeomQuantile sums the PMF up to where
+// the cumulative crosses u, so the support is bounded by min(m, k).
+//===--------------------------------------------------------------------===//
+
+static void RHyperExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow3(args, result, [](double u, double m, double n, double k) {
+		return stats_duck::HyperGeomQuantile(u, m, n, k);
+	});
+}
+
+//===--------------------------------------------------------------------===//
 // Registration helpers.
 //===--------------------------------------------------------------------===//
 
@@ -334,6 +387,12 @@ void RegisterRandomSampling(ExtensionLoader &loader) {
 
 	// ── rpois ───────────────────────────────────────────────────────────────
 	loader.RegisterFunction(MakeVolatile("rpois", {DBL}, DBL, RPoisExec));
+
+	// ── rnbinom ─────────────────────────────────────────────────────────────
+	loader.RegisterFunction(MakeVolatile("rnbinom", {DBL, DBL}, DBL, RNBinomExec));
+
+	// ── rhyper ──────────────────────────────────────────────────────────────
+	loader.RegisterFunction(MakeVolatile("rhyper", {DBL, DBL, DBL}, DBL, RHyperExec));
 }
 
 } // namespace duckdb

--- a/src/random_sampling_function.cpp
+++ b/src/random_sampling_function.cpp
@@ -1,0 +1,339 @@
+#include "random_sampling_function.hpp"
+
+#include "distributions.hpp"
+
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include <cmath>
+#include <limits>
+#include <random>
+
+namespace duckdb {
+
+namespace {
+
+//===--------------------------------------------------------------------===//
+// Thread-local RNG.
+//
+// Each worker thread holds its own std::mt19937_64 seeded from
+// std::random_device on first use. Marking the registered functions VOLATILE
+// keeps DuckDB from constant-folding them, so each row genuinely calls
+// NextUniform() and the per-row independence assumption holds. A future
+// iteration can add an explicit-seed override (e.g. a session-level
+// stats_duck_seed() helper) — today the RNG is non-reproducible by design,
+// matching the ergonomics of DuckDB's `random()`.
+//===--------------------------------------------------------------------===//
+
+static std::mt19937_64 &TLSRng() {
+	thread_local std::mt19937_64 rng = [] {
+		std::random_device rd;
+		uint64_t seed = (static_cast<uint64_t>(rd()) << 32) | rd();
+		return std::mt19937_64(seed);
+	}();
+	return rng;
+}
+
+//! Uniform sample on the open interval (0, 1). Take the top 53 bits of a single
+//! mt19937_64 draw and scale by 2^-53, which gives every representable double
+//! in [0, 1) equal probability mass. A u==0 nudge keeps the inverse-CDF
+//! transforms below away from log(0) / qnorm(0). We deliberately do not use
+//! std::uniform_real_distribution or std::generate_canonical — both have biased
+//! tails on the MSVC STL.
+static inline double NextUniform() {
+	auto &rng = TLSRng();
+	uint64_t x = rng();
+	uint64_t bits = x >> 11; // 53-bit mantissa
+	double u = static_cast<double>(bits) * (1.0 / static_cast<double>(1ULL << 53));
+	if (u <= 0.0) {
+		u = std::numeric_limits<double>::min();
+	}
+	return u;
+}
+
+//! Wrap a quantile-style function in the row-validity discipline used by the
+//! rest of the distribution scalars (NaN / domain errors / domain-arg NULLs →
+//! result NULL). Always consumes one uniform draw from the RNG, regardless of
+//! whether validity is set — keeps the per-row RNG advance independent of
+//! input mask state.
+template <typename Fn>
+static inline double SafeSampleOne(Fn &&fn, ValidityMask &mask, idx_t idx) {
+	double u = NextUniform();
+	try {
+		double v = fn(u);
+		if (std::isnan(v) || std::isinf(v)) {
+			mask.SetInvalid(idx);
+			return 0.0;
+		}
+		return v;
+	} catch (...) {
+		mask.SetInvalid(idx);
+		return 0.0;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Generic per-row executors.
+//
+// DuckDB's UnaryExecutor / BinaryExecutor have a fast path for constant-vector
+// inputs that calls the user lambda *once per chunk* and replicates the output
+// across the row range. That fast path is correct for pure functions but
+// catastrophic for r* sampling — a query like `SELECT rexp(1.0) FROM range(N)`
+// would produce ~N/STANDARD_VECTOR_SIZE unique values instead of N. We mark the
+// functions VOLATILE so DuckDB doesn't constant-fold at the planner level, then
+// also bypass UnaryExecutor / BinaryExecutor with these explicit per-row loops
+// that genuinely draw one fresh uniform per output row.
+//===--------------------------------------------------------------------===//
+
+template <typename Quantile>
+static inline void RunPerRow0(DataChunk &args, Vector &result, Quantile &&q) {
+	idx_t count = args.size();
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto out = FlatVector::GetData<double>(result);
+	auto &mask = FlatVector::Validity(result);
+	for (idx_t i = 0; i < count; i++) {
+		out[i] = SafeSampleOne([&](double u) { return q(u); }, mask, i);
+	}
+}
+
+template <typename Quantile>
+static inline void RunPerRow1(DataChunk &args, Vector &result, Quantile &&q) {
+	idx_t count = args.size();
+	UnifiedVectorFormat a0;
+	args.data[0].ToUnifiedFormat(count, a0);
+	auto v0 = UnifiedVectorFormat::GetData<double>(a0);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto out = FlatVector::GetData<double>(result);
+	auto &mask = FlatVector::Validity(result);
+	for (idx_t i = 0; i < count; i++) {
+		auto i0 = a0.sel->get_index(i);
+		if (!a0.validity.RowIsValid(i0)) {
+			mask.SetInvalid(i);
+			(void)NextUniform(); // keep RNG advance independent of input nulls
+			out[i] = 0.0;
+			continue;
+		}
+		double p0 = v0[i0];
+		out[i] = SafeSampleOne([&](double u) { return q(u, p0); }, mask, i);
+	}
+}
+
+template <typename Quantile>
+static inline void RunPerRow2(DataChunk &args, Vector &result, Quantile &&q) {
+	idx_t count = args.size();
+	UnifiedVectorFormat a0, a1;
+	args.data[0].ToUnifiedFormat(count, a0);
+	args.data[1].ToUnifiedFormat(count, a1);
+	auto v0 = UnifiedVectorFormat::GetData<double>(a0);
+	auto v1 = UnifiedVectorFormat::GetData<double>(a1);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto out = FlatVector::GetData<double>(result);
+	auto &mask = FlatVector::Validity(result);
+	for (idx_t i = 0; i < count; i++) {
+		auto i0 = a0.sel->get_index(i);
+		auto i1 = a1.sel->get_index(i);
+		if (!a0.validity.RowIsValid(i0) || !a1.validity.RowIsValid(i1)) {
+			mask.SetInvalid(i);
+			(void)NextUniform();
+			out[i] = 0.0;
+			continue;
+		}
+		double p0 = v0[i0];
+		double p1 = v1[i1];
+		out[i] = SafeSampleOne([&](double u) { return q(u, p0, p1); }, mask, i);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// rnorm: 0 / 1 / 2 args (defaults mean=0, sd=1).
+//===--------------------------------------------------------------------===//
+
+static void RNormStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow0(args, result, [](double u) { return stats_duck::NormalQuantile(u); });
+}
+static void RNorm1Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result,
+	           [](double u, double mean) { return stats_duck::NormalQuantile(u, mean); });
+}
+static void RNorm2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow2(args, result, [](double u, double mean, double sd) {
+		return stats_duck::NormalQuantile(u, mean, sd);
+	});
+}
+
+//===--------------------------------------------------------------------===//
+// rt(df), rchisq(df).
+//===--------------------------------------------------------------------===//
+
+static void RTExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result,
+	           [](double u, double df) { return stats_duck::StudentTQuantile(u, df); });
+}
+static void RChiSqExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result,
+	           [](double u, double df) { return stats_duck::ChiSquareQuantile(u, df); });
+}
+
+//===--------------------------------------------------------------------===//
+// rf(df1, df2).
+//===--------------------------------------------------------------------===//
+
+static void RFExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow2(args, result, [](double u, double df1, double df2) {
+		return stats_duck::FQuantile(u, df1, df2);
+	});
+}
+
+//===--------------------------------------------------------------------===//
+// rgamma: 1 / 2 args (defaults rate=1).
+//===--------------------------------------------------------------------===//
+
+static void RGamma1Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result,
+	           [](double u, double shape) { return stats_duck::GammaQuantile(u, shape); });
+}
+static void RGamma2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow2(args, result, [](double u, double shape, double rate) {
+		return stats_duck::GammaQuantile(u, shape, rate);
+	});
+}
+
+//===--------------------------------------------------------------------===//
+// rbeta(alpha, beta).
+//===--------------------------------------------------------------------===//
+
+static void RBetaExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow2(args, result, [](double u, double alpha, double beta) {
+		return stats_duck::BetaQuantile(u, alpha, beta);
+	});
+}
+
+//===--------------------------------------------------------------------===//
+// rexp: 0 / 1 args (defaults rate=1).
+//===--------------------------------------------------------------------===//
+
+static void RExpStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow0(args, result, [](double u) { return stats_duck::ExponentialQuantile(u); });
+}
+static void RExp1Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result,
+	           [](double u, double rate) { return stats_duck::ExponentialQuantile(u, rate); });
+}
+
+//===--------------------------------------------------------------------===//
+// rweibull(shape [, scale=1]).
+//===--------------------------------------------------------------------===//
+
+static void RWeibull1Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result,
+	           [](double u, double shape) { return stats_duck::WeibullQuantile(u, shape); });
+}
+static void RWeibull2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow2(args, result, [](double u, double shape, double scale) {
+		return stats_duck::WeibullQuantile(u, shape, scale);
+	});
+}
+
+//===--------------------------------------------------------------------===//
+// rlnorm: 0 / 1 / 2 args (defaults meanlog=0, sdlog=1).
+//===--------------------------------------------------------------------===//
+
+static void RLNormStdExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow0(args, result, [](double u) { return stats_duck::LogNormalQuantile(u); });
+}
+static void RLNorm1Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result, [](double u, double meanlog) {
+		return stats_duck::LogNormalQuantile(u, meanlog);
+	});
+}
+static void RLNorm2Exec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow2(args, result, [](double u, double meanlog, double sdlog) {
+		return stats_duck::LogNormalQuantile(u, meanlog, sdlog);
+	});
+}
+
+//===--------------------------------------------------------------------===//
+// rpois(lambda). Discrete — inverse-CDF via the existing PoissonQuantile,
+// which does monotone integer search seeded from the normal approximation.
+//===--------------------------------------------------------------------===//
+
+static void RPoisExec(DataChunk &args, ExpressionState &, Vector &result) {
+	RunPerRow1(args, result,
+	           [](double u, double lambda) { return stats_duck::PoissonQuantile(u, lambda); });
+}
+
+//===--------------------------------------------------------------------===//
+// Registration helpers.
+//===--------------------------------------------------------------------===//
+
+static ScalarFunction MakeVolatile(string name, vector<LogicalType> args, LogicalType ret,
+                                   scalar_function_t fn) {
+	ScalarFunction f(std::move(name), std::move(args), std::move(ret), fn);
+	f.stability = FunctionStability::VOLATILE;
+	return f;
+}
+
+} // namespace
+
+void RegisterRandomSampling(ExtensionLoader &loader) {
+	const auto DBL = LogicalType::DOUBLE;
+
+	// ── rnorm ───────────────────────────────────────────────────────────────
+	{
+		ScalarFunctionSet set("rnorm");
+		set.AddFunction(MakeVolatile("rnorm", {}, DBL, RNormStdExec));
+		set.AddFunction(MakeVolatile("rnorm", {DBL}, DBL, RNorm1Exec));
+		set.AddFunction(MakeVolatile("rnorm", {DBL, DBL}, DBL, RNorm2Exec));
+		loader.RegisterFunction(set);
+	}
+
+	// ── rt / rchisq ─────────────────────────────────────────────────────────
+	loader.RegisterFunction(MakeVolatile("rt", {DBL}, DBL, RTExec));
+	loader.RegisterFunction(MakeVolatile("rchisq", {DBL}, DBL, RChiSqExec));
+
+	// ── rf ──────────────────────────────────────────────────────────────────
+	loader.RegisterFunction(MakeVolatile("rf", {DBL, DBL}, DBL, RFExec));
+
+	// ── rgamma ──────────────────────────────────────────────────────────────
+	{
+		ScalarFunctionSet set("rgamma");
+		set.AddFunction(MakeVolatile("rgamma", {DBL}, DBL, RGamma1Exec));
+		set.AddFunction(MakeVolatile("rgamma", {DBL, DBL}, DBL, RGamma2Exec));
+		loader.RegisterFunction(set);
+	}
+
+	// ── rbeta ───────────────────────────────────────────────────────────────
+	loader.RegisterFunction(MakeVolatile("rbeta", {DBL, DBL}, DBL, RBetaExec));
+
+	// ── rexp ────────────────────────────────────────────────────────────────
+	{
+		ScalarFunctionSet set("rexp");
+		set.AddFunction(MakeVolatile("rexp", {}, DBL, RExpStdExec));
+		set.AddFunction(MakeVolatile("rexp", {DBL}, DBL, RExp1Exec));
+		loader.RegisterFunction(set);
+	}
+
+	// ── rweibull ────────────────────────────────────────────────────────────
+	{
+		ScalarFunctionSet set("rweibull");
+		set.AddFunction(MakeVolatile("rweibull", {DBL}, DBL, RWeibull1Exec));
+		set.AddFunction(MakeVolatile("rweibull", {DBL, DBL}, DBL, RWeibull2Exec));
+		loader.RegisterFunction(set);
+	}
+
+	// ── rlnorm ──────────────────────────────────────────────────────────────
+	{
+		ScalarFunctionSet set("rlnorm");
+		set.AddFunction(MakeVolatile("rlnorm", {}, DBL, RLNormStdExec));
+		set.AddFunction(MakeVolatile("rlnorm", {DBL}, DBL, RLNorm1Exec));
+		set.AddFunction(MakeVolatile("rlnorm", {DBL, DBL}, DBL, RLNorm2Exec));
+		loader.RegisterFunction(set);
+	}
+
+	// ── rpois ───────────────────────────────────────────────────────────────
+	loader.RegisterFunction(MakeVolatile("rpois", {DBL}, DBL, RPoisExec));
+}
+
+} // namespace duckdb

--- a/src/read_stat_function.cpp
+++ b/src/read_stat_function.cpp
@@ -3,6 +3,8 @@
 
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/types/column/column_data_scan_states.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/main/config.hpp"
@@ -191,6 +193,14 @@ static void BindErrorHandler(const char *error_message, void *ctx) {
 	bind_data.error_message = error_message ? error_message : "Unknown ReadStat error";
 }
 
+// The full schema is known from the header (every variable handler fires before
+// any row data), so we abort as soon as the first value arrives — otherwise
+// ReadStat streams and decodes the entire data section just to discard it, adding
+// a full O(N) file read to every bind.
+static int BindAbortValueHandler(int, readstat_variable_t *, readstat_value_t, void *) {
+	return READSTAT_HANDLER_ABORT;
+}
+
 // ─── Bind function ──────────────────────────────────────────────────────────────
 
 static unique_ptr<FunctionData> ReadStatBind(ClientContext &context, TableFunctionBindInput &input,
@@ -215,12 +225,13 @@ static unique_ptr<FunctionData> ReadStatBind(ClientContext &context, TableFuncti
 		throw InvalidInputException("Cannot detect file format. Specify it with: read_stat('file', format := 'sas7bdat')");
 	}
 
-	// Parse metadata only
+	// Parse the header only: metadata + variables give us the schema, then
+	// BindAbortValueHandler stops the parse before the data section is read.
 	readstat_parser_t *parser = readstat_parser_init();
 	readstat_set_metadata_handler(parser, BindMetadataHandler);
 	readstat_set_variable_handler(parser, BindVariableHandler);
+	readstat_set_value_handler(parser, BindAbortValueHandler);
 	readstat_set_error_handler(parser, BindErrorHandler);
-	readstat_set_row_limit(parser, 0);
 
 	DuckDBIOContext io_ctx;
 	io_ctx.fs = &FileSystem::GetFileSystem(context);
@@ -234,7 +245,9 @@ static unique_ptr<FunctionData> ReadStatBind(ClientContext &context, TableFuncti
 	readstat_set_io_ctx(parser, nullptr); // detach stack ctx before free
 	readstat_parser_free(parser);
 
-	if (error != READSTAT_OK) {
+	// READSTAT_ERROR_USER_ABORT is expected: it's how BindAbortValueHandler stops
+	// after the header. An empty file finishes with READSTAT_OK (no value seen).
+	if (error != READSTAT_OK && error != READSTAT_ERROR_USER_ABORT) {
 		string msg = bind_data->error_message.empty() ? readstat_error_message(error) : bind_data->error_message;
 		throw IOException("Failed to read '%s': %s", bind_data->path, msg);
 	}
@@ -250,90 +263,100 @@ static unique_ptr<FunctionData> ReadStatBind(ClientContext &context, TableFuncti
 
 // ─── Global state ───────────────────────────────────────────────────────────────
 
+// Option A (parse-once). The previous design re-invoked the ReadStat parser for
+// every 2048-row output chunk with an increasing row_offset, which is O(N^2):
+// ReadStat's row_offset reads and decodes every skipped row instead of seeking,
+// and each chunk re-opened and re-read the file from byte 0. Now the file is
+// parsed a single time at InitGlobal into a (spillable) ColumnDataCollection, and
+// Execute streams chunks out of it.
+// See notes/engineering/2026-06-xpt-reader-quadratic.md.
 struct ReadStatGlobalState : public GlobalTableFunctionState {
-	idx_t offset = 0;
-	bool done = false; // true once ReadStat produces 0 rows (EOF)
+	unique_ptr<ColumnDataCollection> buffer;
+	ColumnDataScanState scan_state;
+	bool scan_initialized = false;
 };
 
-static unique_ptr<GlobalTableFunctionState> ReadStatInitGlobal(ClientContext &context,
-                                                                TableFunctionInitInput &input) {
-	return make_uniq<ReadStatGlobalState>();
-}
+// ─── Load-phase ReadStat callbacks ───────────────────────────────────────────────
+// ReadStat hands values in row-major order (every variable of row r, then row
+// r+1), with obs_index = absolute row index. We stage rows into a DataChunk and
+// append it to the buffer whenever it fills.
 
-// ─── Execute-phase ReadStat callbacks ───────────────────────────────────────────
-
-struct ReadStatExecContext {
-	DataChunk *output;
+struct ReadStatLoadContext {
 	const ReadStatBindData *bind_data;
-	idx_t rows_read;
+	ColumnDataCollection *buffer;
+	ColumnDataAppendState *append_state;
+	DataChunk *staging;
+	idx_t flushed = 0; // rows already appended to the buffer
+	idx_t staged = 0;  // rows currently held in the staging chunk
 	string error_message;
 };
 
-static int ExecValueHandler(int obs_index, readstat_variable_t *variable, readstat_value_t value, void *ctx) {
-	auto &exec = *static_cast<ReadStatExecContext *>(ctx);
+static int LoadValueHandler(int obs_index, readstat_variable_t *variable, readstat_value_t value, void *ctx) {
+	auto &lc = *static_cast<ReadStatLoadContext *>(ctx);
+	auto oi = static_cast<idx_t>(obs_index);
+
+	// Crossing a vector boundary means the staging chunk is full: append and reset.
+	while (oi - lc.flushed >= STANDARD_VECTOR_SIZE) {
+		lc.staging->SetCardinality(STANDARD_VECTOR_SIZE);
+		lc.buffer->Append(*lc.append_state, *lc.staging);
+		lc.staging->Reset();
+		lc.flushed += STANDARD_VECTOR_SIZE;
+		lc.staged = 0;
+	}
+	idx_t row = oi - lc.flushed;
 	int col = readstat_variable_get_index(variable);
-	auto &vec = exec.output->data[col];
+	auto &vec = lc.staging->data[col];
 
 	if (readstat_value_is_system_missing(value) || readstat_value_is_tagged_missing(value) ||
 	    readstat_value_is_defined_missing(value, variable)) {
-		FlatVector::SetNull(vec, static_cast<idx_t>(obs_index), true);
+		FlatVector::SetNull(vec, row, true);
 	} else {
-		WriteReadStatValue(value, variable, exec.bind_data->column_types[col],
-		                   exec.bind_data->column_formats[col], vec, static_cast<idx_t>(obs_index));
+		WriteReadStatValue(value, variable, lc.bind_data->column_types[col],
+		                   lc.bind_data->column_formats[col], vec, row);
 	}
-
-	auto row = static_cast<idx_t>(obs_index + 1);
-	if (row > exec.rows_read) {
-		exec.rows_read = row;
+	if (row + 1 > lc.staged) {
+		lc.staged = row + 1;
 	}
 	return READSTAT_HANDLER_OK;
 }
 
-static int ExecMetadataHandler(readstat_metadata_t *metadata, void *ctx) {
+static int LoadNoopMetadataHandler(readstat_metadata_t *, void *) {
 	return READSTAT_HANDLER_OK;
 }
 
-static int ExecVariableHandler(int index, readstat_variable_t *variable, const char *val_labels, void *ctx) {
+static int LoadNoopVariableHandler(int, readstat_variable_t *, const char *, void *) {
 	return READSTAT_HANDLER_OK;
 }
 
-static void ExecErrorHandler(const char *error_message, void *ctx) {
-	auto &exec = *static_cast<ReadStatExecContext *>(ctx);
-	exec.error_message = error_message ? error_message : "Unknown ReadStat error";
+static void LoadErrorHandler(const char *error_message, void *ctx) {
+	auto &lc = *static_cast<ReadStatLoadContext *>(ctx);
+	lc.error_message = error_message ? error_message : "Unknown ReadStat error";
 }
 
-// ─── Execute function ───────────────────────────────────────────────────────────
+// ─── InitGlobal: parse the whole file into the buffer ────────────────────────────
 
-static void ReadStatExecute(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+static unique_ptr<GlobalTableFunctionState> ReadStatInitGlobal(ClientContext &context,
+                                                                TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->Cast<ReadStatBindData>();
-	auto &state = input.global_state->Cast<ReadStatGlobalState>();
+	auto state = make_uniq<ReadStatGlobalState>();
+	state->buffer = make_uniq<ColumnDataCollection>(context, bind_data.column_types);
 
-	// If the format reported a known row count, check the bound.
-	// If row_count is -1 (unknown, e.g. XPT), we rely on ReadStat
-	// returning 0 rows to signal EOF (handled below via SetCardinality(0)).
-	if (bind_data.row_count >= 0 && state.offset >= static_cast<idx_t>(bind_data.row_count)) {
-		return; // Done — empty output signals EOF
-	}
+	ColumnDataAppendState append_state;
+	state->buffer->InitializeAppend(append_state);
+	DataChunk staging;
+	state->buffer->InitializeScanChunk(staging);
 
-	// Guard against re-reading after ReadStat already signaled EOF in a
-	// previous call (rows_read was 0). Without this, unknown-row-count
-	// formats would loop forever.
-	if (state.done) {
-		return;
-	}
-
-	ReadStatExecContext exec;
-	exec.output = &output;
-	exec.bind_data = &bind_data;
-	exec.rows_read = 0;
+	ReadStatLoadContext lc;
+	lc.bind_data = &bind_data;
+	lc.buffer = state->buffer.get();
+	lc.append_state = &append_state;
+	lc.staging = &staging;
 
 	readstat_parser_t *parser = readstat_parser_init();
-	readstat_set_metadata_handler(parser, ExecMetadataHandler);
-	readstat_set_variable_handler(parser, ExecVariableHandler);
-	readstat_set_value_handler(parser, ExecValueHandler);
-	readstat_set_error_handler(parser, ExecErrorHandler);
-	readstat_set_row_offset(parser, static_cast<long>(state.offset));
-	readstat_set_row_limit(parser, static_cast<long>(STANDARD_VECTOR_SIZE));
+	readstat_set_metadata_handler(parser, LoadNoopMetadataHandler);
+	readstat_set_variable_handler(parser, LoadNoopVariableHandler);
+	readstat_set_value_handler(parser, LoadValueHandler);
+	readstat_set_error_handler(parser, LoadErrorHandler);
 
 	DuckDBIOContext io_ctx;
 	io_ctx.fs = &FileSystem::GetFileSystem(context);
@@ -343,22 +366,35 @@ static void ReadStatExecute(ClientContext &context, TableFunctionInput &input, D
 		readstat_set_file_character_encoding(parser, bind_data.encoding.c_str());
 	}
 
-	auto error = ParseWithFormat(parser, bind_data.path, bind_data.format, &exec);
+	auto error = ParseWithFormat(parser, bind_data.path, bind_data.format, &lc);
 	readstat_set_io_ctx(parser, nullptr); // detach stack ctx before free
 	readstat_parser_free(parser);
 
-	if (error != READSTAT_OK && exec.rows_read == 0) {
-		string msg = exec.error_message.empty() ? readstat_error_message(error) : exec.error_message;
-		throw IOException("Failed to read '%s' at offset %llu: %s", bind_data.path, state.offset, msg);
+	// Append the final partial chunk.
+	if (lc.staged > 0) {
+		staging.SetCardinality(lc.staged);
+		state->buffer->Append(append_state, staging);
 	}
 
-	output.SetCardinality(exec.rows_read);
-	state.offset += exec.rows_read;
-
-	// If ReadStat produced no rows in this call, the file is exhausted.
-	if (exec.rows_read == 0) {
-		state.done = true;
+	// Tolerate a late error once rows have been read (matches the previous reader,
+	// which kept whatever rows it had already produced); fail hard otherwise.
+	if (error != READSTAT_OK && lc.flushed + lc.staged == 0) {
+		string msg = lc.error_message.empty() ? readstat_error_message(error) : lc.error_message;
+		throw IOException("Failed to read '%s': %s", bind_data.path, msg);
 	}
+
+	return std::move(state);
+}
+
+// ─── Execute: stream chunks from the buffer ──────────────────────────────────────
+
+static void ReadStatExecute(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	auto &state = input.global_state->Cast<ReadStatGlobalState>();
+	if (!state.scan_initialized) {
+		state.buffer->InitializeScan(state.scan_state);
+		state.scan_initialized = true;
+	}
+	state.buffer->Scan(state.scan_state, output);
 }
 
 // ─── Replacement scan ───────────────────────────────────────────────────────────

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -17,6 +17,7 @@
 #include "corr_matrix_function.hpp"
 #include "lm_function.hpp"
 #include "table_one_function.hpp"
+#include "meta_function.hpp"
 #include "normality_function.hpp"
 #include "ks_test_function.hpp"
 #include "anova_function.hpp"
@@ -79,6 +80,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Table 1 helper
 	RegisterTableOne(loader);
+
+	// Dataset profile (per-column metadata + light stats)
+	RegisterMeta(loader);
 
 	// Data import
 	RegisterReadStat(loader);

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -11,6 +11,7 @@
 #include "sign_test_function.hpp"
 #include "adjust_p_function.hpp"
 #include "poibin_function.hpp"
+#include "bootstrap_function.hpp"
 #include "auto_bin_function.hpp"
 #include "corr_matrix_function.hpp"
 #include "table_one_function.hpp"
@@ -57,6 +58,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Poisson Binomial CDF
 	RegisterPoibinCdf(loader);
+
+	// Bootstrap (with-replacement resampling aggregate)
+	RegisterBootstrap(loader);
 
 	// Auto-binning helpers
 	RegisterBinEdges(loader);

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -15,6 +15,7 @@
 #include "bootstrap_function.hpp"
 #include "auto_bin_function.hpp"
 #include "corr_matrix_function.hpp"
+#include "lm_function.hpp"
 #include "table_one_function.hpp"
 #include "normality_function.hpp"
 #include "ks_test_function.hpp"
@@ -72,6 +73,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Pairwise correlation matrix
 	RegisterCorrMatrix(loader);
+
+	// OLS linear regression
+	RegisterLm(loader);
 
 	// Table 1 helper
 	RegisterTableOne(loader);

--- a/src/stats_duck_extension.cpp
+++ b/src/stats_duck_extension.cpp
@@ -5,6 +5,7 @@
 #include "ttest_agg_function.hpp"
 #include "nonparametric_function.hpp"
 #include "distribution_functions.hpp"
+#include "random_sampling_function.hpp"
 #include "summary_stats_function.hpp"
 #include "correlation_function.hpp"
 #include "rank_correlation_function.hpp"
@@ -52,6 +53,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// Scalar distribution functions (dnorm/pnorm/qnorm/dt/pt/qt/dchisq/...)
 	RegisterDistributionFunctions(loader);
+
+	// Random sampling — per-row inverse-CDF on a thread-local RNG (rnorm/rt/...)
+	RegisterRandomSampling(loader);
 
 	// Multiple-testing corrections
 	RegisterAdjustP(loader);

--- a/src/table_one_function.cpp
+++ b/src/table_one_function.cpp
@@ -46,19 +46,25 @@ struct TableOneRow {
 	// stratum or when the underlying test fails (e.g. zero variance, too few
 	// samples).
 	double p_value;
+	// Between-group effect size: η² for numeric (from ANOVA's eta_squared);
+	// Cramér's V for categorical (sqrt(χ²/(n · (min(r,c)-1)))). NaN under the
+	// same conditions as p_value. Same uniform name across both — the
+	// variable's row's `statistic` field implicitly tells the consumer which.
+	double effect_size;
 
 	// Explicit constructor so 5-arg brace-init calls (the existing pattern in
-	// EmitNumericRows / EmitCategoricalRows) keep working with p_value
-	// defaulted to NaN. A C++17 NSDMI default would also work under MSVC, but
-	// emscripten's libc++ rejects brace-init of an aggregate with NSDMIs
-	// when the brace list is shorter than the field count — the constructor
-	// form is portable across both toolchains.
+	// EmitNumericRows / EmitCategoricalRows) keep working with p_value and
+	// effect_size defaulted to NaN. A C++17 NSDMI default would also work
+	// under MSVC, but emscripten's libc++ rejects brace-init of an aggregate
+	// with NSDMIs when the brace list is shorter than the field count — the
+	// constructor form is portable across both toolchains.
 	TableOneRow(std::string variable, std::string level, std::string statistic,
 	            std::string stratum, std::string display,
-	            double p_value = std::nan(""))
+	            double p_value = std::nan(""),
+	            double effect_size = std::nan(""))
 	    : variable(std::move(variable)), level(std::move(level)),
 	      statistic(std::move(statistic)), stratum(std::move(stratum)),
-	      display(std::move(display)), p_value(p_value) {
+	      display(std::move(display)), p_value(p_value), effect_size(effect_size) {
 	}
 };
 
@@ -277,9 +283,12 @@ static unique_ptr<FunctionData> TableOneBind(ClientContext &context, TableFuncti
 	// repeated on every row of the same variable so a PIVOT can grab it via
 	// FIRST(p_value). NULL when no `by` is set, when there's only one
 	// stratum, or when the test failed.
-	names = {"variable", "level", "statistic", "stratum", "display", "p_value"};
+	// effect_size is the matching effect-size magnitude (η² for numeric,
+	// Cramér's V for categorical) — same repetition and NULL handling.
+	names = {"variable", "level", "statistic", "stratum", "display", "p_value", "effect_size"};
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
-	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE};
+	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE,
+	                LogicalType::DOUBLE};
 	return std::move(bd);
 }
 
@@ -447,12 +456,18 @@ static void EmitCategoricalRows(Connection &conn, const std::string &table,
 //!
 //! Multi-column `by` is folded into a single grouping string by concatenating
 //! the columns with " / " — same separator used for stratum labels.
-static double ComputeBetweenGroupPValue(Connection &conn, const std::string &table,
-                                        const std::string &var, bool numeric,
-                                        const std::vector<std::string> &by_cols,
-                                        idx_t n_strata) {
+struct BetweenGroupStats {
+	double p_value = std::nan("");
+	double effect_size = std::nan("");
+};
+
+static BetweenGroupStats ComputeBetweenGroupStats(Connection &conn, const std::string &table,
+                                                  const std::string &var, bool numeric,
+                                                  const std::vector<std::string> &by_cols,
+                                                  idx_t n_strata) {
+	BetweenGroupStats stats;
 	if (by_cols.empty() || n_strata < 2) {
-		return std::nan("");
+		return stats;
 	}
 
 	// Build the grouping expression: single column verbatim, multi-column
@@ -475,28 +490,42 @@ static double ComputeBetweenGroupPValue(Connection &conn, const std::string &tab
 		where_clause += " AND " + QuoteIdent(b) + " IS NOT NULL";
 	}
 
+	// One SELECT pulls p_value and effect_size from the same aggregate struct,
+	// so the aggregate runs once per variable rather than twice.
+	//   Numeric: anova_oneway exposes p_value and eta_squared directly.
+	//   Categorical: chisq_independence exposes chi_square, n, n_rows, n_cols;
+	//     Cramér's V is √(χ²/(n · (min(r,c)-1))) computed inline.
 	std::stringstream sql;
 	if (numeric) {
-		sql << "SELECT (anova_oneway(" << QuoteIdent(var) << "::DOUBLE, " << group_expr
-		    << ")).p_value FROM " << QuoteIdent(table) << " WHERE " << where_clause;
+		sql << "SELECT (s).p_value, (s).eta_squared FROM ("
+		    << "SELECT anova_oneway(" << QuoteIdent(var) << "::DOUBLE, " << group_expr << ") AS s "
+		    << "FROM " << QuoteIdent(table) << " WHERE " << where_clause << ")";
 	} else {
-		sql << "SELECT (chisq_independence(" << QuoteIdent(var) << "::VARCHAR, " << group_expr
-		    << ")).p_value FROM " << QuoteIdent(table) << " WHERE " << where_clause;
+		sql << "SELECT (s).p_value, "
+		    << "CASE WHEN (s).n > 0 AND LEAST((s).n_rows, (s).n_cols) > 1 "
+		    << "THEN sqrt((s).chi_square / ((s).n * (LEAST((s).n_rows, (s).n_cols) - 1))) "
+		    << "ELSE NULL END "
+		    << "FROM (SELECT chisq_independence(" << QuoteIdent(var) << "::VARCHAR, " << group_expr
+		    << ") AS s FROM " << QuoteIdent(table) << " WHERE " << where_clause << ")";
 	}
 
 	auto result = conn.Query(sql.str());
 	if (result->HasError()) {
-		return std::nan(""); // test infeasible (e.g. zero variance, sparse 2x2) → NULL
+		return stats; // test infeasible (e.g. zero variance, sparse 2x2) → NULL
 	}
 	auto chunk = result->Fetch();
 	if (!chunk || chunk->size() == 0) {
-		return std::nan("");
+		return stats;
 	}
-	auto v = chunk->GetValue(0, 0);
-	if (v.IsNull()) {
-		return std::nan("");
+	auto p_v = chunk->GetValue(0, 0);
+	if (!p_v.IsNull()) {
+		stats.p_value = p_v.GetValue<double>();
 	}
-	return v.GetValue<double>();
+	auto eff = chunk->GetValue(1, 0);
+	if (!eff.IsNull()) {
+		stats.effect_size = eff.GetValue<double>();
+	}
+	return stats;
 }
 
 // ── InitGlobal: pre-compute every row ──────────────────────────────────────
@@ -591,13 +620,14 @@ static unique_ptr<GlobalTableFunctionState> TableOneInitGlobal(ClientContext &co
 			}
 		}
 
-		// Compute the between-group p-value once per variable, then stamp it
-		// on every row we just emitted for this variable. NaN sentinel →
-		// Execute will SetNull on those cells.
-		double p_value = ComputeBetweenGroupPValue(conn, bd.data_table, var, numeric,
-		                                            bd.by_columns, by_tuples.size());
+		// Compute the between-group p-value and effect size once per variable,
+		// then stamp both on every row we just emitted for this variable. NaN
+		// sentinels → Execute will SetNull on those cells.
+		auto stats = ComputeBetweenGroupStats(conn, bd.data_table, var, numeric,
+		                                       bd.by_columns, by_tuples.size());
 		for (size_t i = first_row; i < state->rows.size(); i++) {
-			state->rows[i].p_value = p_value;
+			state->rows[i].p_value = stats.p_value;
+			state->rows[i].effect_size = stats.effect_size;
 		}
 	};
 
@@ -629,6 +659,11 @@ static void TableOneExecute(ClientContext &context, TableFunctionInput &input, D
 			FlatVector::SetNull(output.data[5], emitted, true);
 		} else {
 			output.SetValue(5, emitted, Value::DOUBLE(row.p_value));
+		}
+		if (std::isnan(row.effect_size)) {
+			FlatVector::SetNull(output.data[6], emitted, true);
+		} else {
+			output.SetValue(6, emitted, Value::DOUBLE(row.effect_size));
 		}
 		emitted++;
 	}

--- a/test/sql/bootstrap.test
+++ b/test/sql/bootstrap.test
@@ -1,0 +1,144 @@
+# name: test/sql/bootstrap.test
+# description: bootstrap(value, statistic, n_iters [, seed]) — with-replacement resampling aggregate
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE t AS SELECT * FROM (VALUES
+    (1.0), (2.0), (3.0), (4.0), (5.0),
+    (6.0), (7.0), (8.0), (9.0), (10.0)
+) AS v(x);
+
+# ─── Shape ──────────────────────────────────────────────────────────────────
+
+# n_iters resamples → LIST length = n_iters.
+query I
+SELECT len(bootstrap(x, 'mean', 100, 42)) FROM t
+----
+100
+
+# All elements are doubles (no NaN/NULL with non-empty input + n ≥ 1 for the
+# stats that need it).
+query I
+SELECT len(list_filter(bootstrap(x, 'mean', 50, 7), v -> v IS NOT NULL)) FROM t
+----
+50
+
+# ─── Statistic correctness on the bootstrap mean ────────────────────────────
+
+# The bootstrap mean of means converges to the sample mean — for n_iters=2000
+# the round-to-1-dp answer is the sample mean exactly.
+query R
+SELECT round(list_aggregate(bootstrap(x, 'mean', 2000, 1), 'avg'), 1) FROM t
+----
+5.5
+
+# Average bootstrap median ≈ sample median. Discrete sample of {1..10} means
+# the bootstrap median lands on a small set of values.
+query R
+SELECT round(list_aggregate(bootstrap(x, 'median', 2000, 2), 'avg'), 1) FROM t
+----
+5.5
+
+# Bootstrap sum has expectation = sample sum (each resample sums n values
+# drawn with replacement from {1..10}, so mean(sum) = n · mean(x) = 55).
+query R
+SELECT round(list_aggregate(bootstrap(x, 'sum', 2000, 3), 'avg'), 0) FROM t
+----
+55
+
+# ─── Determinism with seed ──────────────────────────────────────────────────
+
+# Same seed → identical LIST<DOUBLE>.
+query I
+SELECT bootstrap(x, 'mean', 10, 99) = bootstrap(x, 'mean', 10, 99) FROM t
+----
+true
+
+# Different seed → different LIST<DOUBLE> with overwhelming probability.
+query I
+SELECT bootstrap(x, 'mean', 10, 1) <> bootstrap(x, 'mean', 10, 2) FROM t
+----
+true
+
+# ─── GROUP BY semantics ─────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE grouped AS SELECT * FROM (VALUES
+    ('a', 1.0), ('a', 2.0), ('a', 3.0),
+    ('b', 10.0), ('b', 20.0), ('b', 30.0)
+) AS t(g, x);
+
+# Each group produces its own bootstrap distribution; n_iters rows per group.
+query TI
+SELECT g, len(bootstrap(x, 'mean', 50, 42)) FROM grouped GROUP BY g ORDER BY g
+----
+a	50
+b	50
+
+# Per-group means: group 'a' centres on 2, group 'b' centres on 20.
+query TR
+SELECT g, round(list_aggregate(bootstrap(x, 'mean', 1000, 42), 'avg'), 0)
+FROM grouped GROUP BY g ORDER BY g
+----
+a	2
+b	20
+
+# ─── Stddev / variance ──────────────────────────────────────────────────────
+
+# Bootstrap stddev produces a list of n_iters non-negative doubles.
+query I
+SELECT len(list_filter(bootstrap(x, 'stddev', 100, 5), v -> v >= 0)) FROM t
+----
+100
+
+# 'sd' is an alias for 'stddev'; 'var' for 'variance'. Same seed → identical
+# output as the long name.
+query I
+SELECT bootstrap(x, 'stddev', 20, 11) = bootstrap(x, 'sd', 20, 11) FROM t
+----
+true
+
+query I
+SELECT bootstrap(x, 'variance', 20, 11) = bootstrap(x, 'var', 20, 11) FROM t
+----
+true
+
+# ─── Edge cases / errors ────────────────────────────────────────────────────
+
+# Empty input → NULL list.
+query I
+SELECT bootstrap(x, 'mean', 100, 1) IS NULL FROM (SELECT 1.0 AS x WHERE FALSE) t
+----
+true
+
+# NULLs in the input are skipped (consistent with buffer-aggregate convention).
+query I
+SELECT len(bootstrap(x, 'mean', 50, 1))
+FROM (VALUES (1.0), (NULL), (3.0), (NULL), (5.0)) AS t(x)
+----
+50
+
+# Unknown statistic → bind error.
+statement error
+SELECT bootstrap(x, 'mode', 100) FROM t
+----
+unknown statistic 'mode'
+
+# Non-constant statistic → bind error (must be foldable).
+statement error
+SELECT bootstrap(x, CASE WHEN random() < 0.5 THEN 'mean' ELSE 'median' END, 100) FROM t
+----
+'statistic' must be a constant string
+
+# n_iters must be > 0.
+statement error
+SELECT bootstrap(x, 'mean', 0) FROM t
+----
+'n_iters' must be > 0
+
+statement error
+SELECT bootstrap(x, 'mean', -5) FROM t
+----
+'n_iters' must be > 0

--- a/test/sql/distributions_nbinom_hyper.test
+++ b/test/sql/distributions_nbinom_hyper.test
@@ -1,0 +1,193 @@
+# name: test/sql/distributions_nbinom_hyper.test
+# description: Negative binomial and hypergeometric d/p/q/r functions
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Negative Binomial ──────────────────────────────────────────────────────
+#
+# Parameterization (matches R's dnbinom(x, size, prob)):
+#   size = target number of successes, prob = per-trial success probability.
+#   PMF: P(X = k) = C(k+size-1, k) · prob^size · (1-prob)^k
+#   Cross-checks below derived by hand from the binomial coefficient form.
+
+# Hand check: P(X=0; size=5, prob=0.4) = 0.4^5 = 0.01024
+query R
+SELECT round(dnbinom(0.0, 5.0, 0.4), 5)
+----
+0.01024
+
+# Hand check: P(X=3; size=5, prob=0.4) = C(7,4) · 0.4^5 · 0.6^3
+#                                      = 35 · 0.01024 · 0.216 = 0.077414
+query R
+SELECT round(dnbinom(3.0, 5.0, 0.4), 6)
+----
+0.077414
+
+# CDF via the regularized incomplete beta identity. Verified by direct
+# summation: ΣP(X=k; k=0..3) = 0.01024 + 0.03072 + 0.055296 + 0.077414 = 0.17367
+query R
+SELECT round(pnbinom(3.0, 5.0, 0.4), 5)
+----
+0.17367
+
+# PMF sums to 1 over a sufficiently large support.
+query R
+SELECT round((SELECT sum(dnbinom(k::DOUBLE, 5.0, 0.4)) FROM range(0, 100) t(k)), 6)
+----
+1
+
+# CDF is monotone and approaches 1.
+query R
+SELECT round(pnbinom(200.0, 5.0, 0.4), 6)
+----
+1
+
+# Quantile: smallest k with P(X ≤ k) ≥ p. Median for NB(5, 0.4).
+# Cumulative grid: k=6 → 0.467, k=7 → 0.562. So qnbinom(0.5, 5, 0.4) = 7.
+query R
+SELECT qnbinom(0.5, 5.0, 0.4)
+----
+7
+
+# Quantile / CDF round-trip — first k where cdf >= p.
+query I
+SELECT pnbinom(qnbinom(0.7, 8.0, 0.3), 8.0, 0.3) >= 0.7
+----
+true
+
+# Boundaries.
+query RR
+SELECT qnbinom(0.0, 5.0, 0.4), qnbinom(1.0, 5.0, 0.4)
+----
+0	inf
+
+# Non-integer k → PMF returns 0 (matches R's warn-and-zero).
+query R
+SELECT dnbinom(1.5, 5.0, 0.4)
+----
+0
+
+# Invalid params → NULL.
+query R
+SELECT dnbinom(3.0, 0.0, 0.4)
+----
+NULL
+
+query R
+SELECT dnbinom(3.0, 5.0, 0.0)
+----
+NULL
+
+query R
+SELECT dnbinom(3.0, 5.0, 1.5)
+----
+NULL
+
+# ─── Hypergeometric ─────────────────────────────────────────────────────────
+#
+# Parameterization (matches R's dhyper(x, m, n, k)):
+#   m = total "successes" in population, n = total "failures",
+#   k = number drawn (without replacement), x = observed successes.
+#   PMF: P(X = x) = C(m, x) · C(n, k - x) / C(m + n, k)
+#   on support max(0, k-n) ≤ x ≤ min(m, k).
+#   Cross-checks below from direct computation.
+
+# Hand check: P(X=3; m=10, n=15, k=8) = C(10,3) · C(15,5) / C(25,8)
+#                                     = 120 · 3003 / 1081575 = 0.333181
+query R
+SELECT round(dhyper(3.0, 10.0, 15.0, 8.0), 6)
+----
+0.333181
+
+# Boundary: P(X=0; m=10, n=15, k=8) = C(15,8) / C(25,8)
+#                                   = 6435 / 1081575 = 0.005949
+query R
+SELECT round(dhyper(0.0, 10.0, 15.0, 8.0), 6)
+----
+0.005949
+
+# Outside the support — PMF is 0. Cannot draw 9 successes when only 8 drawn.
+query R
+SELECT dhyper(9.0, 10.0, 15.0, 8.0)
+----
+0
+
+# Cannot draw more failures than exist either — at min support floor.
+query R
+SELECT dhyper(-1.0, 10.0, 15.0, 8.0)
+----
+0
+
+# CDF — direct summation of PMF on [0, 3].
+query R
+SELECT round(phyper(3.0, 10.0, 15.0, 8.0), 6)
+----
+0.606865
+
+# PMF sums to 1 over support [max(0, k-n), min(m, k)] = [0, 8] for this case.
+query R
+SELECT round((SELECT sum(dhyper(x::DOUBLE, 10.0, 15.0, 8.0)) FROM range(0, 9) t(x)), 6)
+----
+1
+
+# CDF saturates at 1 above the support max.
+query R
+SELECT phyper(10.0, 10.0, 15.0, 8.0)
+----
+1
+
+# Quantile: median draws ≈ k·m/(m+n) = 8·10/25 = 3.2. Median is the smallest
+# integer with CDF ≥ 0.5, which is 3 (cdf at 3 = 0.607 ≥ 0.5).
+query R
+SELECT qhyper(0.5, 10.0, 15.0, 8.0)
+----
+3
+
+# Quantile / CDF round-trip.
+query I
+SELECT phyper(qhyper(0.9, 10.0, 15.0, 8.0), 10.0, 15.0, 8.0) >= 0.9
+----
+true
+
+# k larger than the population is rejected.
+query R
+SELECT dhyper(0.0, 10.0, 15.0, 30.0)
+----
+NULL
+
+# Negative parameters rejected.
+query R
+SELECT dhyper(0.0, -1.0, 15.0, 5.0)
+----
+NULL
+
+# ─── Random sampling (r* coverage check) ───────────────────────────────────
+
+# rnbinom mean converges to size·(1-prob)/prob = 5·0.6/0.4 = 7.5.
+query R
+SELECT round(avg(rnbinom(5.0, 0.4)), 1) FROM range(50000)
+----
+7.5
+
+# rnbinom is integer-valued.
+query I
+SELECT sum(CASE WHEN v <> floor(v) THEN 1 ELSE 0 END)
+FROM (SELECT rnbinom(5.0, 0.4) AS v FROM range(50000))
+----
+0
+
+# rhyper mean converges to k·m/(m+n) = 8·10/25 = 3.2.
+query R
+SELECT round(avg(rhyper(10.0, 15.0, 8.0)), 1) FROM range(50000)
+----
+3.2
+
+# rhyper output lies in the support [max(0, k-n), min(m, k)] = [0, 8].
+query II
+SELECT
+    sum(CASE WHEN v < 0 OR v > 8 THEN 1 ELSE 0 END) AS out_of_support,
+    count(*) AS total
+FROM (SELECT rhyper(10.0, 15.0, 8.0) AS v FROM range(50000))
+----
+0	50000

--- a/test/sql/distributions_nbinom_hyper.test
+++ b/test/sql/distributions_nbinom_hyper.test
@@ -165,10 +165,10 @@ NULL
 # ─── Random sampling (r* coverage check) ───────────────────────────────────
 
 # rnbinom mean converges to size·(1-prob)/prob = 5·0.6/0.4 = 7.5.
-query R
-SELECT round(avg(rnbinom(5.0, 0.4)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rnbinom(5.0, 0.4)) - 7.5) < 0.2 FROM range(50000)
 ----
-7.5
+true
 
 # rnbinom is integer-valued.
 query I
@@ -178,10 +178,10 @@ FROM (SELECT rnbinom(5.0, 0.4) AS v FROM range(50000))
 0
 
 # rhyper mean converges to k·m/(m+n) = 8·10/25 = 3.2.
-query R
-SELECT round(avg(rhyper(10.0, 15.0, 8.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rhyper(10.0, 15.0, 8.0)) - 3.2) < 0.15 FROM range(50000)
 ----
-3.2
+true
 
 # rhyper output lies in the support [max(0, k-n), min(m, k)] = [0, 8].
 query II

--- a/test/sql/distributions_weibull_lnorm_poisson.test
+++ b/test/sql/distributions_weibull_lnorm_poisson.test
@@ -1,0 +1,184 @@
+# name: test/sql/distributions_weibull_lnorm_poisson.test
+# description: Weibull, log-normal, and Poisson d/p/q functions
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Weibull ────────────────────────────────────────────────────────────────
+
+# R: dweibull(1.5, shape=2, scale=1) = 2 * 1.5 * exp(-2.25) ≈ 0.31620
+query R
+SELECT round(dweibull(1.5, 2.0, 1.0), 5)
+----
+0.3162
+
+# Default scale = 1 — single-arg shape form matches the 2-arg form.
+query R
+SELECT round(dweibull(1.5, 2.0) - dweibull(1.5, 2.0, 1.0), 10)
+----
+0
+
+# CDF at the scale parameter equals 1 - 1/e regardless of shape.
+query R
+SELECT round(pweibull(1.0, 2.5, 1.0), 6)
+----
+0.632121
+
+# R: pweibull(0.5, shape=3, scale=2) = 0.01550385
+query R
+SELECT round(pweibull(0.5, 3.0, 2.0), 6)
+----
+0.015504
+
+# Quantile/CDF round-trip.
+query R
+SELECT round(qweibull(pweibull(2.5, 1.5, 3.0), 1.5, 3.0), 6)
+----
+2.5
+
+# Boundary: p = 0 → 0; p = 1 → +inf.
+query RR
+SELECT qweibull(0.0, 2.0, 1.0), qweibull(1.0, 2.0, 1.0)
+----
+0	inf
+
+# Shape = 1 reduces to Exponential(1/scale).
+query R
+SELECT round(pweibull(2.0, 1.0, 3.0) - pexp(2.0, 1.0 / 3.0), 10)
+----
+0
+
+# x < 0 → PDF/CDF return 0.
+query RR
+SELECT dweibull(-1.0, 2.0, 1.0), pweibull(-1.0, 2.0, 1.0)
+----
+0	0
+
+# Invalid shape / scale → NULL.
+query R
+SELECT dweibull(1.0, 0.0, 1.0)
+----
+NULL
+
+query R
+SELECT pweibull(1.0, 2.0, -1.0)
+----
+NULL
+
+# ─── Log-normal ─────────────────────────────────────────────────────────────
+
+# R: dlnorm(1) = 0.3989423 (= standard normal at log(1)=0, divided by 1).
+query R
+SELECT round(dlnorm(1.0), 6)
+----
+0.398942
+
+# R: dlnorm(2, meanlog=0, sdlog=1) = 0.156874
+query R
+SELECT round(dlnorm(2.0, 0.0, 1.0), 6)
+----
+0.156874
+
+# Default meanlog=0, sdlog=1 form matches the 3-arg form.
+query R
+SELECT round(dlnorm(2.0) - dlnorm(2.0, 0.0, 1.0), 10)
+----
+0
+
+# R: plnorm(2) = 0.7558914
+query R
+SELECT round(plnorm(2.0), 6)
+----
+0.755891
+
+# Median of log-normal(meanlog, sdlog) = exp(meanlog), so plnorm(exp(μ), μ, σ) = 0.5.
+query R
+SELECT round(plnorm(exp(0.7), 0.7, 1.3), 6)
+----
+0.5
+
+# Quantile/CDF round-trip.
+query R
+SELECT round(qlnorm(plnorm(3.5, 0.5, 0.8), 0.5, 0.8), 6)
+----
+3.5
+
+# x ≤ 0 → PDF/CDF return 0.
+query RR
+SELECT dlnorm(0.0), plnorm(-1.0)
+----
+0	0
+
+# Invalid sdlog → NULL.
+query R
+SELECT dlnorm(1.0, 0.0, 0.0)
+----
+NULL
+
+# ─── Poisson ────────────────────────────────────────────────────────────────
+
+# R: dpois(0, lambda=2) = 0.1353353
+query R
+SELECT round(dpois(0.0, 2.0), 6)
+----
+0.135335
+
+# R: dpois(3, lambda=2.5) = 0.2137504
+query R
+SELECT round(dpois(3.0, 2.5), 6)
+----
+0.21375
+
+# PMF sums to (≈) 1 over a large support.
+query R
+SELECT round((SELECT sum(dpois(k::DOUBLE, 4.0)) FROM range(0, 30) t(k)), 6)
+----
+1
+
+# R: ppois(2, lambda=2.5) = 0.5438131
+query R
+SELECT round(ppois(2.0, 2.5), 6)
+----
+0.543813
+
+# CDF is monotone increasing and bounded by 1.
+query R
+SELECT round(ppois(20.0, 4.0), 6)
+----
+1
+
+# Quantile: smallest k with ppois(k, λ) ≥ p. R: qpois(0.5, 4) = 4.
+query R
+SELECT qpois(0.5, 4.0)
+----
+4
+
+# R: qpois(0.95, 10) = 15
+query R
+SELECT qpois(0.95, 10.0)
+----
+15
+
+# Boundary: p = 0 → 0.
+query R
+SELECT qpois(0.0, 5.0)
+----
+0
+
+# k < 0 → 0 for both PMF and CDF.
+query RR
+SELECT dpois(-1.0, 2.0), ppois(-1.0, 2.0)
+----
+0	0
+
+# Non-integer k → PMF is 0 (matches R's warning-and-zero behaviour).
+query R
+SELECT dpois(1.5, 2.0)
+----
+0
+
+# Invalid lambda → NULL.
+query R
+SELECT dpois(0.0, 0.0)
+----
+NULL

--- a/test/sql/ggsql_mark_registry.test
+++ b/test/sql/ggsql_mark_registry.test
@@ -44,6 +44,7 @@ ggsql_mark_v1_regression
 ggsql_mark_v1_rule
 ggsql_mark_v1_text
 ggsql_mark_v1_tick
+ggsql_mark_v1_violin
 
 # Unknown mark — registry lookup fails cleanly.
 statement ok

--- a/test/sql/ggsql_visualize_facet_2d.test
+++ b/test/sql/ggsql_visualize_facet_2d.test
@@ -1,0 +1,83 @@
+# name: test/sql/ggsql_visualize_facet_2d.test
+# description: ggsql `FACET BY <row>, <col>` — 2D row × column grid
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE penguins AS SELECT * FROM (VALUES
+    (39.1, 18.7, 'Adelie',  'female'),
+    (39.5, 17.4, 'Adelie',  'male'),
+    (44.0, 18.0, 'Gentoo',  'female'),
+    (45.2, 17.9, 'Gentoo',  'male'),
+    (48.1, 16.3, 'Chinstrap','female'),
+    (49.3, 15.7, 'Chinstrap','male')
+) AS t(bill_len, bill_dep, species, sex);
+
+# Single-layer 2D facet: facet operator carries both row and column sub-channels.
+# The projected SQL exposes both `facet` and `facet2` as columns.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species, sex
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"row":{"field":"facet","type":"nominal"},"column":{"field":"facet2","type":"nominal"}},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet, sex AS facet2 FROM penguins'}
+
+# Bar mark in 2D facet — GROUP BY extends to (x, facet, facet2).
+query TT
+VISUALIZE species AS x, bill_dep AS y FROM penguins DRAW bar FACET BY species, sex
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"row":{"field":"facet","type":"nominal"},"column":{"field":"facet2","type":"nominal"}},"spec":{"mark":"bar","encoding":{"x":{"field":"x","type":"ordinal"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT x, facet, facet2, SUM(y) AS y FROM (SELECT species AS x, bill_dep AS y, species AS facet, sex AS facet2 FROM penguins) GROUP BY x, facet, facet2 ORDER BY x'}
+
+# Multi-layer 2D facet: layer:[...] sits inside the facet's `spec`.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point DRAW line FACET BY species, sex
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","facet":{"row":{"field":"facet","type":"nominal"},"column":{"field":"facet2","type":"nominal"}},"spec":{"layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet, sex AS facet2 FROM penguins', layer_1='SELECT * FROM (SELECT bill_len AS x, bill_dep AS y, species AS facet, sex AS facet2 FROM penguins) ORDER BY x'}
+
+# 2D facet composes with SCALE on a regular channel.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y, species AS color FROM penguins DRAW point FACET BY species, sex SCALE color TO viridis
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"row":{"field":"facet","type":"nominal"},"column":{"field":"facet2","type":"nominal"}},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal","scale":{"scheme":"viridis"}}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS color, species AS facet, sex AS facet2 FROM penguins'}
+
+# 2D facet composes with TITLE.
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species, sex TITLE 'Bill morphology'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"row":{"field":"facet","type":"nominal"},"column":{"field":"facet2","type":"nominal"}},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},"title":{"text":"Bill morphology"}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, species AS facet, sex AS facet2 FROM penguins'}
+
+# Paren-wrapped expressions are valid (tokenizer preserves them).
+query TT
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY coalesce(species, 'NA'), sex
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"row":{"field":"facet","type":"nominal"},"column":{"field":"facet2","type":"nominal"}},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y, coalesce(species, \'NA\') AS facet, sex AS facet2 FROM penguins'}
+
+# ── Error cases ─────────────────────────────────────────────────────────────
+
+# Missing column expression after the comma.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species,
+----
+Expected column expression after 'FACET BY <row>,'
+
+# Three expressions — over the row × column limit.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species, sex, bill_dep
+----
+FACET BY accepts at most two expressions (row, column)
+
+# ROWS/COLS modifier is rejected in the 2D form (layout is fixed).
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species, sex ROWS
+----
+FACET BY <row>, <col> does not accept ROWS/COLS
+
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY species, sex COLS
+----
+FACET BY <row>, <col> does not accept ROWS/COLS
+
+# Leading comma — no row expression.
+statement error
+VISUALIZE bill_len AS x, bill_dep AS y FROM penguins DRAW point FACET BY , sex
+----
+Expected expression after 'FACET BY'

--- a/test/sql/ggsql_visualize_stat.test
+++ b/test/sql/ggsql_visualize_stat.test
@@ -1,0 +1,99 @@
+# name: test/sql/ggsql_visualize_stat.test
+# description: ggsql per-layer `STAT smooth|summary|identity` modifier
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE samples AS SELECT * FROM (VALUES
+    (1.0, 2.1, 'a'), (2.0, 3.9, 'a'), (3.0, 6.2, 'a'),
+    (1.0, 1.8, 'b'), (2.0, 4.1, 'b'), (3.0, 5.8, 'b'),
+    (1.0, 2.0, 'a'), (2.0, 4.0, 'b'), (3.0, 6.0, 'a')
+) AS t(xv, yv, grp);
+
+# STAT identity is the explicit no-op — spec is byte-identical to the
+# bare DRAW point form.
+query TT
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point STAT identity
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT xv AS x, yv AS y FROM samples'}
+
+# STAT smooth injects a Vega-Lite loess transform on (x, y).
+query TT
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point STAT smooth
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"loess":"y","on":"x"}],"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT xv AS x, yv AS y FROM samples'}
+
+# STAT smooth on a `line` mark — loess transform applied; data_sql keeps
+# its ORDER BY x (line's stock behaviour).
+query TT
+VISUALIZE xv AS x, yv AS y FROM samples DRAW line STAT smooth
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"loess":"y","on":"x"}],"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT * FROM (SELECT xv AS x, yv AS y FROM samples) ORDER BY x'}
+
+# STAT smooth with a mapped color → loess transform groups by color so
+# each category gets its own smoothed curve.
+query TT
+VISUALIZE xv AS x, yv AS y, grp AS color FROM samples DRAW point STAT smooth
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"loess":"y","on":"x","groupby":["color"]}],"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT xv AS x, yv AS y, grp AS color FROM samples'}
+
+# STAT summary rewrites data_sql to AVG(y) GROUP BY x ORDER BY x.
+# Spec stays as the bare mark (transform happens in SQL).
+query TT
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point STAT summary
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT x, AVG(y) AS y FROM (SELECT xv AS x, yv AS y FROM samples) GROUP BY x ORDER BY x'}
+
+# STAT summary extends the GROUP BY when color is mapped — one mean per
+# (x, color) cell.
+query TT
+VISUALIZE xv AS x, yv AS y, grp AS color FROM samples DRAW line STAT summary
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT x, color, AVG(y) AS y FROM (SELECT xv AS x, yv AS y, grp AS color FROM samples) GROUP BY x, color ORDER BY x'}
+
+# STAT summary with FACET BY — group includes facet so each facet cell
+# computes its own mean per x.
+query TT
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point STAT summary FACET BY grp
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"facet":{"field":"facet","type":"nominal"},"spec":{"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}}	{layer_0='SELECT x, facet, AVG(y) AS y FROM (SELECT xv AS x, yv AS y, grp AS facet FROM samples) GROUP BY x, facet ORDER BY x'}
+
+# Multi-layer composition: raw points + smoothed overlay in one VISUALIZE.
+query TT
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point DRAW line STAT smooth
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","layer":[{"data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}},{"data":{"name":"layer_1"},"transform":[{"loess":"y","on":"x"}],"mark":"line","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}]}	{layer_0='SELECT xv AS x, yv AS y FROM samples', layer_1='SELECT * FROM (SELECT xv AS x, yv AS y FROM samples) ORDER BY x'}
+
+# ── Error cases ─────────────────────────────────────────────────────────────
+
+# Unknown stat name — parser rejects.
+statement error
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point STAT loess
+----
+Unknown stat 'loess'
+
+# STAT without a name.
+statement error
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point STAT
+----
+Expected stat name after 'STAT'
+
+# STAT smooth on a mark that already emits its own transform (regression,
+# density, violin, histogram) is rejected — two `transform:` keys would
+# produce invalid Vega-Lite.
+statement error
+VISUALIZE xv AS x, yv AS y FROM samples DRAW regression STAT smooth
+----
+STAT smooth is not allowed on 'regression'
+
+statement error
+VISUALIZE xv AS x FROM samples DRAW density STAT smooth
+----
+STAT smooth is not allowed on 'density'
+
+# STAT is case-insensitive (keyword) and the stat name normalises to lower.
+query TT
+VISUALIZE xv AS x, yv AS y FROM samples DRAW point stat SMOOTH
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"loess":"y","on":"x"}],"mark":"point","encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT xv AS x, yv AS y FROM samples'}

--- a/test/sql/ggsql_visualize_violin.test
+++ b/test/sql/ggsql_visualize_violin.test
@@ -1,0 +1,42 @@
+# name: test/sql/ggsql_visualize_violin.test
+# description: ggsql `violin` mark — per-category density via vega-lite column facet
+# group: [stats_duck]
+
+require stats_duck
+
+statement ok
+CREATE TABLE samples AS SELECT * FROM (VALUES
+    ('a', 1.0), ('a', 2.0), ('a', 3.0), ('a', 4.0), ('a', 5.0),
+    ('b', 2.0), ('b', 3.0), ('b', 4.0), ('b', 5.0), ('b', 6.0),
+    ('c', 3.0), ('c', 4.0), ('c', 5.0), ('c', 6.0), ('c', 7.0)
+) AS t(group_id, value);
+
+# Minimal violin: density groupby x, area mark, column-facet on x.
+query TT
+VISUALIZE group_id AS x, value AS y FROM samples DRAW violin
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
+
+# Optional channels (color, opacity, ...) propagate through BuildOptionalChannels.
+query TT
+VISUALIZE group_id AS x, value AS y, group_id AS color FROM samples DRAW violin
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y, group_id AS color FROM samples'}
+
+# Introspection: required_aesthetics = [x, y].
+query T
+SELECT ggsql_mark_v1_violin()
+----
+{"name":"violin","required_aesthetics":["x","y"]}
+
+# Composes with TITLE / SUBTITLE — the title block is appended after the encoding.
+query TT
+VISUALIZE group_id AS x, value AS y FROM samples DRAW violin TITLE 'Distribution by group'
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}},"title":{"text":"Distribution by group"}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
+
+# Composes with WITH ... VISUALIZE.
+query TT
+WITH s AS (SELECT group_id, value FROM samples WHERE value < 6) VISUALIZE group_id AS x, value AS y FROM s DRAW violin
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='WITH s AS (SELECT group_id, value FROM samples WHERE value < 6) SELECT group_id AS x, value AS y FROM s'}

--- a/test/sql/ggsql_visualize_violin.test
+++ b/test/sql/ggsql_visualize_violin.test
@@ -15,13 +15,13 @@ CREATE TABLE samples AS SELECT * FROM (VALUES
 query TT
 VISUALIZE group_id AS x, value AS y FROM samples DRAW violin
 ----
-{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
 
 # Optional channels (color, opacity, ...) propagate through BuildOptionalChannels.
 query TT
 VISUALIZE group_id AS x, value AS y, group_id AS color FROM samples DRAW violin
 ----
-{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y, group_id AS color FROM samples'}
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"},"color":{"field":"color","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y, group_id AS color FROM samples'}
 
 # Introspection: required_aesthetics = [x, y].
 query T
@@ -33,10 +33,10 @@ SELECT ggsql_mark_v1_violin()
 query TT
 VISUALIZE group_id AS x, value AS y FROM samples DRAW violin TITLE 'Distribution by group'
 ----
-{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}},"title":{"text":"Distribution by group"}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}},"title":{"text":"Distribution by group"}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
 
 # Composes with WITH ... VISUALIZE.
 query TT
 WITH s AS (SELECT group_id, value FROM samples WHERE value < 6) VISUALIZE group_id AS x, value AS y FROM s DRAW violin
 ----
-{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":"area","encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='WITH s AS (SELECT group_id, value FROM samples WHERE value < 6) SELECT group_id AS x, value AS y FROM s'}
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='WITH s AS (SELECT group_id, value FROM samples WHERE value < 6) SELECT group_id AS x, value AS y FROM s'}

--- a/test/sql/lm.test
+++ b/test/sql/lm.test
@@ -196,3 +196,163 @@ statement error
 SELECT * FROM lm('too_small', y := 'y', x := ['x1'])
 ----
 not enough complete-case rows
+
+# ── R-style formula DSL ───────────────────────────────────────────────────
+#
+# `formula := '<lhs> ~ <rhs>'` is an alternative to `y := ...` / `x := [...]`.
+# Supports `+` to add predictors and `- 1` / `+ 0` to drop the intercept.
+# Whitespace is ignored; column names accept the SQL `"..."` quoted form.
+
+# Formula and explicit form fit the same model — coefficients must match.
+query RR
+SELECT round((SELECT estimate FROM lm('mtcars', formula := 'mpg ~ wt + hp')
+              WHERE term = 'wt'), 5),
+       round((SELECT estimate FROM lm('mtcars', y := 'mpg', x := ['wt', 'hp'])
+              WHERE term = 'wt'), 5)
+----
+-3.87783	-3.87783
+
+# Term order follows the formula left-to-right.
+query T
+SELECT term FROM lm('mtcars', formula := 'mpg ~ hp + wt')
+----
+(Intercept)
+hp
+wt
+
+# Whitespace tolerance — these all parse to the same model.
+query I
+SELECT count(*) = 3 FROM lm('mtcars', formula := 'mpg~wt+hp')
+----
+true
+
+query I
+SELECT count(*) = 3 FROM lm('mtcars', formula := '   mpg   ~   wt   +   hp   ')
+----
+true
+
+# Quoted identifiers (matters for column names with reserved/uncommon chars).
+statement ok
+CREATE TABLE "weird names"("My Y" DOUBLE, "x.with.dots" DOUBLE);
+
+statement ok
+INSERT INTO "weird names" VALUES (1, 1), (2, 2.1), (3, 2.9), (4, 4.1), (5, 5.0);
+
+query T
+SELECT term FROM lm('weird names', formula := '"My Y" ~ "x.with.dots"')
+----
+(Intercept)
+x.with.dots
+
+# Intercept removal: `mpg ~ wt + hp - 1` and `mpg ~ wt + hp + 0` produce
+# identical fits, both without an intercept term.
+query I
+SELECT count(*) FROM lm('mtcars', formula := 'mpg ~ wt + hp - 1')
+----
+2
+
+query I
+SELECT count(*) FROM lm('mtcars', formula := 'mpg ~ wt + hp + 0')
+----
+2
+
+# No "(Intercept)" row in the output when the intercept is dropped.
+query I
+SELECT count(*) FROM lm('mtcars', formula := 'mpg ~ wt + hp - 1')
+WHERE term = '(Intercept)'
+----
+0
+
+# Synthetic noiseless case: y = 2·x. With intercept the fit is β₀=0, β₁=2;
+# without intercept the slope is still exactly 2.
+statement ok
+CREATE TABLE noiseless AS SELECT i::DOUBLE AS x, 2.0 * i::DOUBLE AS y
+FROM range(1, 21) t(i);
+
+query R
+SELECT round(estimate, 6) FROM lm('noiseless', formula := 'y ~ x - 1')
+WHERE term = 'x'
+----
+2
+
+query R
+SELECT round(estimate, 6) FROM lm('noiseless', formula := 'y ~ x')
+WHERE term = 'x'
+----
+2
+
+query R
+SELECT round(estimate, 6) FROM lm('noiseless', formula := 'y ~ x')
+WHERE term = '(Intercept)'
+----
+0
+
+# df_residual is n - p when there's no intercept (vs. n - p - 1 with).
+query I
+SELECT df_residual FROM lm_summary('noiseless', formula := 'y ~ x')
+----
+18
+
+query I
+SELECT df_residual FROM lm_summary('noiseless', formula := 'y ~ x - 1')
+----
+19
+
+# `+ 0` and `- 1` are interchangeable: same fit either way.
+query R
+SELECT round(
+    (SELECT estimate FROM lm('mtcars', formula := 'mpg ~ wt - 1') WHERE term = 'wt') -
+    (SELECT estimate FROM lm('mtcars', formula := 'mpg ~ wt + 0') WHERE term = 'wt'),
+    10)
+----
+0
+
+# ── Formula parse errors ──────────────────────────────────────────────────
+
+# Conflict: formula + (y or x).
+statement error
+SELECT * FROM lm('mtcars', formula := 'mpg ~ wt', y := 'mpg', x := ['wt'])
+----
+cannot specify 'formula' together with 'y' or 'x'
+
+# Missing `~`.
+statement error
+SELECT * FROM lm('mtcars', formula := 'mpg wt + hp')
+----
+expected '~' after response column
+
+# Missing predictors.
+statement error
+SELECT * FROM lm('mtcars', formula := 'mpg ~')
+----
+expected at least one term after '~'
+
+# Intercept-only model not supported in v0.6.
+statement error
+SELECT * FROM lm('mtcars', formula := 'mpg ~ 1')
+----
+at least one predictor is required
+
+# Duplicate predictor.
+statement error
+SELECT * FROM lm('mtcars', formula := 'mpg ~ wt + wt')
+----
+duplicate predictor 'wt'
+
+# Subtracting a non-intercept term is rejected.
+statement error
+SELECT * FROM lm('mtcars', formula := 'mpg ~ wt - hp')
+----
+subtracting a predictor
+
+# Non-integer constants on the RHS.
+statement error
+SELECT * FROM lm('mtcars', formula := 'mpg ~ wt + 42')
+----
+only '0' / '1' are valid
+
+# Unterminated quoted identifier.
+statement error
+SELECT * FROM lm('weird names', formula := '"My Y" ~ "x.with.dots')
+----
+unterminated quoted identifier

--- a/test/sql/lm.test
+++ b/test/sql/lm.test
@@ -1,0 +1,198 @@
+# name: test/sql/lm.test
+# description: lm() / lm_summary() OLS linear regression via Cholesky on X'X
+# group: [stats_duck]
+
+require stats_duck
+
+# ── R's built-in cars (50 rows, simple regression) ─────────────────────────
+
+statement ok
+CREATE TABLE cars(speed DOUBLE, dist DOUBLE);
+
+statement ok
+INSERT INTO cars VALUES
+  (4, 2), (4, 10), (7, 4), (7, 22), (8, 16), (9, 10), (10, 18), (10, 26),
+  (10, 34), (11, 17), (11, 28), (12, 14), (12, 20), (12, 24), (12, 28),
+  (13, 26), (13, 34), (13, 34), (13, 46), (14, 26), (14, 36), (14, 60),
+  (14, 80), (15, 20), (15, 26), (15, 54), (16, 32), (16, 40), (17, 32),
+  (17, 40), (17, 50), (18, 42), (18, 56), (18, 76), (18, 84), (19, 36),
+  (19, 46), (19, 68), (20, 32), (20, 48), (20, 52), (20, 56), (20, 64),
+  (22, 66), (23, 54), (24, 70), (24, 92), (24, 93), (24, 120), (25, 85);
+
+# Output schema: 5 columns (term, estimate, std_error, t_statistic, p_value).
+# Coefficients match R's lm(dist ~ speed, cars) to 4 decimals.
+query TRRRR
+SELECT term,
+       round(estimate, 4),
+       round(std_error, 4),
+       round(t_statistic, 3),
+       round(p_value, 7)
+FROM lm('cars', y := 'dist', x := ['speed'])
+ORDER BY term
+----
+(Intercept)	-17.5791	6.7584	-2.601	0.0123188
+speed	3.9324	0.4155	9.464	0.0
+
+# Slope p-value is so small (1.5e-12) that rounding to 7 decimals gives 0.
+# Verify the raw value is in the right neighborhood independently.
+query R
+SELECT round(-log10(p_value), 1) FROM lm('cars', y := 'dist', x := ['speed'])
+WHERE term = 'speed'
+----
+11.8
+
+# lm_summary: R² 0.6511, adj R² 0.6438, F 89.57, σ 15.38, df_model 1,
+# df_residual 48, n 50.
+query RRRRIIRI
+SELECT round(r_squared, 4),
+       round(adj_r_squared, 4),
+       round(f_statistic, 2),
+       round(-log10(f_p_value), 1),
+       df_model,
+       df_residual,
+       round(sigma, 2),
+       n
+FROM lm_summary('cars', y := 'dist', x := ['speed'])
+----
+0.6511	0.6438	89.57	11.8	1	48	15.38	50
+
+# ── mtcars subset (32 rows, two predictors) ────────────────────────────────
+
+statement ok
+CREATE TABLE mtcars(mpg DOUBLE, wt DOUBLE, hp DOUBLE);
+
+statement ok
+INSERT INTO mtcars VALUES
+  (21.0, 2.620, 110), (21.0, 2.875, 110), (22.8, 2.320, 93), (21.4, 3.215, 110),
+  (18.7, 3.440, 175), (18.1, 3.460, 105), (14.3, 3.570, 245), (24.4, 3.190, 62),
+  (22.8, 3.150, 95), (19.2, 3.440, 123), (17.8, 3.440, 123), (16.4, 4.070, 180),
+  (17.3, 3.730, 180), (15.2, 3.780, 180), (10.4, 5.250, 205), (10.4, 5.424, 215),
+  (14.7, 5.345, 230), (32.4, 2.200, 66), (30.4, 1.615, 52), (33.9, 1.835, 65),
+  (21.5, 2.465, 97), (15.5, 3.520, 150), (15.2, 3.435, 150), (13.3, 3.840, 245),
+  (19.2, 3.845, 175), (27.3, 1.935, 66), (26.0, 2.140, 91), (30.4, 1.513, 113),
+  (15.8, 3.170, 264), (19.7, 2.770, 175), (15.0, 3.570, 335), (21.4, 2.780, 109);
+
+# Coefficients from R: lm(mpg ~ wt + hp, mtcars):
+#   (Intercept) 37.22727, wt -3.87783, hp -0.03177
+query TR
+SELECT term, round(estimate, 5)
+FROM lm('mtcars', y := 'mpg', x := ['wt', 'hp'])
+ORDER BY term
+----
+(Intercept)	37.22727
+hp	-0.03177
+wt	-3.87783
+
+# Standard errors match R to 5 decimals.
+query TR
+SELECT term, round(std_error, 5)
+FROM lm('mtcars', y := 'mpg', x := ['wt', 'hp'])
+ORDER BY term
+----
+(Intercept)	1.59879
+hp	0.00903
+wt	0.63273
+
+# Term order follows the user-supplied x list (after the intercept).
+query T
+SELECT term FROM lm('mtcars', y := 'mpg', x := ['wt', 'hp'])
+----
+(Intercept)
+wt
+hp
+
+# Reverse the predictor order — terms come back in the new order.
+query T
+SELECT term FROM lm('mtcars', y := 'mpg', x := ['hp', 'wt'])
+----
+(Intercept)
+hp
+wt
+
+# Model summary: R² 0.8268, F 69.21, σ 2.593, df_model 2, df_residual 29.
+query RRRII
+SELECT round(r_squared, 4),
+       round(f_statistic, 2),
+       round(sigma, 3),
+       df_model,
+       df_residual
+FROM lm_summary('mtcars', y := 'mpg', x := ['wt', 'hp'])
+----
+0.8268	69.21	2.593	2	29
+
+# ── Complete-case filtering for NULLs ──────────────────────────────────────
+
+statement ok
+CREATE TABLE with_nulls AS SELECT * FROM (VALUES
+    (1.0, 1.0, 5.0),
+    (2.0, 2.0, 3.0),
+    (3.0, NULL, 6.0),       -- dropped (x1 NULL)
+    (4.0, 4.0, NULL),       -- dropped (x2 NULL)
+    (NULL, 5.0, 10.0),      -- dropped (y NULL)
+    (6.0, 6.0, 2.0),
+    (7.0, 7.0, 9.0),
+    (8.0, 8.0, 4.0)
+) AS t(y, x1, x2);
+
+# Only 5 complete-case rows survive.
+query I
+SELECT n FROM lm_summary('with_nulls', y := 'y', x := ['x1', 'x2'])
+----
+5
+
+# ── Error cases ────────────────────────────────────────────────────────────
+
+# Missing table.
+statement error
+SELECT * FROM lm('does_not_exist', y := 'y', x := ['x'])
+----
+does_not_exist
+
+# Missing y.
+statement error
+SELECT * FROM lm('cars', y := 'no_such_col', x := ['speed'])
+----
+not found
+
+# Missing x.
+statement error
+SELECT * FROM lm('cars', y := 'dist', x := ['bogus'])
+----
+not found
+
+# Empty x list.
+statement error
+SELECT * FROM lm('cars', y := 'dist', x := [])
+----
+at least one predictor
+
+# Non-numeric y.
+statement ok
+CREATE TABLE mixed AS SELECT 1.0 AS y, 'cat' AS x;
+
+statement error
+SELECT * FROM lm('mixed', y := 'x', x := ['y'])
+----
+not numeric
+
+# Singular X'X (perfectly collinear predictors).
+statement ok
+CREATE TABLE collinear AS SELECT * FROM (VALUES
+    (1.0, 1.0, 2.0), (2.0, 2.0, 4.0), (3.0, 3.0, 6.0),
+    (4.0, 4.0, 8.0), (5.0, 5.0, 10.0), (6.0, 6.0, 12.0)
+) AS t(y, x1, x2);
+
+statement error
+SELECT * FROM lm('collinear', y := 'y', x := ['x1', 'x2'])
+----
+singular
+
+# n ≤ p + 1 — not enough rows.
+statement ok
+CREATE TABLE too_small AS SELECT * FROM (VALUES (1.0, 1.0), (2.0, 2.0))
+AS t(y, x1);
+
+statement error
+SELECT * FROM lm('too_small', y := 'y', x := ['x1'])
+----
+not enough complete-case rows

--- a/test/sql/meta.test
+++ b/test/sql/meta.test
@@ -1,0 +1,155 @@
+# name: test/sql/meta.test
+# description: meta() table function — per-column metadata + stats
+# group: [stats_duck]
+
+require stats_duck
+
+# A small mixed-type table covering numeric, categorical, boolean and
+# temporal kinds, with a handful of NULLs in different columns. The DECIMAL
+# cast forces VALUES literals like 10.5 (which DuckDB would otherwise infer
+# as DECIMAL(3,1)) into DOUBLE so column_type reads as 'DOUBLE'.
+statement ok
+CREATE TABLE m AS
+SELECT id::INTEGER AS id, label, flag, value::DOUBLE AS value, dt, tag
+FROM (VALUES
+    (1, 'A',  true,  10.5, DATE '2024-01-01', 'x'),
+    (2, 'B',  false, 20.5, DATE '2024-02-01', 'y'),
+    (3, 'A',  true,  30.5, DATE '2024-03-01', 'x'),
+    (4, NULL, true,  NULL, DATE '2024-04-01', 'x'),
+    (5, 'B',  false, 50.5, NULL,              'z')
+) AS t(id, label, flag, value, dt, tag);
+
+# Six rows out — one per column in the source.
+query I
+SELECT count(*) FROM meta('m')
+----
+6
+
+# Kind classification + base counts. Column iteration follows catalog order.
+query TTTIII
+SELECT column_name, column_type, kind, n_rows, n_missing, n_distinct
+FROM meta('m')
+ORDER BY column_name
+----
+dt	DATE	temporal	5	1	4
+flag	BOOLEAN	boolean	5	0	2
+id	INTEGER	numeric	5	0	5
+label	VARCHAR	categorical	5	1	2
+tag	VARCHAR	categorical	5	0	3
+value	DOUBLE	numeric	5	1	4
+
+# Numeric distribution for `value`. Non-NULL data is [10.5, 20.5, 30.5, 50.5].
+#   quantile_cont (type 7): p25=18.0, p50=25.5, p75=35.5
+#   mean = 112 / 4 = 28
+#   stddev_samp = sqrt(875/3) ≈ 17.078
+query RRRRRRR
+SELECT min, p25, median, p75, max, round(mean, 4), round(stddev, 4)
+FROM meta('m')
+WHERE column_name = 'value'
+----
+10.5	18	25.5	35.5	50.5	28	17.0783
+
+# Categorical mode — `tag` has 3 x / 1 y / 1 z.
+query TI
+SELECT top, top_freq
+FROM meta('m')
+WHERE column_name = 'tag'
+----
+x	3
+
+# Categorical mode with ties — `label` is 2 A / 2 B (one NULL excluded). Tie
+# broken by smaller value lexicographically, so 'A' wins.
+query TI
+SELECT top, top_freq
+FROM meta('m')
+WHERE column_name = 'label'
+----
+A	2
+
+# Boolean mode — flag is 3 true / 2 false; cast to VARCHAR for top.
+query TI
+SELECT top, top_freq
+FROM meta('m')
+WHERE column_name = 'flag'
+----
+true	3
+
+# Numeric columns leave top/top_freq NULL.
+query II
+SELECT
+    count(*) FILTER (WHERE top IS NULL),
+    count(*) FILTER (WHERE top_freq IS NULL)
+FROM meta('m')
+WHERE kind = 'numeric'
+----
+2	2
+
+# Temporal columns leave the numeric distribution columns NULL but still
+# emit n_rows / n_missing / n_distinct.
+query III
+SELECT n_rows, n_missing, n_distinct
+FROM meta('m')
+WHERE kind = 'temporal'
+----
+5	1	4
+
+query I
+SELECT count(*) FILTER (
+    WHERE min IS NULL AND p25 IS NULL AND median IS NULL AND p75 IS NULL
+      AND max IS NULL AND mean IS NULL AND stddev IS NULL
+)
+FROM meta('m')
+WHERE kind = 'temporal'
+----
+1
+
+# Dataset-level rollup — the canonical use case for meta().
+query IIII
+SELECT
+    count(*) FILTER (WHERE kind = 'numeric')     AS n_numeric,
+    count(*) FILTER (WHERE kind = 'categorical') AS n_categorical,
+    sum(n_missing)                               AS total_missing,
+    count(*) FILTER (WHERE n_missing > 0)        AS cols_with_nulls
+FROM meta('m')
+----
+2	2	3	3
+
+# ─── Edge cases ─────────────────────────────────────────────────────────────
+
+# Empty table — counts are zero, all distributional stats NULL.
+statement ok
+CREATE TABLE empty_tbl (a INTEGER, b VARCHAR)
+
+query TIIIRR
+SELECT column_name, n_rows, n_missing, n_distinct, min, mean
+FROM meta('empty_tbl')
+ORDER BY column_name
+----
+a	0	0	0	NULL	NULL
+b	0	0	0	NULL	NULL
+
+# All-NULL column — n_missing equals n_rows and distributional stats are NULL.
+statement ok
+CREATE TABLE allnull AS SELECT NULL::DOUBLE AS x FROM range(10)
+
+query IIIRRR
+SELECT n_rows, n_missing, n_distinct, min, max, mean
+FROM meta('allnull')
+----
+10	10	0	NULL	NULL	NULL
+
+# Single non-NULL value — quantiles collapse to that value, stddev_samp is
+# NULL (DuckDB returns NULL for n < 2).
+statement ok
+CREATE TABLE one_row AS SELECT 7.0::DOUBLE AS x
+
+query RRRRRRR
+SELECT min, p25, median, p75, max, mean, stddev
+FROM meta('one_row')
+----
+7	7	7	7	7	7	NULL
+
+# Unknown source table — bind error.
+statement error
+SELECT * FROM meta('not_a_real_table')
+----

--- a/test/sql/random_sampling.test
+++ b/test/sql/random_sampling.test
@@ -33,37 +33,39 @@ true
 
 # ─── Distribution moments converge to theory ────────────────────────────────
 #
-# Sample size 50000 chosen so the simple mean/sd checks pass deterministically.
-# These probes target moments that are robust to the seed used by the
-# thread-local std::mt19937_64.
+# The RNG is seeded non-deterministically (std::random_device), so an empirical
+# mean / sd over 50k draws is itself a random quantity. We assert
+# |estimate - theory| < tol, tol several sampling SEs wide — tight enough to
+# catch a misspecified sampler, wide enough never to flake. (Round-to-1-decimal
+# equality flakes near rounding boundaries; CI caught rnbinom and rweibull.)
 
-query R
-SELECT round(stddev(rnorm(0, 2)), 1) FROM range(50000)
+query I
+SELECT abs(stddev(rnorm(0, 2)) - 2) < 0.1 FROM range(50000)
 ----
-2
+true
 
-query R
-SELECT round(stddev(rnorm(10, 0.5)), 1) FROM range(50000)
+query I
+SELECT abs(stddev(rnorm(10, 0.5)) - 0.5) < 0.1 FROM range(50000)
 ----
-0.5
+true
 
 # Exponential mean = 1/rate. rate=2 → 0.5.
-query R
-SELECT round(avg(rexp(2.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rexp(2.0)) - 0.5) < 0.1 FROM range(50000)
 ----
-0.5
+true
 
 # Gamma(shape, rate) mean = shape/rate. shape=4, rate=2 → 2.0.
-query R
-SELECT round(avg(rgamma(4.0, 2.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rgamma(4.0, 2.0)) - 2) < 0.1 FROM range(50000)
 ----
-2
+true
 
 # Beta(α, β) mean = α/(α+β). Beta(2, 3) → 0.4.
-query R
-SELECT round(avg(rbeta(2.0, 3.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rbeta(2.0, 3.0)) - 0.4) < 0.1 FROM range(50000)
 ----
-0.4
+true
 
 # Beta support is [0, 1].
 query II
@@ -75,23 +77,23 @@ FROM (SELECT rbeta(2.0, 3.0) AS v FROM range(50000))
 0	50000
 
 # Weibull(shape=1, scale=s) = Exponential(1/s); mean = s.
-query R
-SELECT round(avg(rweibull(1.0, 5.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rweibull(1.0, 5.0)) - 5) < 0.2 FROM range(50000)
 ----
-5
+true
 
 # Log-normal: log(X) is N(meanlog, sdlog). We check the body via the log
 # moments rather than the raw lnorm mean because the latter has heavy right
 # tails that make 50k-sample rounding seed-dependent.
-query R
-SELECT round(avg(ln(rlnorm(0, 1))), 1) FROM range(50000)
+query I
+SELECT abs(avg(ln(rlnorm(0, 1)))) < 0.1 FROM range(50000)
 ----
-0
+true
 
-query R
-SELECT round(stddev(ln(rlnorm(2.5, 0.5))), 1) FROM range(50000)
+query I
+SELECT abs(stddev(ln(rlnorm(2.5, 0.5))) - 0.5) < 0.1 FROM range(50000)
 ----
-0.5
+true
 
 # Log-normal support is x > 0.
 query I
@@ -100,10 +102,10 @@ SELECT sum(CASE WHEN v <= 0 THEN 1 ELSE 0 END) FROM (SELECT rlnorm() AS v FROM r
 0
 
 # Poisson mean = lambda. Integer-valued.
-query R
-SELECT round(avg(rpois(4.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rpois(4.0)) - 4) < 0.1 FROM range(50000)
 ----
-4
+true
 
 query I
 SELECT sum(CASE WHEN v <> floor(v) THEN 1 ELSE 0 END) FROM (SELECT rpois(3.0) AS v FROM range(50000))
@@ -113,22 +115,22 @@ SELECT sum(CASE WHEN v <> floor(v) THEN 1 ELSE 0 END) FROM (SELECT rpois(3.0) AS
 # ─── df / df1, df2 thread through correctly ─────────────────────────────────
 
 # Chi-square(df) mean = df. df=8 → 8.
-query R
-SELECT round(avg(rchisq(8.0)), 0) FROM range(50000)
+query I
+SELECT abs(avg(rchisq(8.0)) - 8) < 0.2 FROM range(50000)
 ----
-8
+true
 
 # Student's t(df) mean = 0 for df > 1.
-query R
-SELECT round(avg(rt(5.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rt(5.0))) < 0.1 FROM range(50000)
 ----
-0
+true
 
 # F(df1, df2) mean = df2/(df2-2) for df2 > 2. F(10, 8) → 1.333.
-query R
-SELECT round(avg(rf(10.0, 8.0)), 1) FROM range(50000)
+query I
+SELECT abs(avg(rf(10.0, 8.0)) - 8.0/6.0) < 0.15 FROM range(50000)
 ----
-1.3
+true
 
 # ─── Per-row variation under a non-constant parameter column ───────────────
 

--- a/test/sql/random_sampling.test
+++ b/test/sql/random_sampling.test
@@ -1,0 +1,166 @@
+# name: test/sql/random_sampling.test
+# description: rnorm / rt / rchisq / rf / rgamma / rbeta / rexp / rweibull / rlnorm / rpois
+# group: [stats_duck]
+
+require stats_duck
+
+# ─── Per-row uniqueness ─────────────────────────────────────────────────────
+#
+# All r* functions are VOLATILE and use explicit per-row loops (not
+# UnaryExecutor / BinaryExecutor) so constant-vector inputs don't get the
+# "compute once per chunk" optimisation. Over 10k rows we expect every
+# value to be distinct.
+
+query I
+SELECT count(*) = count(DISTINCT v) FROM (SELECT rnorm() AS v FROM range(10000))
+----
+true
+
+query I
+SELECT count(*) = count(DISTINCT v) FROM (SELECT rnorm(0, 1) AS v FROM range(10000))
+----
+true
+
+query I
+SELECT count(*) = count(DISTINCT v) FROM (SELECT rexp(2.0) AS v FROM range(10000))
+----
+true
+
+query I
+SELECT count(*) = count(DISTINCT v) FROM (SELECT rgamma(2.0, 3.0) AS v FROM range(10000))
+----
+true
+
+# ─── Distribution moments converge to theory ────────────────────────────────
+#
+# Sample size 50000 chosen so the simple mean/sd checks pass deterministically.
+# These probes target moments that are robust to the seed used by the
+# thread-local std::mt19937_64.
+
+query R
+SELECT round(stddev(rnorm(0, 2)), 1) FROM range(50000)
+----
+2
+
+query R
+SELECT round(stddev(rnorm(10, 0.5)), 1) FROM range(50000)
+----
+0.5
+
+# Exponential mean = 1/rate. rate=2 → 0.5.
+query R
+SELECT round(avg(rexp(2.0)), 1) FROM range(50000)
+----
+0.5
+
+# Gamma(shape, rate) mean = shape/rate. shape=4, rate=2 → 2.0.
+query R
+SELECT round(avg(rgamma(4.0, 2.0)), 1) FROM range(50000)
+----
+2
+
+# Beta(α, β) mean = α/(α+β). Beta(2, 3) → 0.4.
+query R
+SELECT round(avg(rbeta(2.0, 3.0)), 1) FROM range(50000)
+----
+0.4
+
+# Beta support is [0, 1].
+query II
+SELECT
+    sum(CASE WHEN v < 0.0 OR v > 1.0 THEN 1 ELSE 0 END) AS out_of_support,
+    count(*) AS total
+FROM (SELECT rbeta(2.0, 3.0) AS v FROM range(50000))
+----
+0	50000
+
+# Weibull(shape=1, scale=s) = Exponential(1/s); mean = s.
+query R
+SELECT round(avg(rweibull(1.0, 5.0)), 1) FROM range(50000)
+----
+5
+
+# Log-normal: log(X) is N(meanlog, sdlog). We check the body via the log
+# moments rather than the raw lnorm mean because the latter has heavy right
+# tails that make 50k-sample rounding seed-dependent.
+query R
+SELECT round(avg(ln(rlnorm(0, 1))), 1) FROM range(50000)
+----
+0
+
+query R
+SELECT round(stddev(ln(rlnorm(2.5, 0.5))), 1) FROM range(50000)
+----
+0.5
+
+# Log-normal support is x > 0.
+query I
+SELECT sum(CASE WHEN v <= 0 THEN 1 ELSE 0 END) FROM (SELECT rlnorm() AS v FROM range(50000))
+----
+0
+
+# Poisson mean = lambda. Integer-valued.
+query R
+SELECT round(avg(rpois(4.0)), 1) FROM range(50000)
+----
+4
+
+query I
+SELECT sum(CASE WHEN v <> floor(v) THEN 1 ELSE 0 END) FROM (SELECT rpois(3.0) AS v FROM range(50000))
+----
+0
+
+# ─── df / df1, df2 thread through correctly ─────────────────────────────────
+
+# Chi-square(df) mean = df. df=8 → 8.
+query R
+SELECT round(avg(rchisq(8.0)), 0) FROM range(50000)
+----
+8
+
+# Student's t(df) mean = 0 for df > 1.
+query R
+SELECT round(avg(rt(5.0)), 1) FROM range(50000)
+----
+0
+
+# F(df1, df2) mean = df2/(df2-2) for df2 > 2. F(10, 8) → 1.333.
+query R
+SELECT round(avg(rf(10.0, 8.0)), 1) FROM range(50000)
+----
+1.3
+
+# ─── Per-row variation under a non-constant parameter column ───────────────
+
+# Variable parameter per row: each row's rnorm uses its own row-derived mean.
+# A row with i*1.0 mean and small sd should produce values close to that mean.
+query R
+SELECT round(avg(abs(v - x::DOUBLE)), 1) FROM (
+    SELECT x, rnorm(x::DOUBLE, 0.01) AS v FROM range(10000) t(x)
+)
+----
+0
+
+# ─── NULL handling ──────────────────────────────────────────────────────────
+
+# NULL parameter → NULL result.
+query I
+SELECT v IS NULL FROM (SELECT rnorm(NULL::DOUBLE, 1.0) AS v) t
+----
+true
+
+query I
+SELECT v IS NULL FROM (SELECT rexp(NULL::DOUBLE) AS v) t
+----
+true
+
+# Invalid parameters (e.g. rate <= 0) → NULL.
+query I
+SELECT v IS NULL FROM (SELECT rexp(0.0) AS v) t
+----
+true
+
+query I
+SELECT v IS NULL FROM (SELECT rnorm(0.0, -1.0) AS v) t
+----
+true

--- a/test/sql/table_one.test
+++ b/test/sql/table_one.test
@@ -16,17 +16,17 @@ CREATE TABLE patients AS SELECT * FROM (VALUES
     (NULL, 'M', 27.4, 'B')
 ) AS t(age, sex, bmi, arm);
 
-# ─── Output schema is fixed (variable, level, statistic, stratum, display, p_value) ────
+# ─── Output schema is fixed (variable, level, statistic, stratum, display, p_value, effect_size) ────
 
-# Without `by`: p_value is NULL on every row (nothing to compare against).
-query TTTTTR
+# Without `by`: p_value and effect_size are NULL on every row (nothing to compare against).
+query TTTTTRR
 SELECT * FROM table_one('patients', variables := ['age']) ORDER BY statistic
 ----
-age	NULL	mean (sd)	Overall	55.6 (7.2)	NULL
-age	NULL	median [q1, q3]	Overall	54.2 [51.3, 59.6]	NULL
-age	NULL	min, max	Overall	45.7, 67.1	NULL
-age	NULL	missing	Overall	1	NULL
-age	NULL	n	Overall	7	NULL
+age	NULL	mean (sd)	Overall	55.6 (7.2)	NULL	NULL
+age	NULL	median [q1, q3]	Overall	54.2 [51.3, 59.6]	NULL	NULL
+age	NULL	min, max	Overall	45.7, 67.1	NULL	NULL
+age	NULL	missing	Overall	1	NULL	NULL
+age	NULL	n	Overall	7	NULL	NULL
 
 # ─── Numeric variable rows ──────────────────────────────────────────────────
 
@@ -337,3 +337,53 @@ SELECT DISTINCT p_value FROM table_one('staged_by_arm',
     force_categorical := ['stage'])
 ----
 0.223130
+
+# ─── effect_size column ────────────────────────────────────────────────────
+
+# Without `by`, effect_size is NULL on every row (same as p_value).
+query R
+SELECT DISTINCT effect_size FROM table_one('patients', variables := ['age'])
+----
+NULL
+
+# Numeric variable + by: effect_size is η² from the ANOVA. For age (means
+# 55.x in both arms) variance is mostly within-arm → η² is small.
+query R
+SELECT DISTINCT round(effect_size, 4) FROM table_one('patients',
+    variables := ['age'], by := ['arm'])
+----
+0.0179
+
+# Categorical variable + by: effect_size is Cramér's V. For sex with an
+# identical contingency table per arm, V = 0.
+query R
+SELECT DISTINCT effect_size FROM table_one('patients',
+    variables := ['sex'], by := ['arm'])
+----
+0
+
+# η² and Cramér's V are both in [0, 1] and stamped on every row of the
+# variable (so a downstream PIVOT can grab one via FIRST(effect_size)).
+query R
+SELECT COUNT(DISTINCT effect_size) FROM table_one('patients',
+    variables := ['age', 'bmi', 'sex'], by := ['arm'])
+WHERE effect_size IS NOT NULL
+----
+3
+
+# Same uniform name across numeric (η²) and categorical (Cramér's V): both
+# rows have a non-NULL effect_size when the test fires.
+query TR
+SELECT DISTINCT variable, round(effect_size, 4) FROM table_one('staged_by_arm',
+    variables := ['stage'], by := ['arm'])
+ORDER BY variable
+----
+stage	0.3636
+
+query TR
+SELECT DISTINCT variable, round(effect_size, 4) FROM table_one('staged_by_arm',
+    variables := ['stage'], by := ['arm'],
+    force_categorical := ['stage'])
+ORDER BY variable
+----
+stage	0.6124


### PR DESCRIPTION
Cuts **v0.6.0** (codename `i-m-not-dead`). Full details in `CHANGELOG.md`; highlights below.

## Statistics
- **`lm` / `lm_summary`** — OLS regression (Cholesky of X'X), one-row-per-term and single-row model summary, plus an **R-style `formula := 'y ~ x1 + x2'` DSL** (additive terms, intercept removal, quoted identifiers).
- **`bootstrap(value, statistic, n_iters [, seed])`** — resampling for arbitrary aggregate statistics.
- **New distributions** — negative binomial, hypergeometric, Weibull, log-normal, Poisson (d/p/q/r), completing the **`r*` random-sampling family** for every distribution.
- **`table_one`** — adds an `effect_size` column.

## Data profiling
- **`meta(table)`** — per-column dataset profile in one shot (type, kind, NULLs, distinct, quantiles, mean/stddev, mode), complementing `SUMMARIZE`.

## Visualization (ggsql)
- Per-layer `STAT smooth | summary | identity` modifier, 2D `FACET BY <row>, <col>`, and a `violin` mark.

## Performance
- **`read_stat()` is no longer O(N²).** It re-parsed the whole file from the start for every 2048-row chunk (ReadStat's `row_offset` reads/decodes skipped rows instead of seeking). It now parses once into a spillable buffer that `Execute` streams from, and `bind` stops after the header. A 200k-row XPT drops **67 s → 1.3 s (52×)**; the real-world CDISC pilot `qs.xpt` (122k rows) **39 s → 1.1 s (36×)**; scaling is linear (verified to 1.6M rows). 448 reader/round-trip test assertions pass. See `notes/engineering/2026-06-xpt-reader-quadratic.md`.
- Adds `benchmark/bench_xpt_read.sh` (synthetic sweep + real-file mode).

## Release notes
- CHANGELOG dated 2026-06-15 and CITATION.cff bumped to `0.6.0-i-m-not-dead`. Tag `v0.6.0` at release time (codename lives in CHANGELOG/CITATION, not the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)