### PR TITLE
v0.8: retarget VISUALIZE type overrides to the aesthetic's rendered field

### DIFF
--- a/src/ggsql.cpp
+++ b/src/ggsql.cpp
@@ -203,23 +203,30 @@ string BuildTitleBlock(const VisualizeStatement &stmt) {
 	return out;
 }
 
-// Replace the rendered "type":"..." inside the targeted channel with the user's
-// override. Same lookup pattern as ApplyScales — find the channel block, locate
-// the type field within it, swap the value.
+// Replace the rendered "type":"..." with the user's override, targeting the
+// channel whose "field" is the aesthetic — not the channel that happens to
+// share its name. The two differ in transform marks: violin renders the x
+// aesthetic as the `column` facet while its literal `x` channel is the
+// computed KDE density sweep (retyping that to nominal shatters the axis into
+// one band per density sample). For every direct mark BuildChannel emits
+// field == channel name, so the behavior there is unchanged. Aesthetics whose
+// values only feed a transform (violin/density y, histogram's count axis)
+// render no field and the override is silently ignored, same as an unmapped
+// channel. Runs before ApplyScales, so channel blocks are still flat — the
+// first '}' after the field key closes its channel.
 string ApplyTypeOverrides(string layer_body, const vector<TypeOverride> &overrides) {
 	for (const auto &ov : overrides) {
-		string needle = "\"" + ov.aesthetic + "\":{";
-		size_t pos = layer_body.find(needle);
-		if (pos == string::npos) {
-			continue; // channel not mapped → silently ignore
+		string needle = "\"field\":\"" + ov.aesthetic + "\"";
+		size_t field_pos = layer_body.find(needle);
+		if (field_pos == string::npos) {
+			continue; // aesthetic not rendered as a field → silently ignore
 		}
-		size_t open_brace = pos + needle.size() - 1;
-		size_t close_brace = layer_body.find('}', open_brace + 1);
+		size_t close_brace = layer_body.find('}', field_pos);
 		if (close_brace == string::npos) {
 			continue;
 		}
 		const string type_key = "\"type\":\"";
-		size_t type_pos = layer_body.find(type_key, open_brace);
+		size_t type_pos = layer_body.find(type_key, field_pos);
 		if (type_pos == string::npos || type_pos >= close_brace) {
 			continue;
 		}

--- a/test/sql/ggsql_visualize_type_overrides.test
+++ b/test/sql/ggsql_visualize_type_overrides.test
@@ -33,6 +33,14 @@ VISUALIZE bill_len AS x:nominal, bill_dep AS y FROM penguins DRAW point
 ----
 {"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"mark":"point","encoding":{"x":{"field":"x","type":"nominal"},"y":{"field":"y","type":"quantitative"}}}	{layer_0='SELECT bill_len AS x, bill_dep AS y FROM penguins'}
 
+# Transform marks render computed fields: density's axes are `value` and
+# `density`, so an `x` override has no backing channel and is ignored rather
+# than retyping the computed axis (which would shatter it into per-sample bands).
+query TT
+VISUALIZE bill_len AS x:nominal FROM penguins DRAW density
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"x"}],"mark":"area","encoding":{"x":{"field":"value","type":"quantitative"},"y":{"field":"density","type":"quantitative"}}}	{layer_0=SELECT bill_len AS x FROM penguins}
+
 # Invalid type literal — clean error.
 statement error
 VISUALIZE bill_len AS x, bill_dep AS y, species AS color:bogus FROM penguins DRAW point

--- a/test/sql/ggsql_visualize_violin.test
+++ b/test/sql/ggsql_visualize_violin.test
@@ -40,3 +40,26 @@ query TT
 WITH s AS (SELECT group_id, value FROM samples WHERE value < 6) VISUALIZE group_id AS x, value AS y FROM s DRAW violin
 ----
 {"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='WITH s AS (SELECT group_id, value FROM samples WHERE value < 6) SELECT group_id AS x, value AS y FROM s'}
+
+# An `x` type override targets the channel carrying the x aesthetic — the
+# `column` facet (field "x") — never the literal `x` channel, which is the
+# computed KDE density sweep. Regression test: `x:nominal` used to retype the
+# density axis, exploding each violin into one discrete band per KDE sample.
+query TT
+VISUALIZE group_id AS x:nominal, value AS y FROM samples DRAW violin
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
+
+# Visible retarget: `x:ordinal` lands on the column facet.
+query TT
+VISUALIZE group_id AS x:ordinal, value AS y FROM samples DRAW violin
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"ordinal"}}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}
+
+# The y aesthetic is consumed by the density transform — no channel renders a
+# field named "y", so a `y` override is silently ignored (same contract as an
+# unmapped channel).
+query TT
+VISUALIZE group_id AS x, value AS y:nominal FROM samples DRAW violin
+----
+{"$schema":"https://vega.github.io/schema/vega-lite/v5.json","data":{"name":"layer_0"},"transform":[{"density":"y","groupby":["x"]}],"mark":{"type":"area","orient":"horizontal"},"encoding":{"y":{"field":"value","type":"quantitative"},"x":{"field":"density","type":"quantitative","stack":"center","impute":null,"axis":null},"column":{"field":"x","type":"nominal"}}}	{layer_0='SELECT group_id AS x, value AS y FROM samples'}


### PR DESCRIPTION
## What

`ApplyTypeOverrides` located the channel to retype by its literal channel name. Transform marks break that assumption: violin renders the `x` aesthetic as the `column` facet, while the spec's literal `x` channel is the computed KDE density sweep. `era AS x:nominal ... DRAW violin` therefore retyped the density axis to nominal — one discrete band per KDE sample — rendering a page-wide ribbon instead of violins. `DRAW density` had the same corruption class via its computed `value`/`density` fields.

Overrides now target the channel whose `"field"` is the aesthetic:

- **Direct marks** (point, line, bar, boxplot, heatmap, …): `BuildChannel` emits field == channel name — behavior unchanged, byte-identical specs.
- **violin**: `x` overrides land on the `column` facet (so `x:ordinal` now meaningfully controls category sort); `y` feeds the density transform, renders no field, and is silently ignored like any unmapped channel.
- **density / histogram**: overrides on transform-consumed aesthetics are ignored instead of corrupting the computed axis.

## Tests

- `ggsql_visualize_violin.test`: x:nominal regression case (was red with the exact reported symptom), x:ordinal retarget, y ignored.
- `ggsql_visualize_type_overrides.test`: density-mark guard; existing direct-mark cases unchanged.
- Full `test/sql` suite green.

## Downstream

Bedevere 0.15 revendors both the win-x64 v1.5.1 native build (desktop) and the v1.4.3 WASM artifacts from this PR's CI (web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)