### PR TITLE
Build VISUALIZE parser hook against DuckDB v1.5.1 (guarded, dual-version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ that name is preserved across releases for backward compatibility.
   its first consumer (and `lm`/`lm_summary` will be re-hosted on it). The C++ API
   is documented in `docs/kernel_api.md`; build and validate it standalone with
   `scripts/run-cpp-tests.sh`.
+- **DuckDB v1.5.1 source compatibility.** The `VISUALIZE` parser hook now
+  feature-detects DuckDB's parser-extension registration API — v1.5.1 moved it
+  from `DBConfig::parser_extensions` to the extension callback manager — so the
+  same source compiles against both the pinned **v1.4.3** (the duckdb-wasm bundle
+  target) and **v1.5.1**. Verified on both: full SQL suite green and the
+  `VISUALIZE` parser hook attaches at runtime. Shipped binaries still target
+  v1.4.3.
 
 ### Changed
 

--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -14,6 +14,15 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parser/parser_extension.hpp"
 
+// DuckDB v1.5.x moved parser-extension registration from
+// DBConfig::parser_extensions to the ExtensionCallbackManager. Feature-detect
+// the header so this one source compiles against both: v1.4.3 (the pinned /
+// duckdb-wasm-bundle target) and v1.5.1+ (native). See RegisterGgsql below.
+#if __has_include("duckdb/main/extension_callback_manager.hpp")
+#include "duckdb/main/extension_callback_manager.hpp"
+#define STATSDUCK_DUCKDB_HAS_CALLBACK_MANAGER 1
+#endif
+
 #include <algorithm>
 
 namespace duckdb {
@@ -563,7 +572,11 @@ public:
 void RegisterGgsql(ExtensionLoader &loader) {
 	auto &db = loader.GetDatabaseInstance();
 	auto &config = DBConfig::GetConfig(db);
-	config.parser_extensions.push_back(ggsql::GgsqlParserExtension());
+#ifdef STATSDUCK_DUCKDB_HAS_CALLBACK_MANAGER
+	config.GetCallbackManager().Register(ggsql::GgsqlParserExtension()); // DuckDB v1.5.x+
+#else
+	config.parser_extensions.push_back(ggsql::GgsqlParserExtension()); // DuckDB ≤ v1.4.x
+#endif
 }
 
 } // namespace duckdb


### PR DESCRIPTION
## What
Makes the extension source compile against **DuckDB v1.5.1** in addition to the pinned **v1.4.3**, so folding into the (unreleased) 0.7.0.

## Why
DuckDB v1.5.1 removed `DBConfig::parser_extensions`, moving parser-extension registration to the `ExtensionCallbackManager` (upstream `11bd94073b`). `ggsql.cpp`'s `RegisterGgsql` no longer compiled against v1.5.1 — the only such break in the whole extension (scoped by pushing the compile all the way through).

## How
Feature-detect the callback-manager header so one source builds on both — v1.4.3 stays byte-identical (it's the `#else`), and it's the duckdb-wasm bundle target so it must keep working:

```cpp
#if __has_include("duckdb/main/extension_callback_manager.hpp")
  config.GetCallbackManager().Register(ggsql::GgsqlParserExtension());   // v1.5.x+
#else
  config.parser_extensions.push_back(ggsql::GgsqlParserExtension());     // <= v1.4.x
#endif
```

## Verification (both versions, native MSVC)
| | v1.4.3 (`#else`) | v1.5.1 (callback mgr) |
|---|---|---|
| Build | ✅ clean | ✅ clean |
| VISUALIZE tests | ✅ 313/313 | ✅ 313/313 |
| Full SQL suite | ✅ (2033/2033 on main) | ✅ 2033/2033 |

The v1.5.1 runtime check matters specifically: it confirms the parser hook **attaches and fires** under the callback manager, not just that it compiles.

## Scope
Source compatibility only. **Shipped binaries still target v1.4.3** (the duckdb-wasm bundle); adding v1.5.1 to the CI build/distribution matrix is a separate, opt-in change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
