### PR TITLE
CI: grant actions:read to the deploy job (fix nightly-deploy 403)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -32,6 +32,16 @@ jobs:
     needs: duckdb-stable-build
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.4.3
     secrets: inherit
+    # The reusable deploy workflow declares no permissions and relies on the
+    # default GITHUB_TOKEN. actions/download-artifact@v4 (v4.3.0+) needs
+    # `actions: read` to ListArtifacts; on the push-to-main event the default
+    # token lacks it, so the artifact download 403s. Grant it explicitly (the
+    # caller's permissions propagate to the reusable workflow). contents: read
+    # is for the checkout step; the S3 upload uses inherited secrets, not the
+    # token. See duckdb/extension-ci-tools _extension_deploy.yml.
+    permissions:
+      contents: read
+      actions: read
     with:
       extension_name: stats_duck
       duckdb_version: v1.4.3


### PR DESCRIPTION
## Problem
The Main Extension Distribution Pipeline fails on **push-to-main** at *Deploy to nightly*:

```
actions/download-artifact@v4: Failed to ListArtifacts: Received non-retryable error: (403) Forbidden
```

## Root cause (not an outdated action, not a code change)
- `download-artifact@v4` resolves to the **latest** (v4.3.0) — not stale.
- The reusable `duckdb/extension-ci-tools/_extension_deploy.yml` declares **no `permissions:`** (true even on its `@main`) and uses the default `GITHUB_TOKEN`.
- Current `download-artifact` needs **`actions: read`** to `ListArtifacts`; on the `push` event the default token lacks it → 403.
- PR runs looked green because `deploy_latest`/`deploy_versioned` are false on PRs, so the deploy job skips the download entirely — only main/tag runs actually download.

## Fix
Grant `contents: read` + `actions: read` to the `duckdb-stable-deploy` job. Caller permissions propagate to the reusable workflow. The build job is untouched (it already succeeds).

## Verification
Can't be exercised on this PR (the deploy download only runs on push-to-main / tags). The **post-merge `main` run** is the test — the *Deploy to nightly* jobs should download + deploy cleanly. This needs to land **before tagging `v0.7.0`**, since the tag push runs the same deploy path.

> Note: fundamentally an upstream gap — `extension-ci-tools`' deploy workflow ships no permissions block, so every extension on this pipeline is exposed. This caller-side grant is the correct local fix; worth an upstream issue too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
